### PR TITLE
Update src

### DIFF
--- a/src/conversion/light_shape/from_spot.rs
+++ b/src/conversion/light_shape/from_spot.rs
@@ -32,8 +32,8 @@ pub fn create_light_shape_from_spot(props: &PropertyMap) -> Option<LightShape> {
     let coneangle = props.find_one_float("coneangle").unwrap_or(30.0);
     let conedelta = props.find_one_float("conedeltaangle").unwrap_or(5.0);
     //0,0,0 -> 0,0,1
-    let coneangle = coneangle * 0.5; //convert to half angle
-    let conedelta = conedelta * 0.5; //convert to half angle
+    // let coneangle = coneangle * 0.5; //convert to half angle
+    // let conedelta = conedelta * 0.5; //convert to half angle
 
     let mut lines = Vec::new();
 

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -1,3 +1,4 @@
+use crate::base;
 use crate::render::wgpu::light::RenderLightType;
 
 use super::material::RenderUniformValue;
@@ -208,10 +209,11 @@ impl LightingMeshRenderer {
             for (i, item) in mesh_items.iter().enumerate() {
                 let local_to_world = item.get_matrix();
                 let world_to_local = local_to_world.inverse();
+                let base_color = get_base_color(item);
                 let uniform = LocalUniforms {
                     local_to_world: local_to_world.to_cols_array_2d(),
                     world_to_local: world_to_local.to_cols_array_2d(),
-                    base_color: get_base_color(item),
+                    base_color: base_color,
                     _pad1: [0.0; 4],
                     _pad2: [0.0; 4],
                     _pad3: [0.0; 4],


### PR DESCRIPTION
This pull request makes improvements to the lighting calculations and code organization for mesh rendering. The main changes involve correcting how light and view directions are transformed in the shader, updating the handling of spot light angles to remove unnecessary half-angle conversions, and refactoring some Rust code for clarity and efficiency.

### Shader logic and lighting calculations

* Updated the transformation of light (`wi`) and view (`wo`) directions in the `render_lighting_mesh.wgsl` shader to consistently apply the tangent space matrix, improving correctness and readability. [[1]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697R132-R138) [[2]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697R148-R150)
* Changed spot light angle calculations to use the full angle values instead of half-angles, and updated the falloff computation to use more descriptive variable names and logic. This aligns the shader with the expected input values for spot lights.

### Rust code organization and clarity

* Commented out unnecessary half-angle conversions for spot light angles in `create_light_shape_from_spot`, ensuring that the shader and Rust code are consistent in how angles are handled.
* Refactored the assignment of `base_color` in `LightingMeshRenderer` for clarity by introducing a local variable.
* Added a missing import for `base` in `lighting_mesh_renderer.rs` to resolve dependencies.