### PR TITLE
Add RectLight

### DIFF
--- a/src/conversion/light_shape/from_area.rs
+++ b/src/conversion/light_shape/from_area.rs
@@ -77,7 +77,7 @@ fn create_lines_from_rect(plane: &PlaneMesh) -> Option<Vec<Vec<Vector3>>> {
     if let Some(outline) = create_plane_outline_from_plane_mesh(plane) {
         if let Some(rect) = create_plane_rect_from_plane_outline(&outline, 0.99) {
             let mut total_lines = Vec::new();
-            let center = Vector3::new(rect.center[0], rect.center[1], rect.center[2]);
+            let center = Vector3::new(rect.position[0], rect.position[1], rect.position[2]);
             let u_axis = Vector3::new(rect.u_axis[0], rect.u_axis[1], rect.u_axis[2]);
             let v_axis = Vector3::new(rect.v_axis[0], rect.v_axis[1], rect.v_axis[2]);
             let corners = [

--- a/src/conversion/plane_data/plane_data.rs
+++ b/src/conversion/plane_data/plane_data.rs
@@ -11,7 +11,7 @@ pub struct PlaneOutline {
 
 #[derive(Debug, Clone)]
 pub struct PlaneRect {
-    pub center: [f32; 3],
+    pub position: [f32; 3],
     pub normal: [f32; 3],
     pub u_axis: [f32; 3],
     pub v_axis: [f32; 3],

--- a/src/conversion/plane_data/rect.rs
+++ b/src/conversion/plane_data/rect.rs
@@ -80,7 +80,7 @@ pub fn create_plane_rect_from_plane_outline(
         let u_axis = u_dir * 0.5;
         let v_axis = v_dir * 0.5;
         let rect = PlaneRect {
-            center: [center.x, center.y, center.z],
+            position: [center.x, center.y, center.z],
             normal: [normal.x, normal.y, normal.z],
             u_axis: [u_axis.x, u_axis.y, u_axis.z],
             v_axis: [v_axis.x, v_axis.y, v_axis.z],

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -29,10 +29,9 @@ pub struct DiskRenderLight {
     pub outer_angle: f32,    // Outer radius for disk
 }
 
+
 #[derive(Debug, Clone, Default)]
-pub struct RectRenderLight {
-    pub id: Uuid,
-    pub edition: String,
+pub struct RenderLightRect {
     pub position: [f32; 3],
     pub direction: [f32; 3],
     pub u_axis: [f32; 3],    // U axis for rectangle
@@ -40,12 +39,19 @@ pub struct RectRenderLight {
     pub intensity: [f32; 3], // RGB intensity
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct RectsRenderLight {
+    pub id: Uuid,
+    pub edition: String,
+    pub rects: Vec<RenderLightRect>, // Multiple rectangles
+}
+
 #[derive(Debug, Clone)]
 pub enum RenderLight {
     Directional(DirectionalRenderLight),
     Sphere(SphereRenderLight),
     Disk(DiskRenderLight),
-    Rect(RectRenderLight),
+    Rects(RectsRenderLight),
     // Add other light types as needed
 }
 
@@ -55,7 +61,7 @@ impl RenderLight {
             RenderLight::Directional(light) => light.id,
             RenderLight::Sphere(light) => light.id,
             RenderLight::Disk(light) => light.id,
-            RenderLight::Rect(light) => light.id,
+            RenderLight::Rects(light) => light.id,
             // Handle other light types here
         }
     }
@@ -65,7 +71,7 @@ impl RenderLight {
             RenderLight::Directional(light) => light.edition.clone(),
             RenderLight::Sphere(light) => light.edition.clone(),
             RenderLight::Disk(light) => light.edition.clone(),
-            RenderLight::Rect(light) => light.edition.clone(),
+            RenderLight::Rects(light) => light.edition.clone(),
             // Handle other light types here
         }
     }


### PR DESCRIPTION
This pull request introduces significant changes to how rectangular lights are represented and processed in the rendering pipeline. The main update is a refactor from handling single rectangle lights to supporting multiple rectangles per light, along with the necessary changes throughout the codebase to accommodate this. Key changes include updates to data structures, buffer management, and the rendering logic.

### Rectangular lights refactor

* Replaced the `RectRenderLight` struct with `RenderLightRect` and introduced `RectsRenderLight` to support multiple rectangles per light. The `RenderLight` enum now uses `Rects(RectsRenderLight)` instead of `Rect(RectRenderLight)`.
* Updated all references and logic to use the new `RectsRenderLight` type, including methods for retrieving light IDs and editions. [[1]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cL58-R64) [[2]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cL68-R74)

### Rendering pipeline and buffer management

* Added a new buffer for rectangle lights (`rect_light_buffer`) and updated the renderer to process multiple rectangles per light, transforming their properties and writing them to the buffer. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R114) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R417-R467)
* Added a new `RectLight` struct for GPU uniform representation and integrated it into the renderer’s buffer setup and bind group layout. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R83-R92) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R652-R653) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L641-R717) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R779-R784) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L720-R814) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L751-R839)
* Updated the light uniform struct to track the number of rectangle lights and added a constant for their maximum count. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L49-R49) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R20)

### Data structure naming consistency

* Renamed the `center` field in `PlaneRect` to `position` for clarity and consistency, and updated all usages accordingly. [[1]](diffhunk://#diff-8b9809a6d2001867d1841fa41f3655909287fd4fa51229af261508cac322e95aL14-R14) [[2]](diffhunk://#diff-7eeea80c017c572feedd8f4e3f4214b8bf2c9a3d8351d45f4778a24834932ddfL83-R83) [[3]](diffhunk://#diff-48071303c5bc1433c41d2ef4857a4ca19b05485cfb021963c73f353d56191b51L80-R80)

### Code organization and cleanup

* Updated imports and removed unused code related to the old rectangle light implementation. [[1]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cL3-R5) [[2]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cR17-R19) [[3]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cL452-R456)

These changes collectively improve the flexibility and scalability of how rectangular lights are handled in the renderer, enabling more complex lighting setups and better code maintainability.