### PR TITLE
Update src

### DIFF
--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -543,7 +543,7 @@ impl LightingMeshRenderer {
 }
 
 impl LightingMeshRenderer {
-    pub fn new<'a>(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
         let global_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("Global Bind Group Layout"),

--- a/src/render/wgpu/linear_to_srgb_renderer.rs
+++ b/src/render/wgpu/linear_to_srgb_renderer.rs
@@ -1,0 +1,125 @@
+use eframe::wgpu;
+
+#[derive(Debug, Clone)]
+pub struct LinearToSrgbRenderer {
+    // This renderer is used to copy the final render texture to the screen
+    // It can be used to apply post-processing effects or simply display the final render
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    sampler: wgpu::Sampler,
+    bind_group: Option<wgpu::BindGroup>,
+}
+
+impl LinearToSrgbRenderer {
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Linear To SRGB Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/copy_texture.wgsl").into()),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+            ],
+            label: None,
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Linear To SRGB Pipeline Layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Linear To SRGB Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(target_format.into())],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("Texture Sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        LinearToSrgbRenderer {
+            pipeline,
+            bind_group_layout,
+            sampler,
+            bind_group: None, // Initialize with no bind group
+        }
+    }
+
+    pub fn prepare(&mut self, device: &wgpu::Device, texture: &wgpu::Texture) {
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(
+                        &texture.create_view(&Default::default()),
+                    ),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+            ],
+            label: None,
+        });
+        self.bind_group = Some(bind_group);
+    }
+
+    pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
+        if let Some(bindgroup) = self.bind_group.as_ref() {
+            render_pass.set_pipeline(&self.pipeline); // Set the appropriate pipeline
+            render_pass.set_bind_group(0, bindgroup, &[]);
+            render_pass.draw(0..6, 0..1); // Draw a full-screen quad
+        }
+    }
+}

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -15,3 +15,4 @@ pub mod solid_mesh_renderer;
 pub mod solid_renderer;
 pub mod wire_mesh_renderer;
 pub mod wire_renderer;
+pub mod linear_to_srgb_renderer;

--- a/src/render/wgpu/solid_mesh_renderer.rs
+++ b/src/render/wgpu/solid_mesh_renderer.rs
@@ -204,11 +204,7 @@ impl SolidMeshRenderer {
 }
 
 impl SolidMeshRenderer {
-    pub fn new<'a>(cc: &'a eframe::CreationContext<'a>) -> Option<Self> {
-        let wgpu_render_state = cc.wgpu_render_state.as_ref()?;
-        let device = &wgpu_render_state.device;
-        //let queue = &wgpu_render_state.queue;
-
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Solid Shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("shaders/render_solid_mesh.wgsl").into()),
@@ -299,7 +295,7 @@ impl SolidMeshRenderer {
                 entry_point: Some("fs_main"),
                 //targets: &[Some(wgpu_render_state.target_format.into())],
                 targets: &[Some(wgpu::ColorTargetState {
-                    format: wgpu_render_state.target_format,
+                    format: target_format,
                     blend: Some(wgpu::BlendState::REPLACE),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
@@ -362,7 +358,7 @@ impl SolidMeshRenderer {
             }],
         });
 
-        return Some(SolidMeshRenderer {
+        return SolidMeshRenderer {
             pipeline,
             global_bind_group_layout,
             global_bind_group,
@@ -371,6 +367,6 @@ impl SolidMeshRenderer {
             local_bind_group,
             local_uniform_buffer,
             local_uniform_alignment,
-        });
+        };
     }
 }

--- a/src/render/wgpu/solid_renderer.rs
+++ b/src/render/wgpu/solid_renderer.rs
@@ -85,17 +85,13 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
 
             //println!("Preparing lines renderer with {} items", render_items.len());
             let mut renderer = self.lines_renderer.write().unwrap();
-            let cmds = renderer.prepare(
+            renderer.prepare(
                 device,
                 queue,
-                screen_descriptor,
-                encoder,
-                resources,
                 &render_items,
                 &self.world_to_camera,
                 &self.camera_to_clip,
             );
-            command_buffers.extend(cmds);
         }
         return command_buffers;
     }
