### PR TITLE
Update src

### DIFF
--- a/src/panel/views/render/scene_view/get_render_items.rs
+++ b/src/panel/views/render/scene_view/get_render_items.rs
@@ -247,7 +247,7 @@ fn get_base_color_value(
                 return None;
             } else if key_type == "spectrum" {
                 //let spectrum
-                return Some(RenderUniformValue::Vec4([1.0, 1.0, 1.0, 1.0]));
+                return Some(RenderUniformValue::Vec4([1.0, 0.0, 1.0, 1.0]));
             }
             // Handle texture loading if needed
             return None;
@@ -276,13 +276,7 @@ fn get_base_color(
             );
         }
         "metal" => {
-            return get_base_color_value(
-                resource_manager,
-                render_resource_manager,
-                gl,
-                props,
-                "Kr",
-            );
+            return get_base_color_value(resource_manager, render_resource_manager, gl, props, "k");
         }
         "glass" | "mirror" => {
             return get_base_color_value(
@@ -291,6 +285,15 @@ fn get_base_color(
                 gl,
                 props,
                 "Kr",
+            );
+        }
+        "substrate" => {
+            return get_base_color_value(
+                resource_manager,
+                render_resource_manager,
+                gl,
+                props,
+                "Kd",
             );
         }
         "kdsubsurface" => {


### PR DESCRIPTION
This pull request includes changes to improve the behavior of PBRT file export and adjustments to rendering logic for base color handling in the scene view. The most important changes ensure conditional handling of enabled nodes during PBRT export and refine the logic for determining base color values in rendering.

### PBRT Export Enhancements:

* [`src/io/export/pbrt/save.rs`](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R551): Added checks to ensure that only enabled nodes are processed during PBRT file export. This prevents unnecessary operations on disabled nodes. [[1]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R551) [[2]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R569) [[3]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R583) [[4]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316R597)

### Rendering Logic Adjustments:

* [`src/panel/views/render/scene_view/get_render_items.rs`](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adL250-R250): Modified the default base color for "spectrum" key type to `[1.0, 0.0, 1.0, 1.0]` to align with updated rendering requirements.
* [`src/panel/views/render/scene_view/get_render_items.rs`](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adR279-R281): Updated logic to handle "metal," "glass," "mirror," and "substrate" materials, including changes to base color key mappings like switching "Kr" to "Kd" for "substrate." [[1]](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adR279-R281) [[2]](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adL287-R296)