### PR TITLE
Add Spectrum

### DIFF
--- a/src/conversion/spectrum/float_file.rs
+++ b/src/conversion/spectrum/float_file.rs
@@ -4,7 +4,7 @@ use std::fs::read_to_string;
 
 use log;
 
-pub fn read_f32_file(path: &str) -> Result<Vec<f32>, PbrtError> {
+pub fn read_float_file(path: &str) -> Result<Vec<f32>, PbrtError> {
     let s = read_to_string(path)
         .map_err(|_| PbrtError::error(&format!("Unable to open file \"{}\".", path)))?;
     let mut values = Vec::new();

--- a/src/conversion/spectrum/mod.rs
+++ b/src/conversion/spectrum/mod.rs
@@ -29,7 +29,7 @@ impl Spectrum {
     }
 
     pub fn load_from_file(path: &str) -> Result<Spectrum, PbrtError> {
-        match read_f32_file(path) {
+        match read_float_file(path) {
             Ok(vals) => {
                 if vals.len() % 2 != 0 {
                     log::warn!(


### PR DESCRIPTION
This pull request updates the naming of a function and its usage to improve clarity and consistency in the codebase. The changes focus on renaming `read_f32_file` to `read_float_file` in both its definition and all instances where it is called.

Function renaming for clarity:

* [`src/conversion/spectrum/float_file.rs`](diffhunk://#diff-0a73f51abdc9e2400c414c0e3a1fb3dfe7573757c51bef49f6a164be2a14dbadL7-R7): Renamed the function `read_f32_file` to `read_float_file` to better align with naming conventions and improve code readability.
* [`src/conversion/spectrum/mod.rs`](diffhunk://#diff-3e73777e563bcf6f751b39310d34fa16d26996950719c86ad0e9d2851db777d5L32-R32): Updated the invocation of `read_f32_file` to `read_float_file` in the `load_from_file` method to reflect the function renaming.