### PR TITLE
Update src

### DIFF
--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -69,15 +69,15 @@ struct SphereLight {
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
 struct DiskLight {
-    position: [f32; 4],  // Position of the light // 4 * 4 = 16
-    direction: [f32; 4], // Direction of the light // 4 * 4 = 16
-    intensity: [f32; 4], // Intensity of the light // 4 * 4 = 16
-    radius: f32,         // Radius of the light // 1 * 4 = 4
-    range: f32,          // Range of the light // 1 * 4 = 4
-    _pad1: [f32; 2],     // Padding to ensure alignment
-    inner_angle: f32,    // Angle of the spotlight
-    outer_angle: f32,    // Angle of the spotlight
-    _pad2: [f32; 2],     // Padding to ensure alignmentå
+    position: [f32; 4],   // Position of the light // 4 * 4 = 16
+    direction: [f32; 4],  // Direction of the light // 4 * 4 = 16
+    intensity: [f32; 4],  // Intensity of the light // 4 * 4 = 16
+    radius: f32,          // Radius of the light // 1 * 4 = 4
+    range: f32,           // Range of the light // 1 * 4 = 4
+    _pad1: [f32; 2],      // Padding to ensure alignment
+    cos_inner_angle: f32, // Angle of the spotlight
+    cos_outer_angle: f32, // Angle of the spotlight
+    _pad2: [f32; 2],      // Padding to ensure alignmentå
 }
 
 #[derive(Debug, Clone)]
@@ -381,13 +381,15 @@ impl LightingMeshRenderer {
                             //println!("Point light position: {:?}", position);
                             let intensity = light.intensity;
                             let radius = light.radius;
+                            let cos_inner_angle = f32::cos(light.inner_angle);
+                            let cos_outer_angle = f32::cos(light.outer_angle);
                             let light = DiskLight {
                                 position: [position.x, position.y, position.z, 1.0],
                                 direction: [direction.x, direction.y, direction.z, 0.0],
                                 intensity: [intensity[0], intensity[1], intensity[2], 1.0],
                                 radius: radius,
-                                inner_angle: light.inner_angle,
-                                outer_angle: light.outer_angle,
+                                cos_inner_angle: cos_inner_angle,
+                                cos_outer_angle: cos_outer_angle,
                                 ..Default::default()
                             };
                             queue.write_buffer(


### PR DESCRIPTION
This pull request refactors the spotlight angle handling in both Rust and WGSL shader code to improve performance and consistency. Instead of passing raw angles, the cosine of the inner and outer angles is now computed in Rust and passed to the shader, allowing the shader to avoid redundant calculations. Additionally, the spotlight intersection logic and attenuation formula have been streamlined for clarity and efficiency.

**Spotlight angle handling improvements:**

* Changed the `DiskLight` struct in both `lighting_mesh_renderer.rs` and `render_lighting_mesh.wgsl` to store `cos_inner_angle` and `cos_outer_angle` instead of raw angles, ensuring consistent usage and reducing computation in the shader. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L78-R79) [[2]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L36-R37)
* Updated the Rust code in `LightingMeshRenderer` to precompute the cosine values of the spotlight angles before passing them to the GPU.
* Modified the WGSL shader to use the precomputed cosine values, removing unnecessary calls to `cos()` in the shader for spotlight calculations.

**Shader logic and performance improvements:**

* Refactored the spotlight intersection calculation in the WGSL shader for clarity and numerical stability, including adjustments to ray direction and intersection point calculation.
* Simplified the quadratic attenuation formula in the shader for improved performance and removed redundant multiplication in the color calculation.