### PR TITLE
Fix Light Transform

### DIFF
--- a/src/io/import/pbrt/targets/scene/scene_target.rs
+++ b/src/io/import/pbrt/targets/scene/scene_target.rs
@@ -69,11 +69,11 @@ fn create_default_material() -> Arc<RwLock<Material>> {
 fn coordinate_system(d1: &Vector3) -> (Vector3, Vector3, Vector3) {
     let v1 = d1.normalize();
     if f32::abs(v1.x) > f32::abs(v1.y) {
-        let v2 = Vector3::new(-v1.z, f32::default(), v1.x).normalize();
+        let v2 = Vector3::new(-v1.z, 0.0, v1.x).normalize();
         let v3 = Vector3::cross(&v1, &v2).normalize();
         return (v1, v2, v3);
     } else {
-        let v2 = Vector3::new(f32::default(), v1.z, -v1.y).normalize();
+        let v2 = Vector3::new(0.0, v1.z, -v1.y).normalize();
         let v3 = Vector3::cross(&v1, &v2).normalize();
         return (v1, v2, v3);
     }

--- a/src/models/base/property.rs
+++ b/src/models/base/property.rs
@@ -258,4 +258,9 @@ impl ParamSet {
         }
         return None;
     }
+    //--------------------------------------------------//
+    pub fn remove(&mut self, key: &str) {
+        let (_key_type, key_name) = Self::get_param_type(key);
+        self.0.retain(|(_, k, _)| k != key_name);
+    }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `SceneTarget` and `ParamSet` implementations, focusing on improving light transformation logic, adding utility methods, and refining function visibility. The key changes include the addition of light transformation calculations, a new `remove` method for `ParamSet`, and adjustments to function visibility for encapsulation.

### Enhancements to light transformation logic:
* Added a `coordinate_system` utility function to compute orthonormal basis vectors for light transformations in `SceneTarget`. This is used to determine the orientation of lights such as "spot" and "distant" based on "from" and "to" parameters. (`src/io/import/pbrt/targets/scene/scene_target.rs`, [src/io/import/pbrt/targets/scene/scene_target.rsL63-R81](diffhunk://#diff-ba473a5120669786a2dd0bc06b93b2db59ce997cbbbe4ee0ea7dbb93e32a5fd2L63-R81))
* Extended the `ParseTarget` implementation for `SceneTarget` to handle "point," "spot," and "distant" light types. This includes parsing "from" and "to" parameters, calculating transformation matrices, and applying them to `TransformComponent`. (`src/io/import/pbrt/targets/scene/scene_target.rs`, [src/io/import/pbrt/targets/scene/scene_target.rsR657-R733](diffhunk://#diff-ba473a5120669786a2dd0bc06b93b2db59ce997cbbbe4ee0ea7dbb93e32a5fd2R657-R733))

### Utility method addition:
* Introduced a `remove` method in the `ParamSet` struct to allow removal of parameters by key. This is used to clean up processed parameters during light parsing. (`src/models/base/property.rs`, [src/models/base/property.rsR261-R265](diffhunk://#diff-f1295ce7d42c99221ab3f8a4513eefe425cfe55f0d90b7f5dc9ea8ee7a08454fR261-R265))

### Function visibility adjustments:
* Changed the visibility of the `create_default_material` function from `pub` to private (`fn`) to restrict its usage to within the module. (`src/io/import/pbrt/targets/scene/scene_target.rs`, [src/io/import/pbrt/targets/scene/scene_target.rsL63-R81](diffhunk://#diff-ba473a5120669786a2dd0bc06b93b2db59ce997cbbbe4ee0ea7dbb93e32a5fd2L63-R81))