### PR TITLE
Update src

### DIFF
--- a/src/conversion/mesh_data/heal_mesh_data.rs
+++ b/src/conversion/mesh_data/heal_mesh_data.rs
@@ -154,7 +154,7 @@ fn heal_uvs(mesh_data: &mut MeshData) {
     }
 }
 
-/* 
+
 #[inline]
 fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v2 = if f32::abs(v1.x) > f32::abs(v1.y) {
@@ -165,7 +165,7 @@ fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v3 = Vector3::cross(v1, &v2).normalize();
     return (v2, v3);
 }
-*/
+/* 
 #[inline]
 fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v1 = [v1.x, v1.y, v1.z];
@@ -196,6 +196,7 @@ fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v2 = Vector3::cross(&v3, &v1).normalize();
     return (v2, v3);
 }
+*/
 
 
 fn difference_of_products_f32(a: f32, b: f32, c: f32, d: f32) -> f32 {
@@ -229,7 +230,7 @@ fn heal_tangents(mesh_data: &mut MeshData) {
                     mesh_data.normals[3 * i + 1],
                     mesh_data.normals[3 * i + 2],
                 );
-                let (tangent, _bitangent) = coordinate_system(&n);
+                let (tangent, _bitangent) = coordinate_system(&-n);
                 tangents[i] = tangent;
             }
             mesh_data.tangents.resize(num_vertices * 3, 0.0);


### PR DESCRIPTION
This pull request makes adjustments to the `coordinate_system` function usage and implementation in the `heal_mesh_data.rs` file, primarily to correct the orientation of generated tangents in the mesh healing process. The most significant change is that the normal vector is now negated before being passed to `coordinate_system` in the `heal_tangents` function. Additionally, some code cleanup was performed by commenting and uncommenting alternate implementations of `coordinate_system`.

Key changes:

**Mesh tangent calculation:**
* In `heal_tangents`, the normal vector is now negated before being passed to `coordinate_system`, which likely corrects the direction of the computed tangents.

**Code organization and cleanup:**
* Adjusted commented/uncommented blocks for two alternate implementations of `coordinate_system`, clarifying which version is active and which is not. [[1]](diffhunk://#diff-ebf888ba4babcc08e57fe667c3dcc99c1dd044439c6a925fd2296c098d6768f8L157-R157) [[2]](diffhunk://#diff-ebf888ba4babcc08e57fe667c3dcc99c1dd044439c6a925fd2296c098d6768f8L168-R168) [[3]](diffhunk://#diff-ebf888ba4babcc08e57fe667c3dcc99c1dd044439c6a925fd2296c098d6768f8R199)