### PR TITLE
Update attenuation

### DIFF
--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -147,7 +147,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let r1 = light.range[1];
         var light_to_object = in.w_position - light.position.xyz;
         var distance = length(light_to_object);
-        let attenuation = pow(max(1.0 - ((distance - r0) / (r1 - r0)), 0.0), 2.0); // Simple quadratic attenuation
+        let attenuation = 1.0 / pow(max((distance - r0), 1e-6), 2.0); // Simple quadratic attenuation
         var wi = -normalize(light_to_object);
         wi = normalize(tbn * wi); // Transform light direction to tangent space
         var wo = -camera_to_object;// object to camera vector
@@ -168,7 +168,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         light_to_object = normalize(light_to_object);
         let cos_angle = max(dot(light_to_object, direction), 0.0);
         var falloff = pow(select(step(a1, cos_angle), clamp((cos_angle - a1) / (a0 - a1), 0.0, 1.0), (a0 - a1) > 0.0), 4.0);//select(FALSE, TRUE, condition)
-        let attenuation = pow(max(1.0 - ((distance - r0) / (r1 - r0)), 0.0), 2.0); // Simple quadratic attenuation
+        let attenuation = 1.0 / pow(max((distance - r0), 1e-6), 2.0); // Simple quadratic attenuation
         var wi = -light_to_object;
         wi = normalize(tbn * wi); // Transform light direction to tangent space
         var wo = -camera_to_object;// object to camera vector


### PR DESCRIPTION
This pull request updates the attenuation calculation for lights in the `render_lighting_mesh.wgsl` shader. The new approach uses an inverse quadratic formula, which avoids division by zero and provides more physically accurate light falloff.

Lighting attenuation calculation changes:

* Updated the attenuation formula in two places within `fn fs_main` to use `1.0 / pow(max((distance - r0), 1e-6), 2.0)` instead of the previous quadratic approach, improving stability and realism in light falloff calculations. [[1]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L150-R150) [[2]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L171-R171)