### PR TITLE
Shader Logic and Lighting

### DIFF
--- a/src/conversion/mesh_data/heal_mesh_data.rs
+++ b/src/conversion/mesh_data/heal_mesh_data.rs
@@ -154,7 +154,6 @@ fn heal_uvs(mesh_data: &mut MeshData) {
     }
 }
 
-
 #[inline]
 fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v2 = if f32::abs(v1.x) > f32::abs(v1.y) {
@@ -165,7 +164,7 @@ fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v3 = Vector3::cross(v1, &v2).normalize();
     return (v2, v3);
 }
-/* 
+/*
 #[inline]
 fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     let v1 = [v1.x, v1.y, v1.z];
@@ -197,7 +196,6 @@ fn coordinate_system(v1: &Vector3) -> (Vector3, Vector3) {
     return (v2, v3);
 }
 */
-
 
 fn difference_of_products_f32(a: f32, b: f32, c: f32, d: f32) -> f32 {
     //X =  a * b - cd

--- a/src/render/wgpu/shaders/render_dpdu_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_dpdu_mesh.wgsl
@@ -1,0 +1,68 @@
+struct GlobalUniforms {
+    world_to_camera: mat4x4<f32>,
+    camera_to_clip: mat4x4<f32>,
+    camera_position: vec4<f32>,
+}
+
+struct LocalUniforms {
+    local_to_world: mat4x4<f32>,
+    local_to_world_inverse: mat4x4<f32>, // inverse of world to camera
+    base_color: vec4<f32>,
+}
+
+// global uniforms
+@group(0)
+@binding(0)
+var<uniform> global_uniforms: GlobalUniforms;
+
+// local uniforms
+@group(1)
+@binding(0)
+var<uniform> local_uniforms: LocalUniforms;
+
+struct VertexOut {
+    @location(0) world_position: vec3<f32>,
+    @location(1) uv: vec2<f32>,
+    @location(2) world_normal:   vec3<f32>,
+    @location(3) world_tangent:  vec3<f32>,
+    @builtin(position) position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(
+    @location(0) position: vec3<f32>,
+    @location(1) uvw: vec3<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) tangent: vec3<f32>,
+) -> VertexOut {
+    var out: VertexOut;
+    // local_to_world * world_to_camera * camera_to_clip
+    let m_world = local_uniforms.local_to_world;
+    let m_clip = global_uniforms.camera_to_clip * global_uniforms.world_to_camera * m_world;
+    let m_world_it = transpose(local_uniforms.local_to_world_inverse);
+    let world_position = (m_world * vec4<f32>(position, 1.0)).xyz;
+    let world_normal = normalize((m_world_it * vec4<f32>(normal, 0.0)).xyz);
+    let world_tangent = normalize((m_world_it * vec4<f32>(tangent, 0.0)).xyz);
+    
+    out.position = m_clip * vec4<f32>(position, 1.0);
+    out.world_position = world_position;
+    out.uv = uvw.xy;
+    out.world_normal = world_normal;
+    out.world_tangent = world_tangent;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    let camera_position = global_uniforms.camera_position.xyz;//world position
+    let camera_to_object = normalize(in.world_position - camera_position);
+    var normal = normalize(in.world_normal);
+    var tangent = normalize(in.world_tangent);
+    if dot(normal, camera_to_object) > 0.0 {
+        normal = -normal;
+    }
+    //let color = 0.5 * (normal + vec3<f32>(1.0, 1.0, 1.0));
+    let color = 0.5 * (tangent + vec3<f32>(1.0, 1.0, 1.0));
+    //return vec4<f32>(in.uv, 0.0, 1.0);
+    return vec4<f32>(color, 1.0);
+}

--- a/src/render/wgpu/shaders/render_solid_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_solid_mesh.wgsl
@@ -1,12 +1,14 @@
 struct GlobalUniforms {
     world_to_camera: mat4x4<f32>,
     camera_to_clip: mat4x4<f32>,
-    camera_position: vec4<f32>,
+    camera_to_world: mat4x4<f32>,
+    light_direction: vec4<f32>, // Example light direction
+    light_intensity: vec4<f32>, // Example light intensity
 }
 
 struct LocalUniforms {
     local_to_world: mat4x4<f32>,
-    local_to_world_inverse: mat4x4<f32>, // inverse of world to camera
+    world_to_local: mat4x4<f32>, // inverse of world to camera
     base_color: vec4<f32>,
 }
 
@@ -21,10 +23,10 @@ var<uniform> global_uniforms: GlobalUniforms;
 var<uniform> local_uniforms: LocalUniforms;
 
 struct VertexOut {
-    @location(0) world_position: vec3<f32>,
+    @location(0) camera_position: vec3<f32>,
     @location(1) uv: vec2<f32>,
-    @location(2) world_normal:   vec3<f32>,
-    @location(3) world_tangent:  vec3<f32>,
+    @location(2) camera_normal:   vec3<f32>,
+    @location(3) camera_tangent:  vec3<f32>,
     @builtin(position) position: vec4<f32>,
 };
 
@@ -36,33 +38,32 @@ fn vs_main(
     @location(3) tangent: vec3<f32>,
 ) -> VertexOut {
     var out: VertexOut;
-    // local_to_world * world_to_camera * camera_to_clip
-    let m_world = local_uniforms.local_to_world;
-    let m_clip = global_uniforms.camera_to_clip * global_uniforms.world_to_camera * m_world;
-    let m_world_it = transpose(local_uniforms.local_to_world_inverse);
-    let world_position = (m_world * vec4<f32>(position, 1.0)).xyz;
-    let world_normal = normalize((m_world_it * vec4<f32>(normal, 0.0)).xyz);
-    let world_tangent = normalize((m_world_it * vec4<f32>(tangent, 0.0)).xyz);
+    let m_camera = global_uniforms.world_to_camera * local_uniforms.local_to_world;
+    let m_clip = global_uniforms.camera_to_clip * m_camera;
+    let m_camera_it = transpose(local_uniforms.world_to_local * global_uniforms.camera_to_world);
+
+    let camera_position = (m_camera * vec4<f32>(position, 1.0)).xyz;
+    let camera_normal = normalize((m_camera_it * vec4<f32>(normal, 0.0)).xyz);
+    let camera_tangent = normalize((m_camera_it * vec4<f32>(tangent, 0.0)).xyz);
     
     out.position = m_clip * vec4<f32>(position, 1.0);
-    out.world_position = world_position;
+    out.camera_position = camera_position;
     out.uv = uvw.xy;
-    out.world_normal = world_normal;
-    out.world_tangent = world_tangent;
+    out.camera_normal = camera_normal;
+    out.camera_tangent = camera_tangent;
     return out;
 }
 
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
-    let camera_position = global_uniforms.camera_position.xyz;//world position
-    let camera_to_object = normalize(in.world_position - camera_position);
-    var normal = normalize(in.world_normal);
-    var tangent = normalize(in.world_tangent);
+    let camera_to_object = normalize(in.camera_position);
+    var normal = normalize(in.camera_normal);
     if dot(normal, camera_to_object) > 0.0 {
         normal = -normal;
     }
-    //let color = 0.5 * (normal + vec3<f32>(1.0, 1.0, 1.0));
-    let color = 0.5 * (tangent + vec3<f32>(1.0, 1.0, 1.0));
-    //return vec4<f32>(in.uv, 0.0, 1.0);
-    return vec4<f32>(color, 1.0);
+    let light_direction = global_uniforms.light_direction.xyz; // Example light direction
+    let light_intensity = global_uniforms.light_intensity.x; // Example light intensity
+    let diffuse = (max(dot(normal, light_direction), 0.0) * 0.9 + 0.1) * light_intensity;
+    let diffuse_color = vec3<f32>(diffuse);
+    return vec4<f32>(diffuse_color, 1.0);
 }


