### PR TITLE
Update src

### DIFF
--- a/src/render/wgpu/lines_renderer.rs
+++ b/src/render/wgpu/lines_renderer.rs
@@ -4,8 +4,6 @@ use super::lines::RenderLinesVertex;
 use super::render_item::RenderItem;
 use std::sync::Arc;
 
-use eframe::egui;
-use eframe::egui_wgpu;
 use eframe::wgpu;
 use eframe::wgpu::util::DeviceExt;
 use wgpu::util::align_to;
@@ -146,10 +144,7 @@ impl LinesRenderer {
         self.render_items = render_items.to_vec();
     }
 
-    pub fn paint(
-        &self,
-        render_pass: &mut wgpu::RenderPass,
-    ) {
+    pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
         if !self.render_items.is_empty() {
             let local_uniform_alignment = self.local_uniform_alignment;
             render_pass.set_pipeline(&self.pipeline); //

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -1,6 +1,7 @@
 pub mod light;
 pub mod lighting_mesh_renderer;
 pub mod lighting_renderer;
+pub mod linear_to_srgb_renderer;
 pub mod lines;
 pub mod lines_renderer;
 pub mod material;
@@ -15,4 +16,3 @@ pub mod solid_mesh_renderer;
 pub mod solid_renderer;
 pub mod wire_mesh_renderer;
 pub mod wire_renderer;
-pub mod linear_to_srgb_renderer;


### PR DESCRIPTION
This pull request introduces support for area lights defined by mesh shapes in the rendering pipeline, specifically handling `trianglemesh` and `plymesh` types. The changes include a new method for extracting area light information from mesh data, as well as related utility functions. Additionally, there are minor code cleanups and module organization adjustments.

### Area light mesh support:

* Added `get_area_light_item_from_mesh` function to extract and create area light render items from meshes of type `trianglemesh` or `plymesh`, including logic to detect square meshes and compute light properties.
* Integrated mesh-based area light handling into the main area light item creation logic by calling the new mesh function for supported shape types.
* Implemented `check_square_mesh` utility to verify if two triangles form a square mesh, which is necessary for the area light extraction.

### Codebase organization and cleanup:

* Added missing import for `create_mesh_data` in `render_light_item.rs` to enable mesh data extraction.
* Removed redundant imports (`egui`, `egui_wgpu`) from `lines_renderer.rs` for code cleanliness.
* Fixed module organization by moving `linear_to_srgb_renderer` to the correct location in `wgpu/mod.rs`. [[1]](diffhunk://#diff-10566cc63055b224302ee6933768cf389c2873c283ce0c7dc677c04a8f4ffb36R4) [[2]](diffhunk://#diff-10566cc63055b224302ee6933768cf389c2873c283ce0c7dc677c04a8f4ffb36L18)

### Minor formatting:

* Simplified the formatting of the `paint` method signature in `lines_renderer.rs`.