### PR TITLE
Move shader into files

### DIFF
--- a/src/panel/views/render/scene_view/render_gizmo_program.rs
+++ b/src/panel/views/render/scene_view/render_gizmo_program.rs
@@ -24,30 +24,8 @@ pub fn create_render_gizmo_program(
         let program = gl.create_program().ok()?;
 
         let (vertex_shader_source, fragment_shader_source) = (
-            r#"
-                layout(location = 0) in vec3 position;   //
-
-                out vec4 vertexColor;
-
-                uniform vec4 base_color;
-                uniform mat4 local_to_world;
-                uniform mat4 world_to_camera;
-                uniform mat4 camera_to_clip;
-                void main() {
-                    //gl_Position = camera_to_clip * world_to_camera * local_to_world * vec4(position, 1);
-                    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
-                    vertexColor = base_color;
-                }
-            "#,
-            r#"
-                precision highp float;
-                in vec4 vertexColor;
-
-                out vec4 outColor;
-                void main() {
-                    outColor = vertexColor;
-                }
-            "#,
+            include_str!("shaders/gizmo/gizmo.vs"),
+            include_str!("shaders/gizmo/gizmo.fs"),
         );
 
         let shader_sources = [

--- a/src/panel/views/render/scene_view/render_solid_program.rs
+++ b/src/panel/views/render/scene_view/render_solid_program.rs
@@ -3,7 +3,6 @@ use crate::renderer::gl::RenderProgram;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use eframe::epaint::color;
 use uuid::Uuid;
 
 use eframe::egui_glow;
@@ -15,61 +14,12 @@ pub const RENDER_SOLID_SHADER_TEXTURE_ID: &str = "5af7fcd0-189c-4458-b872-17ed2b
 fn get_shader_source(id: Uuid) -> Option<(&'static str, &'static str)> {
     match id {
         _ if id == Uuid::parse_str(RENDER_SOLID_SHADER_COLOR_ID).unwrap() => Some((
-            r#"
-            layout(location = 0) in vec3 position;
-            layout(location = 2) in vec2 uv;
-
-            out vec2 vertexUV;
-
-            uniform mat4 local_to_world;
-            uniform mat4 world_to_camera;
-            uniform mat4 camera_to_clip;
-
-            void main() {
-                gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
-                vertexUV = uv;
-            }
-        "#,
-            r#"
-            precision highp float;
-            in vec2 vertexUV;
-            uniform vec4 base_color;
-
-            out vec4 outColor;
-
-            void main() {
-                outColor = base_color;
-            }
-        "#,
+            include_str!("shaders/solid/solid_color.vs"),
+            include_str!("shaders/solid/solid_color.fs"),
         )),
         _ if id == Uuid::parse_str(RENDER_SOLID_SHADER_TEXTURE_ID).unwrap() => Some((
-            r#"
-                layout(location = 0) in vec3 position;
-                layout(location = 2) in vec2 uv;
-
-                out vec2 vertexUV;
-
-                uniform vec4 base_color;
-                uniform mat4 local_to_world;
-                uniform mat4 world_to_camera;
-                uniform mat4 camera_to_clip;
-
-                void main() {
-                    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
-                    vertexUV = uv;
-                }
-            "#,
-            r#"
-                precision highp float;
-                in vec2 vertexUV;
-                uniform sampler2D base_color;
-
-                out vec4 outColor;
-
-                void main() {
-                    outColor = texture(base_color, vertexUV);
-                }
-            "#,
+            include_str!("shaders/solid/solid_texture.vs"),
+            include_str!("shaders/solid/solid_texture.fs"),
         )),
         _ => None,
     }

--- a/src/panel/views/render/scene_view/render_wireframe_program.rs
+++ b/src/panel/views/render/scene_view/render_wireframe_program.rs
@@ -24,32 +24,8 @@ pub fn create_render_wireframe_program(
         let program = gl.create_program().ok()?;
 
         let (vertex_shader_source, fragment_shader_source) = (
-            r#"
-                layout(location = 0) in vec3 position;   //
-                //layout(location = 1) in vec3 normal;     //
-                //layout(location = 2) in vec2 uv;         //
-
-                out vec4 vertexColor;
-
-                uniform vec4 base_color;
-                uniform mat4 local_to_world;
-                uniform mat4 world_to_camera;
-                uniform mat4 camera_to_clip;
-                void main() {
-                    //gl_Position = camera_to_clip * world_to_camera * local_to_world * vec4(position, 1);
-                    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
-                    vertexColor = base_color;
-                }
-            "#,
-            r#"
-                precision highp float;
-                in vec4 vertexColor;
-
-                out vec4 outColor;
-                void main() {
-                    outColor = vertexColor;
-                }
-            "#,
+            include_str!("shaders/wireframe/wireframe.vs"),
+            include_str!("shaders/wireframe/wireframe.fs"),
         );
 
         let shader_sources = [

--- a/src/panel/views/render/scene_view/shaders/gizmo/gizmo.fs
+++ b/src/panel/views/render/scene_view/shaders/gizmo/gizmo.fs
@@ -1,0 +1,7 @@
+precision highp float;
+in vec4 vertexColor;
+
+out vec4 outColor;
+void main() {
+    outColor = vertexColor;
+}

--- a/src/panel/views/render/scene_view/shaders/gizmo/gizmo.vs
+++ b/src/panel/views/render/scene_view/shaders/gizmo/gizmo.vs
@@ -1,0 +1,13 @@
+layout(location = 0) in vec3 position;   //
+
+out vec4 vertexColor;
+
+uniform vec4 base_color;
+uniform mat4 local_to_world;
+uniform mat4 world_to_camera;
+uniform mat4 camera_to_clip;
+void main() {
+    //gl_Position = camera_to_clip * world_to_camera * local_to_world * vec4(position, 1);
+    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
+    vertexColor = base_color;
+}

--- a/src/panel/views/render/scene_view/shaders/solid/solid_color.fs
+++ b/src/panel/views/render/scene_view/shaders/solid/solid_color.fs
@@ -1,0 +1,9 @@
+precision highp float;
+in vec2 vertexUV;
+uniform vec4 base_color;
+
+out vec4 outColor;
+
+void main() {
+    outColor = base_color;
+}

--- a/src/panel/views/render/scene_view/shaders/solid/solid_color.vs
+++ b/src/panel/views/render/scene_view/shaders/solid/solid_color.vs
@@ -1,0 +1,13 @@
+layout(location = 0) in vec3 position;
+layout(location = 2) in vec2 uv;
+
+out vec2 vertexUV;
+
+uniform mat4 local_to_world;
+uniform mat4 world_to_camera;
+uniform mat4 camera_to_clip;
+
+void main() {
+    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
+    vertexUV = uv;
+}

--- a/src/panel/views/render/scene_view/shaders/solid/solid_texture.fs
+++ b/src/panel/views/render/scene_view/shaders/solid/solid_texture.fs
@@ -1,0 +1,9 @@
+precision highp float;
+in vec2 vertexUV;
+uniform sampler2D base_color;
+
+out vec4 outColor;
+
+void main() {
+    outColor = texture(base_color, vertexUV);
+}

--- a/src/panel/views/render/scene_view/shaders/solid/solid_texture.vs
+++ b/src/panel/views/render/scene_view/shaders/solid/solid_texture.vs
@@ -1,0 +1,14 @@
+layout(location = 0) in vec3 position;
+layout(location = 2) in vec2 uv;
+
+out vec2 vertexUV;
+
+uniform vec4 base_color;
+uniform mat4 local_to_world;
+uniform mat4 world_to_camera;
+uniform mat4 camera_to_clip;
+
+void main() {
+    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
+    vertexUV = uv;
+}

--- a/src/panel/views/render/scene_view/shaders/wireframe/wireframe.fs
+++ b/src/panel/views/render/scene_view/shaders/wireframe/wireframe.fs
@@ -1,0 +1,7 @@
+precision highp float;
+in vec4 vertexColor;
+
+out vec4 outColor;
+void main() {
+    outColor = vertexColor;
+}

--- a/src/panel/views/render/scene_view/shaders/wireframe/wireframe.vs
+++ b/src/panel/views/render/scene_view/shaders/wireframe/wireframe.vs
@@ -1,0 +1,14 @@
+layout(location = 0) in vec3 position;   //
+//layout(location = 1) in vec3 normal;     //
+//layout(location = 2) in vec2 uv;         //
+
+out vec4 vertexColor;
+
+uniform vec4 base_color;
+uniform mat4 local_to_world;
+uniform mat4 world_to_camera;
+uniform mat4 camera_to_clip;
+void main() {
+    gl_Position = vec4(position, 1) * local_to_world * world_to_camera * camera_to_clip;
+    vertexColor = base_color;
+}


### PR DESCRIPTION
This pull request refactors shader management in the rendering pipeline by replacing inline shader source code with external shader files. Additionally, it removes unused imports and improves maintainability by centralizing shader definitions. 

### Shader Refactoring:
* [`src/panel/views/render/scene_view/render_gizmo_program.rs`](diffhunk://#diff-0a27b69aac8cd4bc9d129b262ff4db028b0e2e1ee2c7401d2e03bddaa4ef1a14L27-R28): Replaced inline vertex and fragment shader source code with external files `gizmo.vs` and `gizmo.fs` using `include_str!`.
* [`src/panel/views/render/scene_view/render_wireframe_program.rs`](diffhunk://#diff-e0f26335a2767276ff9d8001c65214b51a04f4204280bf02fc6cb6793e3f891bL27-R28): Updated shader source code to use external files `wireframe.vs` and `wireframe.fs`.
* [`src/panel/views/render/scene_view/render_solid_program.rs`](diffhunk://#diff-c9ad772a45fad5f323812dbad77d359762463ecd6986c3c133ad6c27bda01bcaL18-R22): Replaced inline shader definitions with external files `solid_color.vs`, `solid_color.fs`, `solid_texture.vs`, and `solid_texture.fs`.

### Shader File Additions:
* Added new shader files: `gizmo.vs`, `gizmo.fs`, `solid_color.vs`, `solid_color.fs`, `solid_texture.vs`, `solid_texture.fs`, `wireframe.vs`, and `wireframe.fs` to centralize shader definitions. [[1]](diffhunk://#diff-7b5dcf7da2f69ff5e1ef6f2cdc8fdc727986748729f86d4793f2a93ebe0da510R1-R13) [[2]](diffhunk://#diff-53ff2d76f30fdcc5a4c88ce996568f154ef3f2082bf5bfeb231a4fc6e55ccfd6R1-R7) [[3]](diffhunk://#diff-c7f6ee54f436283491128d8a3a8943c673d21886f3b27a491221db36ae5c6761R1-R13) [[4]](diffhunk://#diff-dc8bf625cd2ad332d0cdcd578043b9539e5d975c2f1c90861f9e00428e4c4733R1-R9) [[5]](diffhunk://#diff-c05938f519156e6bcd92e5a1a0b887218176d0625582883e57ea0338f61a6c93R1-R14) [[6]](diffhunk://#diff-b4570e67fe70eda769701a76dbe14f066fc3ec6ea054760ea384e705a8efa08dR1-R9) [[7]](diffhunk://#diff-95a759eed6c10b0a07aefe43332703aa2cf25e66758a06112db368a5431594cdR1-R14)

### Code Cleanup:
* [`src/panel/views/render/scene_view/render_solid_program.rs`](diffhunk://#diff-c9ad772a45fad5f323812dbad77d359762463ecd6986c3c133ad6c27bda01bcaL6): Removed unused `eframe::epaint::color` import to clean up dependencies.