### PR TITLE
Fix mapping

### DIFF
--- a/src/models/scene/properties/mapping.rs
+++ b/src/models/scene/properties/mapping.rs
@@ -9,8 +9,8 @@ const PARAMETERS: [(&str, &str, &str, &str, &str); 8] = [
     ("uv", "float", "vdelta", "0.0", "0.0 100.0"),
     ("planar", "vector", "v1", "1.0 0.0 0.0", ""),
     ("planar", "vector", "v2", "0.0 0.0 0.0", ""),
-    ("uv", "float", "udelta", "0.0", "0.0 100.0"),
-    ("uv", "float", "vdelta", "0.0", "0.0 100.0"),
+    ("planar", "float", "udelta", "0.0", "0.0 100.0"),
+    ("planar", "float", "vdelta", "0.0", "0.0 100.0"),
 ];
 
 fn parse_floats(value: &str) -> Vec<f32> {

--- a/src/panels/inspector/light_component.rs
+++ b/src/panels/inspector/light_component.rs
@@ -18,7 +18,7 @@ impl InspectorPanel {
         let t = component.get_type();
         let title = LightComponent::get_name_from_type(&t);
         let mut keys = Vec::new();
-        let entries = self.light_parameters.get_entries(&t);
+        let entries = self.light_properties.get_entries(&t);
         let props = &mut component.props;
         for (key_type, key_name, init, range) in entries.iter() {
             if props.get(key_name).is_none() {

--- a/src/panels/inspector/material_component.rs
+++ b/src/panels/inspector/material_component.rs
@@ -28,7 +28,7 @@ impl InspectorPanel {
         props: &mut PropertyMap,
         resource_selector: &ResourceSelector,
     ) {
-        let material_types = self.material_parameters.get_types();
+        let material_types = self.material_properties.get_types();
         let mut name = props
             .find_one_string("string name_")
             .unwrap_or("".to_string());
@@ -48,7 +48,7 @@ impl InspectorPanel {
                 ui.separator();
                 let mut keys = Vec::new();
                 let mat_type = props.find_one_string("string type").unwrap();
-                if let Some(params) = self.material_parameters.get(&mat_type) {
+                if let Some(params) = self.material_properties.get(&mat_type) {
                     for (key_type, key_name, init, range) in params.iter() {
                         if props.get(key_name).is_none() {
                             let key = PropertyMap::get_key(key_type, key_name);


### PR DESCRIPTION
This pull request refactors the `InspectorPanel` to standardize the naming of property collections across components and introduces support for mapping properties. The changes primarily focus on renaming variables, updating method calls, and adding functionality for handling mapping properties.

### Refactoring for Consistency:
* Replaced all occurrences of `*_parameters` with `*_properties` for property collections in `InspectorPanel`, affecting components such as material, shape, light, and others. This change ensures consistent naming across the codebase. [[1]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL45-R73) [[2]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL143-R145) [[3]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL154-R156) [[4]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL163-R165) [[5]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL172-R174) [[6]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL197-R199) [[7]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL224-R226) [[8]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL248-R250) [[9]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL324-R337) [[10]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL341-R354) [[11]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL353-R366)

### Support for Mapping Properties:
* Added `MappingProperties` to the `InspectorPanel` to handle texture mapping configurations. This includes initializing `mapping_properties` and integrating it into the texture property handling logic. [[1]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL45-R73) [[2]](diffhunk://#diff-38721b2145b65367a9c471fadb95c453a8f49ea38aae778507c8d8d1e63edb0fL291-R311)
* Updated the texture inspection logic to display mapping-related properties alongside texture properties.

### Parameter Updates in Mapping:
* Updated the `PARAMETERS` array in `mapping.rs` to correct the `udelta` and `vdelta` entries, changing their mapping type from `uv` to `planar`. This aligns the parameters with the intended mapping context.

### Method Call Updates:
* Updated method calls in `InspectorPanel` to reflect the renaming of property collections, ensuring the correct methods are invoked for retrieving properties. [[1]](diffhunk://#diff-b2fe1c92719168dc22939c91b0d9ab61aaf9cd32275bde849d97b8b7e8b00605L21-R21) [[2]](diffhunk://#diff-11e3f9e55f0d1fdd99e26925dd7664b03a2d72ea3e385a1979701708fcef2daaL31-R31) [[3]](diffhunk://#diff-11e3f9e55f0d1fdd99e26925dd7664b03a2d72ea3e385a1979701708fcef2daaL51-R51)

These changes improve code clarity, maintainability, and extend functionality to support mapping properties in the `InspectorPanel`.