### PR TITLE
Add enable for Node

### DIFF
--- a/src/model/scene/node.rs
+++ b/src/model/scene/node.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct Node {
+    pub enable: bool,
     pub id: Uuid,
     pub name: String,
     pub parent: Option<Weak<RwLock<Node>>>,
@@ -20,6 +21,7 @@ impl Node {
     pub fn root_node(name: &str) -> Arc<RwLock<Node>> {
         let components = vec![Box::new(TransformComponent::default()) as Box<dyn Any>];
         let node = Node {
+            enable: true,
             name: name.to_string(),
             id: Uuid::new_v4(),
             parent: None,
@@ -32,6 +34,7 @@ impl Node {
     pub fn child_node(name: &str, parent: &Arc<RwLock<Node>>) -> Arc<RwLock<Node>> {
         let components = vec![Box::new(TransformComponent::default()) as Box<dyn Any>];
         let node = Node {
+            enable: true,
             name: name.to_string(),
             id: Uuid::new_v4(),
             parent: Some(Arc::downgrade(parent)),
@@ -41,6 +44,18 @@ impl Node {
         let c = Arc::new(RwLock::new(node));
         Node::add_child(parent, &c);
         return c;
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enable
+    }
+
+    pub fn get_enable(&self) -> bool {
+        self.enable
+    }
+
+    pub fn set_enable(&mut self, enable: bool) {
+        self.enable = enable;
     }
 
     pub fn get_name(&self) -> String {

--- a/src/panel/inspector/panel.rs
+++ b/src/panel/inspector/panel.rs
@@ -99,7 +99,7 @@ impl InspectorPanel {
         let resource_selector = self.get_resource_selector();
         let mut node = node.write().unwrap();
         {
-            let mut enabled = true; //todo
+            let mut enabled = node.is_enabled();
             let mut name = node.get_name();
             egui::TopBottomPanel::top("node").show_inside(ui, |ui| {
                 ui.horizontal(|ui| {
@@ -108,6 +108,7 @@ impl InspectorPanel {
                 });
                 ui.add_space(3.0);
             });
+            node.set_enable(enabled);
             if !name.is_empty() {
                 node.set_name(&name);
             }

--- a/src/panel/views/render/scene_view/get_render_items.rs
+++ b/src/panel/views/render/scene_view/get_render_items.rs
@@ -77,6 +77,10 @@ fn get_material(node: &Arc<RwLock<Node>>) -> Arc<RwLock<Material>> {
 }
 
 fn get_scene_item(parent_matrix: &Matrix4x4, node: &Arc<RwLock<Node>>, items: &mut Vec<SceneItem>) {
+    if !node.read().unwrap().is_enabled() {
+        return;
+    }
+
     let local_matrix = get_local_matrix(node);
     let world_matrix = *parent_matrix * local_matrix;
 


### PR DESCRIPTION
This pull request introduces a new `enable` property to the `Node` struct in `src/model/scene/node.rs`, along with associated methods to manage its state. It also integrates this property into the `InspectorPanel` and `get_scene_item` logic to control node behavior based on its enabled state.

### Changes to Node struct:

* Added `enable` property to the `Node` struct to track whether a node is enabled. (`src/model/scene/node.rs`, [src/model/scene/node.rsR12](diffhunk://#diff-4acd6064d01544723a24de625eaef6e021dad92eee2494ff6a48ac5a5caf014cR12))
* Updated `root_node` and `child_node` constructors to initialize the `enable` property to `true`. (`src/model/scene/node.rs`, [[1]](diffhunk://#diff-4acd6064d01544723a24de625eaef6e021dad92eee2494ff6a48ac5a5caf014cR24) [[2]](diffhunk://#diff-4acd6064d01544723a24de625eaef6e021dad92eee2494ff6a48ac5a5caf014cR37)
* Added methods `is_enabled`, `get_enable`, and `set_enable` to manage the `enable` property. (`src/model/scene/node.rs`, [src/model/scene/node.rsR49-R60](diffhunk://#diff-4acd6064d01544723a24de625eaef6e021dad92eee2494ff6a48ac5a5caf014cR49-R60))

### Integration with InspectorPanel:

* Modified `InspectorPanel` to use the `is_enabled` method to read the `enable` state and added logic to update it using `set_enable`. (`src/panel/inspector/panel.rs`, [[1]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL102-R102) [[2]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bR111)

### Integration with Scene Rendering:

* Updated `get_scene_item` logic to skip processing nodes that are not enabled by checking the `is_enabled` method. (`src/panel/views/render/scene_view/get_render_items.rs`, [src/panel/views/render/scene_view/get_render_items.rsR80-R83](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adR80-R83))