### PR TITLE
Fix glsl version

### DIFF
--- a/src/panel/views/render/scene_view/mod.rs
+++ b/src/panel/views/render/scene_view/mod.rs
@@ -4,6 +4,7 @@ mod render_item;
 mod render_mode;
 mod render_solid_program;
 mod render_wireframe_program;
+mod render_version;
 
 pub use get_render_items::get_render_items;
 pub use render_item::{GizmoRenderItem, MeshRenderItem, RenderItem};

--- a/src/panel/views/render/scene_view/render_gizmo_program.rs
+++ b/src/panel/views/render/scene_view/render_gizmo_program.rs
@@ -1,3 +1,4 @@
+use super::render_version::get_glsl_version_line;
 use crate::renderer::gl::RenderProgram;
 
 use std::collections::HashMap;
@@ -5,10 +6,10 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
-use eframe::egui_glow;
 use eframe::glow;
 
 pub const GIZMO_SHADER_ID: &str = "c80398e9-a45b-4783-96a9-03ccd15ced40";
+
 pub fn create_render_gizmo_program(
     gl: &Arc<glow::Context>,
     id: Uuid,
@@ -16,11 +17,7 @@ pub fn create_render_gizmo_program(
     use glow::HasContext as _;
 
     unsafe {
-        // Check if the OpenGL context is current
-        // get gl shader version
-        let _shader_version = egui_glow::ShaderVersion::get(gl);
-
-        //todo!("Implement create_dunny_program");
+        let version_string= get_glsl_version_line(gl)?;
         let program = gl.create_program().ok()?;
 
         let (vertex_shader_source, fragment_shader_source) = (
@@ -38,7 +35,7 @@ pub fn create_render_gizmo_program(
             .map(|(shader_type, shader_source)| {
                 let source = format!(
                     "{}\n{}",
-                    "#version 330", //shader_version.version_declaration(),
+                    version_string,
                     shader_source
                 );
                 let shader = gl.create_shader(*shader_type).ok().unwrap();

--- a/src/panel/views/render/scene_view/render_solid_program.rs
+++ b/src/panel/views/render/scene_view/render_solid_program.rs
@@ -1,3 +1,4 @@
+use super::render_version::get_glsl_version_line;
 use crate::renderer::gl::RenderProgram;
 
 use std::collections::HashMap;
@@ -5,7 +6,6 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
-use eframe::egui_glow;
 use eframe::glow;
 
 pub const RENDER_SOLID_SHADER_COLOR_ID: &str = "812e32bf-8051-42a7-94af-03e4099025da";
@@ -32,11 +32,7 @@ pub fn create_render_solid_program(
     use glow::HasContext as _;
 
     unsafe {
-        // Check if the OpenGL context is current
-        // get gl shader version
-        let _shader_version = egui_glow::ShaderVersion::get(gl);
-
-        //todo!("Implement create_dunny_program");
+        let version_string= get_glsl_version_line(gl)?;
         let program = gl.create_program().ok()?;
 
         let (vertex_shader_source, fragment_shader_source) = get_shader_source(id)?;
@@ -51,7 +47,7 @@ pub fn create_render_solid_program(
             .map(|(shader_type, shader_source)| {
                 let source = format!(
                     "{}\n{}",
-                    "#version 330", //shader_version.version_declaration(),
+                    version_string,
                     shader_source
                 );
                 let shader = gl.create_shader(*shader_type).ok().unwrap();

--- a/src/panel/views/render/scene_view/render_version.rs
+++ b/src/panel/views/render/scene_view/render_version.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use eframe::glow;
+use glow::HasContext as _;
+
+pub fn get_gl_version(gl: &Arc<glow::Context>) -> String {
+    unsafe {
+        return gl.get_parameter_string(glow::VERSION);
+    }
+}
+
+pub fn get_glsl_version(gl: &Arc<glow::Context>) -> String {
+    unsafe {
+        return gl.get_parameter_string(glow::SHADING_LANGUAGE_VERSION);
+    }
+}
+
+const GLSL_VERSION_LINE: [(&str, &str); 9] = [
+    ("1.3", "#version 130"),
+    ("1.4", "#version 140"),
+    ("1.5", "#version 150"),
+    ("3.3", "#version 330"),
+    ("4.0", "#version 400"),
+    ("4.1", "#version 410"),
+    ("4.2", "#version 420"),
+    ("4.3", "#version 430"),
+    ("4.4", "#version 440"),
+];
+
+pub fn get_glsl_version_line(gl: &Arc<glow::Context>) -> Option<String> {
+    let version_str = get_glsl_version(gl);
+    for (version, line) in GLSL_VERSION_LINE.iter() {
+        if version_str.contains(version) {
+            return Some(line.to_string());
+        }
+    }
+    return None;
+}

--- a/src/panel/views/render/scene_view/render_wireframe_program.rs
+++ b/src/panel/views/render/scene_view/render_wireframe_program.rs
@@ -1,3 +1,4 @@
+use super::render_version::get_glsl_version_line;
 use crate::renderer::gl::RenderProgram;
 
 use std::collections::HashMap;
@@ -5,10 +6,10 @@ use std::sync::Arc;
 
 use uuid::Uuid;
 
-use eframe::egui_glow;
 use eframe::glow;
 
 pub const WIREFRAME_SHADER_ID: &str = "612e32bf-8051-42a7-94af-03e4099025da";
+
 pub fn create_render_wireframe_program(
     gl: &Arc<glow::Context>,
     id: Uuid,
@@ -16,11 +17,7 @@ pub fn create_render_wireframe_program(
     use glow::HasContext as _;
 
     unsafe {
-        // Check if the OpenGL context is current
-        // get gl shader version
-        let _shader_version = egui_glow::ShaderVersion::get(gl);
-
-        //todo!("Implement create_dunny_program");
+        let version_string= get_glsl_version_line(gl)?;
         let program = gl.create_program().ok()?;
 
         let (vertex_shader_source, fragment_shader_source) = (
@@ -38,7 +35,7 @@ pub fn create_render_wireframe_program(
             .map(|(shader_type, shader_source)| {
                 let source = format!(
                     "{}\n{}",
-                    "#version 330", //shader_version.version_declaration(),
+                    version_string,
                     shader_source
                 );
                 let shader = gl.create_shader(*shader_type).ok().unwrap();


### PR DESCRIPTION
This pull request refactors shader version handling in the rendering modules. It introduces a new utility for determining GLSL version lines dynamically based on the OpenGL context and replaces hardcoded shader version declarations across multiple rendering programs. Additionally, it removes the dependency on `eframe::egui_glow` for shader version handling.

### Shader Version Handling Refactor:

* **Added `render_version` module**: Introduced utility functions `get_gl_version`, `get_glsl_version`, and `get_glsl_version_line` to dynamically retrieve OpenGL and GLSL versions and map them to appropriate GLSL version lines. (`src/panel/views/render/scene_view/render_version.rs`)
* **Updated shader version handling in rendering programs**: Replaced hardcoded GLSL version declarations (`#version 330`) with dynamically retrieved `version_string` using `get_glsl_version_line` in `create_render_gizmo_program`, `create_render_solid_program`, and `create_render_wireframe_program`. (`src/panel/views/render/scene_view/render_gizmo_program.rs` [[1]](diffhunk://#diff-0a27b69aac8cd4bc9d129b262ff4db028b0e2e1ee2c7401d2e03bddaa4ef1a14R1-R20) [[2]](diffhunk://#diff-0a27b69aac8cd4bc9d129b262ff4db028b0e2e1ee2c7401d2e03bddaa4ef1a14L41-R38); `src/panel/views/render/scene_view/render_solid_program.rs` [[3]](diffhunk://#diff-c9ad772a45fad5f323812dbad77d359762463ecd6986c3c133ad6c27bda01bcaR1-L8) [[4]](diffhunk://#diff-c9ad772a45fad5f323812dbad77d359762463ecd6986c3c133ad6c27bda01bcaL35-R35) [[5]](diffhunk://#diff-c9ad772a45fad5f323812dbad77d359762463ecd6986c3c133ad6c27bda01bcaL54-R50); `src/panel/views/render/scene_view/render_wireframe_program.rs` [[6]](diffhunk://#diff-e0f26335a2767276ff9d8001c65214b51a04f4204280bf02fc6cb6793e3f891bR1-R20) [[7]](diffhunk://#diff-e0f26335a2767276ff9d8001c65214b51a04f4204280bf02fc6cb6793e3f891bL41-R38)

### Dependency Cleanup:

* **Removed `eframe::egui_glow` dependency**: Eliminated the use of `egui_glow::ShaderVersion::get` for retrieving shader versions, simplifying dependencies in rendering modules. (`src/panel/views/render/scene_view/render_gizmo_program.rs` [[1]](diffhunk://#diff-0a27b69aac8cd4bc9d129b262ff4db028b0e2e1ee2c7401d2e03bddaa4ef1a14R1-R20); `src/panel/views/render/scene_view/render_solid_program.rs` [[2]](diffhunk://#diff-c9ad772a45fad5f323812dbad77d359762463ecd6986c3c133ad6c27bda01bcaR1-L8); `src/panel/views/render/scene_view/render_wireframe_program.rs` [[3]](diffhunk://#diff-e0f26335a2767276ff9d8001c65214b51a04f4204280bf02fc6cb6793e3f891bR1-R20)

### Code Organization:

* **Added `render_version` module import**: Included the new `render_version` module in `scene_view/mod.rs` for shared usage across rendering programs. (`src/panel/views/render/scene_view/mod.rs`)