@@ -112,22 +108,21 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
         }
         if true {
             let renderer = self.lines_renderer.read().unwrap();
-            renderer.paint(&info, render_pass, resources);
+            renderer.paint(render_pass);
         }
     }
 }
 
 impl SolidRenderer {
     pub fn new<'a>(cc: &'a eframe::CreationContext<'a>) -> Option<Self> {
-        if let Some(mesh_renderer) = SolidMeshRenderer::new(cc) {
-            if let Some(lines_renderer) = LinesRenderer::new(cc) {
-                return Some(SolidRenderer {
-                    mesh_renderer: Arc::new(RwLock::new(mesh_renderer)),
-                    lines_renderer: Arc::new(RwLock::new(lines_renderer)),
-                });
-            }
-        }
-        return None;
+        let render_state = cc.wgpu_render_state.as_ref()?;
+        let device = &render_state.device;
+        let mesh_renderer = SolidMeshRenderer::new(device, render_state.target_format);
+        let lines_renderer = LinesRenderer::new(device, render_state.target_format);
+        return Some(SolidRenderer {
+            mesh_renderer: Arc::new(RwLock::new(mesh_renderer)),
+            lines_renderer: Arc::new(RwLock::new(lines_renderer)),
+        });
     }
 
     pub fn render(

--- a/src/render/wgpu/wire_mesh_renderer.rs
+++ b/src/render/wgpu/wire_mesh_renderer.rs
@@ -171,11 +171,7 @@ impl WireMeshRenderer {
 }
 
 impl WireMeshRenderer {
-    pub fn new<'a>(cc: &'a eframe::CreationContext<'a>) -> Option<Self> {
-        let wgpu_render_state = cc.wgpu_render_state.as_ref()?;
-        let device = &wgpu_render_state.device;
-        //let queue = &wgpu_render_state.queue;
-
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Wireframe Shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("shaders/render_wire_mesh.wgsl").into()),
@@ -246,7 +242,7 @@ impl WireMeshRenderer {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: Some("fs_main"),
-                targets: &[Some(wgpu_render_state.target_format.into())],
+                targets: &[Some(target_format.into())],
                 compilation_options: wgpu::PipelineCompilationOptions::default(),
             }),
             primitive: primitive,
@@ -303,7 +299,7 @@ impl WireMeshRenderer {
             }],
         });
 
-        return Some(WireMeshRenderer {
+        return WireMeshRenderer {
             pipeline,
             global_bind_group_layout,
             global_bind_group,
@@ -312,6 +308,6 @@ impl WireMeshRenderer {
             local_bind_group,
             local_uniform_buffer,
             local_uniform_alignment,
-        });
+        };
     }
 }


### PR DESCRIPTION
This pull request refactors the rendering pipeline to improve modularity and post-processing flexibility. The main changes include replacing the old `CopyTextureRenderer` with a new `LinearToSrgbRenderer`, refactoring renderer constructors to take explicit device and target format arguments, and updating the `LinesRenderer` to streamline its API and integration. These changes make the rendering flow more explicit and allow for easier future extensions.

**Renderer Pipeline Refactor and Post-Processing Improvements:**

* Replaced the legacy `CopyTextureRenderer` with the new `LinearToSrgbRenderer` for final texture display and post-processing, moving its implementation to `src/render/wgpu/linear_to_srgb_renderer.rs` and updating all usages in `lighting_renderer.rs`. [[1]](diffhunk://#diff-cab936d6e690ed4aa1e284e220332362cdbd6efece881ff0853c1988c6b11d00L30-R39) [[2]](diffhunk://#diff-cf2aad3813b28fa9003dba140eeef751d15a76d6374cf63df0977d73b322fdd2R1-R125)
* Updated the `LightingRenderer` struct and initialization to include both a mesh renderer and a lines renderer, and refactored how renderers are prepared and painted per frame. [[1]](diffhunk://#diff-cab936d6e690ed4aa1e284e220332362cdbd6efece881ff0853c1988c6b11d00L322-R215) [[2]](diffhunk://#diff-cab936d6e690ed4aa1e284e220332362cdbd6efece881ff0853c1988c6b11d00R137-R146) [[3]](diffhunk://#diff-cab936d6e690ed4aa1e284e220332362cdbd6efece881ff0853c1988c6b11d00R183-R186) [[4]](diffhunk://#diff-cab936d6e690ed4aa1e284e220332362cdbd6efece881ff0853c1988c6b11d00R236)

**Renderer API and Constructor Refactoring:**

* Refactored constructors for `LightingMeshRenderer`, `SolidMeshRenderer`, and `LinesRenderer` to take explicit `device` and `target_format` arguments for more flexible and consistent initialization. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L546-R546) [[2]](diffhunk://#diff-449919f6da513779a298155a32e63942fba3052e285117107ee5d32ed4b79b3cL207-R207) [[3]](diffhunk://#diff-449919f6da513779a298155a32e63942fba3052e285117107ee5d32ed4b79b3cL302-R298) [[4]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L147-R171) [[5]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L318-R301) [[6]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L327-R311) [[7]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L261-R242)

**Lines Renderer API Simplification:**

* Simplified the `LinesRenderer` API by removing unused per-frame resource management and streamlining the `prepare` and `paint` methods to operate directly on internal state. [[1]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L44-R44) [[2]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L73-R78) [[3]](diffhunk://#diff-8f70fcc91215d257519e75eab01ec309d383b8532bd2d928b998bc742d9e8df7L147-R171)

**Module Organization:**

* Added the new `linear_to_srgb_renderer` module to `src/render/wgpu/mod.rs` to support the new renderer.