### PR TITLE
Use SBO

### DIFF
--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -15,8 +15,8 @@ use bytemuck::{Pod, Zeroable};
 
 const MIN_LOCAL_BUFFER_NUM: usize = 64;
 const MAX_DIRECTIONAL_LIGHT_NUM: usize = 4; // Maximum number of directional lights
-const MAX_SPOT_LIGHT_NUM: usize = 4; // Maximum number of spot lights
-const MAX_POINT_LIGHT_NUM: usize = 4; // Maximum number of point lights
+const MAX_SPOT_LIGHT_NUM: usize = 32; // Maximum number of spot lights
+const MAX_POINT_LIGHT_NUM: usize = 256; // Maximum number of point lights
 
 //pub struct SolidMeshRenderer {}
 
@@ -42,19 +42,18 @@ struct LocalUniforms {
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
-struct DirectionalLight {
-    direction: [f32; 4], // Direction of the light // 4 * 4 = 16
-    intensity: [f32; 4], // Intensity of the light // 4 * 4 = 16
+struct LightUniforms {
+    num_directional_lights: u32, // Number of directional lights
+    num_point_lights: u32,       // Number of point lights
+    num_spot_lights: u32,        // Number of spot lights
+    _pad1: u32,                  // Padding to ensure alignment
 }
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
-struct DirectionalLightUniforms {
-    lights: [DirectionalLight; MAX_DIRECTIONAL_LIGHT_NUM], // 8 * 16 = 256
-    count: u32,                                            // Number of directional lights
-    _pad1: u32,
-    _pad2: u32,
-    _pad3: u32,
+struct DirectionalLight {
+    direction: [f32; 4], // Direction of the light // 4 * 4 = 16
+    intensity: [f32; 4], // Intensity of the light // 4 * 4 = 16
 }
 
 #[repr(C)]
@@ -68,16 +67,6 @@ struct PointLight {
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
-struct PointLightUniforms {
-    lights: [PointLight; MAX_POINT_LIGHT_NUM], // 8 * 16 = 256
-    count: u32,                                // Number of directional lights
-    _pad1: u32,
-    _pad2: u32,
-    _pad3: u32,
-}
-
-#[repr(C)]
-#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
 struct SpotLight {
     position: [f32; 4],  // Position of the light // 4 * 4 = 16
     direction: [f32; 4], // Direction of the light // 4 * 4 = 16
@@ -86,16 +75,6 @@ struct SpotLight {
     outer_angle: f32,    // Angle of the spotlight
     inner_angle: f32,    // Angle of the spotlight
     _pad1: [f32; 2],     // Padding to ensure alignmentå
-}
-
-#[repr(C)]
-#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
-struct SpotLightUniforms {
-    lights: [SpotLight; MAX_SPOT_LIGHT_NUM], // 8 * 16 = 256
-    count: u32,                              // Number of directional lights
-    _pad1: u32,
-    _pad2: u32,
-    _pad3: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -115,9 +94,10 @@ pub struct LightingMeshRenderer {
     #[allow(dead_code)]
     light_bind_group_layout: wgpu::BindGroupLayout,
     light_bind_group: wgpu::BindGroup,
-    directional_light_uniform_buffer: wgpu::Buffer,
-    point_light_uniform_buffer: wgpu::Buffer,
-    spot_light_uniform_buffer: wgpu::Buffer,
+    light_uniform_buffer: wgpu::Buffer,
+    directional_light_buffer: wgpu::Buffer,
+    point_light_buffer: wgpu::Buffer,
+    spot_light_buffer: wgpu::Buffer,
 }
 
 #[derive(Debug, Clone)]
@@ -231,150 +211,156 @@ impl LightingMeshRenderer {
             resources.insert(per_frame_resources);
         }
 
-        // Directional lights
         {
-            let light_items = render_items
-                .iter()
-                .filter(|item| {
-                    if let RenderItem::Light(item) = item.as_ref() {
-                        if item.light.light_type == RenderLightType::Directional {
-                            return true;
+            let mut light_uniforms = LightUniforms::default();
+            // Point lights
+            {
+                let light_items = render_items
+                    .iter()
+                    .filter(|item| {
+                        if let RenderItem::Light(item) = item.as_ref() {
+                            if item.light.light_type == RenderLightType::Point {
+                                return true;
+                            }
                         }
-                    }
-                    return false;
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            let num_light_items = light_items.len();
-            let mut light_uniforms = DirectionalLightUniforms::default();
-            light_uniforms.count = num_light_items as u32;
-            for (i, item) in light_items.iter().enumerate() {
-                if let RenderItem::Light(light_item) = item.as_ref() {
-                    if i < MAX_DIRECTIONAL_LIGHT_NUM {
-                        let matrix = light_item.matrix; //local_to_world
-                        let direction = light_item.light.direction;
-                        let direction = matrix.transform_vector3(glam::vec3(
-                            direction[0],
-                            direction[1],
-                            direction[2],
-                        ));
-                        let intensity = light_item.light.intensity;
-                        light_uniforms.lights[i] = DirectionalLight {
-                            direction: [direction[0], direction[1], direction[2], 0.0],
-                            intensity: [intensity[0], intensity[1], intensity[2], 1.0],
-                        };
+                        return false;
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                // Currently, we do not handle point lights in this renderer.
+                // You can implement similar logic as above for point lights if needed.
+                let num_light_items = light_items.len();
+                light_uniforms.num_point_lights = num_light_items as u32;
+                for (i, item) in light_items.iter().enumerate() {
+                    //println!("Point light item: {:?}", item);
+                    if let RenderItem::Light(light_item) = item.as_ref() {
+                        if i < MAX_POINT_LIGHT_NUM {
+                            let matrix = light_item.matrix; //local_to_world
+                            let position = light_item.light.position;
+                            let position = matrix.transform_point3(glam::vec3(
+                                position[0],
+                                position[1],
+                                position[2],
+                            ));
+                            //println!("Point light position: {:?}", position);
+                            let intensity = light_item.light.intensity;
+                            let range = light_item.light.range;
+                            let light = PointLight {
+                                position: [position.x, position.y, position.z, 1.0],
+                                intensity: [intensity[0], intensity[1], intensity[2], 1.0],
+                                range: [range[0], range[1], 0.0, 0.0], // min and max range
+                                ..Default::default()
+                            };
+                            queue.write_buffer(
+                                &self.point_light_buffer,
+                                (i * size_of::<PointLight>()) as wgpu::BufferAddress,
+                                bytemuck::bytes_of(&light),
+                            );
+                        }
                     }
                 }
             }
-            queue.write_buffer(
-                &self.directional_light_uniform_buffer,
-                0,
-                bytemuck::bytes_of(&light_uniforms),
-            );
-        }
 
-        // Spot lights
-        {
-            let light_items = render_items
-                .iter()
-                .filter(|item| {
-                    if let RenderItem::Light(item) = item.as_ref() {
-                        if item.light.light_type == RenderLightType::Spot {
-                            return true;
+            // Spot lights
+            {
+                let light_items = render_items
+                    .iter()
+                    .filter(|item| {
+                        if let RenderItem::Light(item) = item.as_ref() {
+                            if item.light.light_type == RenderLightType::Spot {
+                                return true;
+                            }
                         }
-                    }
-                    return false;
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            // Currently, we do not handle spot lights in this renderer.
-            // You can implement similar logic as above for spot lights if needed.
-            let num_light_items = light_items.len();
-            let mut light_uniforms = SpotLightUniforms::default();
-            light_uniforms.count = num_light_items as u32;
-            for (i, item) in light_items.iter().enumerate() {
-                //println!("Point light item: {:?}", item);
-                if let RenderItem::Light(light_item) = item.as_ref() {
-                    if i < MAX_SPOT_LIGHT_NUM {
-                        let matrix = light_item.matrix; //local_to_world
-                        let position = light_item.light.position;
-                        let position = matrix.transform_point3(glam::vec3(
-                            position[0],
-                            position[1],
-                            position[2],
-                        ));
-                        let direction = light_item.light.direction;
-                        let direction = matrix.transform_vector3(glam::vec3(
-                            direction[0],
-                            direction[1],
-                            direction[2],
-                        ));
-                        //println!("Point light position: {:?}", position);
-                        let intensity = light_item.light.intensity;
-                        let range = light_item.light.range;
-                        light_uniforms.lights[i] = SpotLight {
-                            position: [position.x, position.y, position.z, 1.0],
-                            direction: [direction.x, direction.y, direction.z, 0.0],
-                            intensity: [intensity[0], intensity[1], intensity[2], 1.0],
-                            range: [range[0], range[1], 0.0, 0.0], // min and max range
-                            outer_angle: light_item.light.angle[1],
-                            inner_angle: light_item.light.angle[0],
-                            ..Default::default()
-                        };
+                        return false;
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                // Currently, we do not handle spot lights in this renderer.
+                // You can implement similar logic as above for spot lights if needed.
+                let num_light_items = light_items.len();
+                light_uniforms.num_spot_lights = num_light_items as u32;
+                for (i, item) in light_items.iter().enumerate() {
+                    //println!("Point light item: {:?}", item);
+                    if let RenderItem::Light(light_item) = item.as_ref() {
+                        if i < MAX_SPOT_LIGHT_NUM {
+                            let matrix = light_item.matrix; //local_to_world
+                            let position = light_item.light.position;
+                            let position = matrix.transform_point3(glam::vec3(
+                                position[0],
+                                position[1],
+                                position[2],
+                            ));
+                            let direction = light_item.light.direction;
+                            let direction = matrix.transform_vector3(glam::vec3(
+                                direction[0],
+                                direction[1],
+                                direction[2],
+                            ));
+                            //println!("Point light position: {:?}", position);
+                            let intensity = light_item.light.intensity;
+                            let range = light_item.light.range;
+                            let light = SpotLight {
+                                position: [position.x, position.y, position.z, 1.0],
+                                direction: [direction.x, direction.y, direction.z, 0.0],
+                                intensity: [intensity[0], intensity[1], intensity[2], 1.0],
+                                range: [range[0], range[1], 0.0, 0.0], // min and max range
+                                outer_angle: light_item.light.angle[1],
+                                inner_angle: light_item.light.angle[0],
+                                ..Default::default()
+                            };
+                            queue.write_buffer(
+                                &self.spot_light_buffer,
+                                (i * size_of::<SpotLight>()) as wgpu::BufferAddress,
+                                bytemuck::bytes_of(&light),
+                            );
+                        }
                     }
                 }
             }
-            queue.write_buffer(
-                &self.spot_light_uniform_buffer,
-                0,
-                bytemuck::bytes_of(&light_uniforms),
-            );
-        }
 
-        // Point lights
-        {
-            let light_items = render_items
-                .iter()
-                .filter(|item| {
-                    if let RenderItem::Light(item) = item.as_ref() {
-                        if item.light.light_type == RenderLightType::Point {
-                            return true;
+            // Directional lights
+            {
+                let light_items = render_items
+                    .iter()
+                    .filter(|item| {
+                        if let RenderItem::Light(item) = item.as_ref() {
+                            if item.light.light_type == RenderLightType::Directional {
+                                return true;
+                            }
                         }
-                    }
-                    return false;
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            // Currently, we do not handle point lights in this renderer.
-            // You can implement similar logic as above for point lights if needed.
-            let num_light_items = light_items.len();
-            let mut light_uniforms = PointLightUniforms::default();
-            light_uniforms.count = num_light_items as u32;
-            for (i, item) in light_items.iter().enumerate() {
-                //println!("Point light item: {:?}", item);
-                if let RenderItem::Light(light_item) = item.as_ref() {
-                    if i < MAX_POINT_LIGHT_NUM {
-                        let matrix = light_item.matrix; //local_to_world
-                        let position = light_item.light.position;
-                        let position = matrix.transform_point3(glam::vec3(
-                            position[0],
-                            position[1],
-                            position[2],
-                        ));
-                        //println!("Point light position: {:?}", position);
-                        let intensity = light_item.light.intensity;
-                        let range = light_item.light.range;
-                        light_uniforms.lights[i] = PointLight {
-                            position: [position.x, position.y, position.z, 1.0],
-                            intensity: [intensity[0], intensity[1], intensity[2], 1.0],
-                            range: [range[0], range[1], 0.0, 0.0], // min and max range
-                            ..Default::default()
-                        };
+                        return false;
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+                let num_light_items = light_items.len();
+                light_uniforms.num_directional_lights = num_light_items as u32;
+                for (i, item) in light_items.iter().enumerate() {
+                    if let RenderItem::Light(light_item) = item.as_ref() {
+                        if i < MAX_DIRECTIONAL_LIGHT_NUM {
+                            let matrix = light_item.matrix; //local_to_world
+                            let direction = light_item.light.direction;
+                            let direction = matrix.transform_vector3(glam::vec3(
+                                direction[0],
+                                direction[1],
+                                direction[2],
+                            ));
+                            let intensity = light_item.light.intensity;
+                            let light = DirectionalLight {
+                                direction: [direction[0], direction[1], direction[2], 0.0],
+                                intensity: [intensity[0], intensity[1], intensity[2], 1.0],
+                            };
+                            queue.write_buffer(
+                                &self.directional_light_buffer,
+                                (i * size_of::<DirectionalLight>()) as wgpu::BufferAddress,
+                                bytemuck::bytes_of(&light),
+                            );
+                        }
                     }
                 }
             }
+
             queue.write_buffer(
-                &self.point_light_uniform_buffer,
+                &self.light_uniform_buffer,
                 0,
                 bytemuck::bytes_of(&light_uniforms),
             );
@@ -447,7 +433,7 @@ impl LightingMeshRenderer {
         //let queue = &wgpu_render_state.queue;
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Solid Shader"),
+            label: Some("Lighting Shader"),
             source: wgpu::ShaderSource::Wgsl(
                 include_str!("shaders/render_lighting_mesh.wgsl").into(),
             ),
@@ -510,6 +496,12 @@ impl LightingMeshRenderer {
                 }],
             });
 
+        let point_light_buffer_size =
+            (MAX_POINT_LIGHT_NUM * size_of::<PointLight>()) as wgpu::BufferAddress;
+        let spot_light_buffer_size =
+            (MAX_SPOT_LIGHT_NUM * size_of::<SpotLight>()) as wgpu::BufferAddress;
+        let directional_light_buffer_size =
+            (MAX_DIRECTIONAL_LIGHT_NUM * size_of::<DirectionalLight>()) as wgpu::BufferAddress;
         let light_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("Light Bind Group Layout"),
@@ -521,7 +513,7 @@ impl LightingMeshRenderer {
                             ty: wgpu::BufferBindingType::Uniform,
                             has_dynamic_offset: false,
                             min_binding_size: wgpu::BufferSize::new(size_of::<
-                                DirectionalLightUniforms,
+                                LightUniforms,
                             >()
                                 as _),
                         },
@@ -531,11 +523,11 @@ impl LightingMeshRenderer {
                         binding: 1,
                         visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Uniform,
+                            ty: wgpu::BufferBindingType::Storage {
+                                read_only: true,
+                            },
                             has_dynamic_offset: false,
-                            min_binding_size: wgpu::BufferSize::new(
-                                size_of::<PointLightUniforms>() as _,
-                            ),
+                            min_binding_size: wgpu::BufferSize::new(point_light_buffer_size),
                         },
                         count: None,
                     },
@@ -543,11 +535,23 @@ impl LightingMeshRenderer {
                         binding: 2,
                         visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Uniform,
+                            ty: wgpu::BufferBindingType::Storage {
+                                read_only: true,
+                            },
                             has_dynamic_offset: false,
-                            min_binding_size: wgpu::BufferSize::new(
-                                size_of::<SpotLightUniforms>() as _
-                            ),
+                            min_binding_size: wgpu::BufferSize::new(spot_light_buffer_size),
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage {
+                                read_only: true,
+                            },
+                            has_dynamic_offset: false,
+                            min_binding_size: wgpu::BufferSize::new(directional_light_buffer_size),
                         },
                         count: None,
                     },
@@ -573,7 +577,7 @@ impl LightingMeshRenderer {
         };
 
         let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Solid Pipeline"),
+            label: Some("Lighting Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
@@ -641,27 +645,31 @@ impl LightingMeshRenderer {
             }],
         });
 
-        let directional_light_uniforms = DirectionalLightUniforms::default();
-        let directional_light_uniform_buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Uniform Buffer for Directional Lights"),
-                contents: bytemuck::bytes_of(&directional_light_uniforms),
-                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
-            });
-        let point_light_uniforms = PointLightUniforms::default();
-        let point_light_uniform_buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Uniform Buffer for Point Lights"),
-                contents: bytemuck::bytes_of(&point_light_uniforms),
-                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
-            });
-        let spot_light_uniforms = SpotLightUniforms::default();
-        let spot_light_uniform_buffer =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Uniform Buffer for Spot Lights"),
-                contents: bytemuck::bytes_of(&spot_light_uniforms),
-                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
-            });
+        let light_uniforms = LightUniforms::default();
+        let light_uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Uniform Buffer for Light"),
+            contents: bytemuck::bytes_of(&light_uniforms),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+        });
+
+        let point_light_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Buffer for Point Lights"),
+            size: point_light_buffer_size,
+            mapped_at_creation: false,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+        });
+        let spot_light_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Buffer for Spot Lights"),
+            size: spot_light_buffer_size,
+            mapped_at_creation: false,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+        });
+        let directional_light_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Buffer for Point Lights"),
+            size: directional_light_buffer_size,
+            mapped_at_creation: false,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+        });
 
         let light_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Lighting Light Bind Group"),
@@ -669,15 +677,19 @@ impl LightingMeshRenderer {
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: directional_light_uniform_buffer.as_entire_binding(),
+                    resource: light_uniform_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: point_light_uniform_buffer.as_entire_binding(),
+                    resource: point_light_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
-                    resource: spot_light_uniform_buffer.as_entire_binding(),
+                    resource: spot_light_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: directional_light_buffer.as_entire_binding(),
                 },
             ],
         });
@@ -696,9 +708,10 @@ impl LightingMeshRenderer {
             local_uniform_buffer,
             light_bind_group_layout,
             light_bind_group,
-            directional_light_uniform_buffer,
-            point_light_uniform_buffer,
-            spot_light_uniform_buffer,
+            light_uniform_buffer,
+            directional_light_buffer,
+            point_light_buffer,
+            spot_light_buffer,
         });
     }
 }


### PR DESCRIPTION
This pull request refactors the lighting system in `lighting_mesh_renderer.rs` to support a significantly larger number of lights and improves how light data is managed and passed to the GPU. Instead of using uniform buffers for each light type, it introduces dedicated storage buffers for directional, point, and spot lights, and consolidates light counts into a single uniform struct. These changes make the renderer more scalable and efficient.

**Lighting system refactor and scalability improvements:**

* Increased maximum supported lights: `MAX_POINT_LIGHT_NUM` raised from 4 to 256, and `MAX_SPOT_LIGHT_NUM` from 4 to 32, allowing many more lights in the scene.
* Replaced per-light-type uniform structs (`DirectionalLightUniforms`, `PointLightUniforms`, `SpotLightUniforms`) with a consolidated `LightUniforms` struct for light counts, and switched to using storage buffers for actual light data (`directional_light_buffer`, `point_light_buffer`, `spot_light_buffer`). [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L45-R56) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L69-L78) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L91-L100) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L118-R100) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L644-R671) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L672-R692) [[7]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L699-R714)

**Buffer and bind group layout changes:**

* Updated bind group layout to use storage buffers for light data, increasing flexibility and supporting larger arrays of lights. Added new bindings for directional, point, and spot light buffers. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R499-R504) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L534-R554)
* Refactored buffer creation to allocate appropriate sizes for the increased number of lights and use storage buffers instead of uniform buffers.

**Renderer logic updates:**

* Refactored light data upload logic: now writes individual light structs directly to the respective storage buffers for each light type, using the new buffer structure and consolidated uniform. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L234-L273) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L293-R281) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L315-R302) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R311-R363) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L576-R580)

**Miscellaneous improvements:**

* Updated shader and pipeline labels to reflect the new lighting system. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L450-R436) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L576-R580)