### PR TITLE
Update exporter

### DIFF
--- a/src/io/export/pbrt/save.rs
+++ b/src/io/export/pbrt/save.rs
@@ -25,6 +25,8 @@ use crate::models::scene::SamplerComponent;
 use crate::models::scene::SamplerProperties;
 use crate::models::scene::ShapeComponent;
 use crate::models::scene::ShapeProperties;
+use crate::models::scene::SubdivComponent;
+use crate::models::scene::SubdivProperties;
 use crate::models::scene::TextureProperties;
 use crate::models::scene::TransformComponent;
 
@@ -61,6 +63,7 @@ struct PbrtSaver {
     shape_properties: ShapeProperties,
     light_properties: LightProperties,
     mesh_properties: MeshProperties,
+    subdiv_properties: SubdivProperties,
     mapping_properties: MappingProperties,
 }
 
@@ -136,6 +139,7 @@ impl PbrtSaver {
             shape_properties: ShapeProperties::new(),
             light_properties: LightProperties::new(),
             mesh_properties: MeshProperties::new(),
+            subdiv_properties: SubdivProperties::new(),
             mapping_properties: MappingProperties::new(),
         }
     }
@@ -537,6 +541,18 @@ impl PbrtSaver {
                 let mesh = mesh.read().unwrap();
                 let t = mesh.get_type(); //
                 if let Some(props) = self.shape_properties.get(&t) {
+                    writer.write(format!("{}Shape \"{}\"", make_indent(indent), t).as_bytes())?;
+                    for (key_type, key_name, init, _range) in props.iter() {
+                        self.write_property(indent, key_type, key_name, init, &mesh.props, writer)?;
+                    }
+                    writer.write("\n".as_bytes())?;
+                }
+            };
+        } else if let Some(c) = node.get_component::<SubdivComponent>() {
+            if let Some(mesh) = c.mesh.as_ref() {
+                let mesh = mesh.read().unwrap();
+                let t = mesh.get_type(); //
+                if let Some(props) = self.subdiv_properties.get(&t) {
                     writer.write(format!("{}Shape \"{}\"", make_indent(indent), t).as_bytes())?;
                     for (key_type, key_name, init, _range) in props.iter() {
                         self.write_property(indent, key_type, key_name, init, &mesh.props, writer)?;

--- a/src/models/scene/components/shape.rs
+++ b/src/models/scene/components/shape.rs
@@ -24,7 +24,8 @@ impl ShapeComponent {
         props.insert("string type", Property::from(shape_type));
         let edition_id = Uuid::new_v4();
         props.insert("string edition", Property::from(edition_id.to_string()));
-        let mesh = create_mesh("Sphere", &props);
+        let name = Self::get_name_from_type(shape_type);
+        let mesh = create_mesh(&name, &props);
         ShapeComponent { mesh: Some(mesh) }
     }
 

--- a/src/models/scene/components/subdiv.rs
+++ b/src/models/scene/components/subdiv.rs
@@ -18,10 +18,17 @@ fn create_mesh(name: &str, props: &PropertyMap) -> Arc<RwLock<Mesh>> {
     Arc::new(RwLock::new(mesh))
 }
 
+fn replace_properties(props: &mut PropertyMap) {
+    if let Some((_, key_name, _)) = props.entry_mut("levels") {
+        *key_name = "nlevels".to_string();
+    }
+}
+
 impl SubdivComponent {
     pub fn new(t: &str, props: &PropertyMap) -> Self {
         let mut props = props.clone();
-        props.insert("string type", Property::from(t));
+        props.add_string("string type", &t);
+        replace_properties(&mut props);
         //let edition_id = Uuid::new_v4();
         //props.insert("string edition", Property::from(edition_id.to_string()));
         let name = Self::get_name_from_type(t);

--- a/src/models/scene/properties/mod.rs
+++ b/src/models/scene/properties/mod.rs
@@ -9,6 +9,7 @@ mod mesh;
 mod option;
 mod sampler;
 mod shape;
+mod subdiv;
 mod texture;
 mod value_range;
 
@@ -23,5 +24,6 @@ pub use mesh::*;
 pub use option::*;
 pub use sampler::*;
 pub use shape::*;
+pub use subdiv::*;
 pub use texture::*;
 pub use value_range::*;

--- a/src/models/scene/properties/subdiv.rs
+++ b/src/models/scene/properties/subdiv.rs
@@ -1,0 +1,123 @@
+use super::value_range::ValueRange;
+use crate::models::base::*;
+use std::collections::HashMap;
+
+const PARAMETERS: [(&str, &str, &str, &str, &str); 4] = [
+    ("loopsubdiv", "integer", "nlevels", "3", ""),
+    ("loopsubdiv", "integer", "indices", "", ""),
+    ("loopsubdiv", "point", "P", "", ""),
+    ("loopsubdiv", "string", "scheme", "loop", ""),
+];
+
+fn parse_floats(value: &str) -> Vec<f32> {
+    let mut floats = Vec::new();
+    for s in value.split_whitespace() {
+        if let Ok(f) = s.parse::<f32>() {
+            floats.push(f);
+        }
+    }
+    floats
+}
+
+fn parse_ints(value: &str) -> Vec<i32> {
+    let mut ints = Vec::new();
+    for s in value.split_whitespace() {
+        if let Ok(i) = s.parse::<i32>() {
+            ints.push(i);
+        }
+    }
+    ints
+}
+
+fn parse_strings(value: &str) -> Vec<String> {
+    let mut strings = Vec::new();
+    for s in value.split_whitespace() {
+        strings.push(s.to_string());
+    }
+    if strings.is_empty() {
+        strings.push("".to_string());
+    }
+    strings
+}
+
+fn parse_bools(value: &str) -> Vec<bool> {
+    let mut bools = Vec::new();
+    for s in value.split_whitespace() {
+        if let Ok(b) = s.parse::<bool>() {
+            bools.push(b);
+        }
+    }
+    bools
+}
+
+fn parse_range(key_type: &str, range: &str) -> Option<ValueRange> {
+    if range.is_empty() {
+        return None;
+    }
+    match key_type {
+        "float" => {
+            let mut range = range.split_whitespace();
+            let min = range.next().unwrap_or("0.0").parse::<f32>().unwrap_or(0.0);
+            let max = range.next().unwrap_or("1.0").parse::<f32>().unwrap_or(1.0);
+            Some(ValueRange::FloatRange(min, max))
+        }
+        "integer" => {
+            let mut range = range.split_whitespace();
+            let min = range.next().unwrap_or("0").parse::<i32>().unwrap_or(0);
+            let max = range.next().unwrap_or("1").parse::<i32>().unwrap_or(1);
+            Some(ValueRange::IntRange(min, max))
+        }
+        _ => None,
+    }
+}
+
+fn parse_parameter(
+    param: (&str, &str, &str, &str, &str),
+) -> (String, (String, String, Property, Option<ValueRange>)) {
+    let (name, key_type, key_name, value, range) = param;
+    let key_type = key_type.to_string();
+    let key_name = key_name.to_string();
+    let value = match key_type.as_str() {
+        "point" | "vector" | "normal" | "color" | "float" => Property::from(parse_floats(value)),
+        "integer" => Property::from(parse_ints(value)),
+        "string" | "spectrum" | "texture" => Property::from(parse_strings(value)),
+        "bool" => Property::from(parse_bools(value)),
+        _ => panic!("Unknown parameter type"),
+    };
+    let range = parse_range(&key_type, range);
+
+    (name.to_string(), (key_type, key_name, value, range))
+}
+
+#[derive(Debug, Clone)]
+pub struct SubdivProperties(
+    pub HashMap<String, Vec<(String, String, Property, Option<ValueRange>)>>,
+);
+
+impl SubdivProperties {
+    pub fn new() -> Self {
+        let mut params = HashMap::new();
+        for param in PARAMETERS.iter() {
+            let (name, (key_type, key_name, value, range)) = parse_parameter(*param);
+            params
+                .entry(name)
+                .or_insert_with(Vec::new)
+                .push((key_type, key_name, value, range));
+        }
+        SubdivProperties(params)
+    }
+
+    pub fn get(&self, name: &str) -> Option<&Vec<(String, String, Property, Option<ValueRange>)>> {
+        self.0.get(name)
+    }
+
+    pub fn get_keys(&self, name: &str) -> Vec<(String, String)> {
+        let mut keys = Vec::new();
+        if let Some(params) = self.0.get(name) {
+            for (key_type, key_name, _, _) in params.iter() {
+                keys.push((key_type.to_string(), key_name.to_string()));
+            }
+        }
+        keys
+    }
+}


### PR DESCRIPTION
This pull request introduces support for subdivision surfaces in the PBRT export functionality. It includes changes to handle subdivision surface properties, update mesh creation logic, and add parsing utilities for subdivision parameters. The most important changes are grouped into two themes: **Subdivision Surface Support** and **Utility Enhancements**.

### Subdivision Surface Support:
* Added `SubdivProperties` and `SubdivComponent` to the `PbrtSaver` struct, enabling subdivision surface properties to be handled during PBRT export. (`src/io/export/pbrt/save.rs`, [[1]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R66) [[2]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R142)
* Implemented logic in `PbrtSaver` to write subdivision surface properties to the PBRT file format, including handling mesh types and associated properties. (`src/io/export/pbrt/save.rs`, [src/io/export/pbrt/save.rsR551-R562](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R551-R562))
* Introduced a new module `subdiv.rs` for managing subdivision surface properties, including parameter parsing and range validation. (`src/models/scene/properties/subdiv.rs`, [src/models/scene/properties/subdiv.rsR1-R123](diffhunk://#diff-f8b08d97b01ade89b05a5d07e998c5005cb8541f75586b3b7b0ee3e8bb502945R1-R123))

### Utility Enhancements:
* Updated the `ShapeComponent` initialization logic to dynamically derive mesh names based on the shape type. (`src/models/scene/components/shape.rs`, [src/models/scene/components/shape.rsL27-R28](diffhunk://#diff-94ecf054fda06e32603f3f33b0df986ea79c1055badc49ee1c6d8ce8ea39cab9L27-R28))
* Added a helper function `replace_properties` in `SubdivComponent` to rename specific property keys, ensuring compatibility with PBRT conventions. (`src/models/scene/components/subdiv.rs`, [src/models/scene/components/subdiv.rsR21-R31](diffhunk://#diff-79e477f683c7f5b4ee2eb49618214c2b873bbaf32c555e820f6b64adf49c0f5dR21-R31))

These changes collectively enable subdivision surface support in the PBRT export workflow while improving the flexibility and maintainability of the codebase.