### PR TITLE
Feature/texture order

### DIFF
--- a/src/io/export/pbrt/save.rs
+++ b/src/io/export/pbrt/save.rs
@@ -382,7 +382,7 @@ impl PbrtSaver {
                         format!("{}MakeNamedMaterial \"{}\"", make_indent(indent), name).as_bytes(),
                     )?;
                     writer.write(format!(" \"string type\" [\"{}\"]", t).as_bytes())?;
-                    writer.write(format!(" \"string id\" [\"{}\"]", id.to_string()).as_bytes())?;
+                    //writer.write(format!(" \"string id\" [\"{}\"]", id.to_string()).as_bytes())?;
                     for (key_type, key_name, init, _range) in props.iter() {
                         self.write_property(0, key_type, key_name, init, &material.props, writer)?;
                     }
@@ -408,7 +408,7 @@ impl PbrtSaver {
                 writer.write(format!("{}# Textures\n", make_indent(indent)).as_bytes())?;
             }
             let mut textures = Vec::new();
-            for (id, texture) in resouces_component.textures.iter() {
+            for texture in resouces_component.textures.values() {
                 let order = texture.read().unwrap().get_order();
                 textures.push((order, texture.clone()));
             }

--- a/src/io/import/pbrt/targets/scene/scene_target.rs
+++ b/src/io/import/pbrt/targets/scene/scene_target.rs
@@ -142,7 +142,7 @@ impl SceneTarget {
 
         // Set define order of the texture
         {
-            let order = self.textures.len();//
+            let order = self.textures.len(); //
             let mut texture = texture.write().unwrap();
             texture.set_order(order as i32);
         }

--- a/src/models/scene/texture.rs
+++ b/src/models/scene/texture.rs
@@ -79,9 +79,7 @@ impl Texture {
     }
 
     pub fn get_order(&self) -> i32 {
-        self.props
-            .find_one_int("integer order")
-            .unwrap_or(-1)
+        self.props.find_one_int("integer order").unwrap_or(-1)
     }
 
     pub fn set_order(&mut self, order: i32) {


### PR DESCRIPTION
This pull request introduces changes to the texture handling logic in the PBRT export and import functionalities, focusing on improving the ordering and management of textures. Additionally, some unused code related to texture IDs has been commented out for cleanup purposes.

### Texture ordering and management:

* [`src/io/import/pbrt/targets/scene/scene_target.rs`](diffhunk://#diff-ba473a5120669786a2dd0bc06b93b2db59ce997cbbbe4ee0ea7dbb93e32a5fd2R142-R149): Added logic to set a "define order" for textures when they are added to the scene, ensuring consistent ordering during processing.
* [`src/models/scene/texture.rs`](diffhunk://#diff-ac9fd540ecb7f7d4b19a181460c541be4040a24f4c691665cddec65217709a7cR80-R87): Introduced `get_order` and `set_order` methods in the `Texture` struct to retrieve and assign the order property of textures. This supports the new texture ordering logic.
* [`src/io/export/pbrt/save.rs`](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316L410-R416): Modified the texture iteration logic to sort textures by their assigned order before exporting them, ensuring a predictable output order.

### Code cleanup:

* [`src/io/export/pbrt/save.rs`](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316L385-R385): Commented out lines related to writing the "string id" property for materials and textures, as these are no longer necessary. [[1]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316L385-R385) [[2]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316L429-R435)