### PR DESCRIPTION
This pull request updates the solid mesh rendering pipeline to improve how camera transforms and lighting are handled, both in the Rust code and the associated WGSL shaders. The main changes involve refactoring uniform buffer structures, updating shader logic to support lighting, and ensuring proper matrix transformations for rendering.

### Rendering Pipeline and Uniform Buffer Refactoring

* Refactored the `GlobalUniforms` and `LocalUniforms` structs in both Rust (`solid_mesh_renderer.rs`) and WGSL shaders to include new fields: `camera_to_world`, `light_direction`, and `light_intensity`, while removing or renaming old fields such as `camera_position` and `local_to_world_inverse`. Added padding to `LocalUniforms` to ensure correct alignment. [[1]](diffhunk://#diff-449919f6da513779a298155a32e63942fba3052e285117107ee5d32ed4b79b3cL21-R33) [[2]](diffhunk://#diff-449919f6da513779a298155a32e63942fba3052e285117107ee5d32ed4b79b3cL123-R129) [[3]](diffhunk://#diff-449919f6da513779a298155a32e63942fba3052e285117107ee5d32ed4b79b3cL140-R147) [[4]](diffhunk://#diff-449919f6da513779a298155a32e63942fba3052e285117107ee5d32ed4b79b3cL315-R320) [[5]](diffhunk://#diff-61235242e07c3a1e2304524945b4e8cec42fc98e78b4a340d3e2979394f65fe1L4-R11)
* Updated the binding visibility for the local uniform buffer to include both vertex and fragment shader stages, allowing fragment shaders to access local uniform data.

### Shader Logic and Lighting Improvements

* Overhauled the WGSL shader logic in `render_solid_mesh.wgsl` to use the new uniform structures, compute positions and normals in camera space, and implement simple diffuse lighting using the new `light_direction` and `light_intensity` uniforms. [[1]](diffhunk://#diff-61235242e07c3a1e2304524945b4e8cec42fc98e78b4a340d3e2979394f65fe1L24-R29) [[2]](diffhunk://#diff-61235242e07c3a1e2304524945b4e8cec42fc98e78b4a340d3e2979394f65fe1L39-R68)
* Added a new shader, `render_dpdu_mesh.wgsl`, which demonstrates similar uniform handling and coordinate transformations, and outputs tangent-based coloring for debugging or visualization.

### Minor Code Cleanups

* Removed unnecessary blank lines and comments in `heal_mesh_data.rs` for code clarity. [[1]](diffhunk://#diff-ebf888ba4babcc08e57fe667c3dcc99c1dd044439c6a925fd2296c098d6768f8L157) [[2]](diffhunk://#diff-ebf888ba4babcc08e57fe667c3dcc99c1dd044439c6a925fd2296c098d6768f8L201)

These changes collectively modernize the rendering code to support more flexible and realistic rendering with lighting, and lay the groundwork for further visual improvements.