### PR TITLE
Feature/enbale node2

### DIFF
--- a/src/geometry/mesh_data/from_loopsubdiv.rs
+++ b/src/geometry/mesh_data/from_loopsubdiv.rs
@@ -712,13 +712,18 @@ fn loop_subdiv(levels: i32, indices: Vec<i32>, p: Vec<Vector3>) -> Option<MeshDa
         n.push(v.z);
     }
 
-    let _uv = Vec::new();
+    let mut uv = Vec::new();
+    for _ in 0..p_limit.len() {
+        uv.push(0.0);
+        uv.push(0.0);
+    }
+
     let _s = Vec::new();
     let mesh_data = MeshData {
         indices: verts,
         positions: p,
         normals: n,
-        uvs: _uv,
+        uvs: uv,
         tangents: _s,
     };
 

--- a/src/io/import/pbrt/load.rs
+++ b/src/io/import/pbrt/load.rs
@@ -12,10 +12,10 @@ use std::sync::RwLock;
 pub fn load_pbrt(path: &str) -> Result<Arc<RwLock<Node>>, PbrtError> {
     let scene_target = Arc::new(RwLock::new(SceneTarget::default()));
     {
-        let print_target = Arc::new(RwLock::new(PrintTarget::default()));
+        //let print_target = Arc::new(RwLock::new(PrintTarget::default()));
 
         let mut target = MultipleTarget::default();
-        target.add_target(print_target.clone());
+        //target.add_target(print_target.clone());
         target.add_target(scene_target.clone());
         // Parse the PBRT file
         pbrt_parse_file(path, &mut target)?;

--- a/src/panel/views/render/scene_view/get_render_items.rs
+++ b/src/panel/views/render/scene_view/get_render_items.rs
@@ -34,7 +34,6 @@ use crate::renderer::gl::{GLResourceComponent, RenderTexture};
 use uuid::Uuid;
 
 use eframe::glow;
-use std::default;
 use std::sync::{Arc, RwLock};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/panel/views/render/scene_view/get_render_items.rs
+++ b/src/panel/views/render/scene_view/get_render_items.rs
@@ -165,7 +165,7 @@ fn get_shader_id(
         }
         RenderMode::Solid => {
             if let Some(base_color) = uniforms.iter().find(|(k, _)| k == "base_color") {
-                if let RenderUniformValue::Vec4(color) = &base_color.1 {
+                if let RenderUniformValue::Vec4(_) = &base_color.1 {
                     // Use a unique ID based on the base color
                     return Uuid::parse_str(RENDER_SOLID_SHADER_COLOR_ID).unwrap(); // Placeholder for solid shader ID
                 } else if let RenderUniformValue::Texture(_) = &base_color.1 {


### PR DESCRIPTION
This pull request includes changes to improve the geometry processing, clean up unused code, and simplify logic in shader ID assignment. The most important changes involve updating UV handling in mesh data generation, commenting out unused targets in PBRT file parsing, and removing redundant code in shader ID logic.

### Geometry Processing Improvements:
* [`src/geometry/mesh_data/from_loopsubdiv.rs`](diffhunk://#diff-2502e4aec94ebca3293453fce1cdfc45255775f38de33743ad7837b6509d6543L715-R726): Changed `_uv` to `uv` and initialized UVs with default values to ensure proper UV handling in mesh data creation.

### Code Cleanup:
* [`src/io/import/pbrt/load.rs`](diffhunk://#diff-73c52d1cf586c04e14eb188e2ca4d96fb553293ac8bd29879dccd67433342f50L15-R18): Commented out unused `print_target` initialization and related code to streamline PBRT file parsing and reduce unnecessary operations.
* [`src/panel/views/render/scene_view/get_render_items.rs`](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adL37): Removed unused `std::default` import to clean up dependencies.

### Shader Logic Simplification:
* [`src/panel/views/render/scene_view/get_render_items.rs`](diffhunk://#diff-5ebebc1cbcabd9112fff319dc225f4803b3a63524adec078e560c2bd1690e2adL169-R168): Simplified `get_shader_id` logic by removing unnecessary checks for `RenderUniformValue::Vec4(color)` and replaced it with a more concise condition.