### PR TITLE
Add Infinite Light

### DIFF
--- a/src/panel/views/render/scene_view.rs
+++ b/src/panel/views/render/scene_view.rs
@@ -84,7 +84,7 @@ impl SceneView {
         let available_size = available_rect.size();
 
         let mut znear = 0.01f32;
-        let mut zfar = 1000.0f32;
+        let mut zfar = 10000.0f32;
         let mut fov = 90.0f32.to_radians();
         let mut w2c = Matrix4x4::identity();
         let mut render_size = Vec2::new(1280.0, 720.0);

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Default)]
@@ -29,9 +30,10 @@ pub struct DiskRenderLight {
     pub outer_angle: f32,    // Outer radius for disk
 }
 
-
 #[derive(Debug, Clone, Default)]
-pub struct RenderLightRect {
+pub struct RectRenderLight {
+    pub id: Uuid,
+    pub edition: String,
     pub position: [f32; 3],
     pub direction: [f32; 3],
     pub u_axis: [f32; 3],    // U axis for rectangle
@@ -43,7 +45,7 @@ pub struct RenderLightRect {
 pub struct RectsRenderLight {
     pub id: Uuid,
     pub edition: String,
-    pub rects: Vec<RenderLightRect>, // Multiple rectangles
+    pub rects: Vec<Arc<RenderLight>>, // Multiple rectangles
 }
 
 #[derive(Debug, Clone)]
@@ -52,6 +54,7 @@ pub enum RenderLight {
     Sphere(SphereRenderLight),
     Disk(DiskRenderLight),
     Rects(RectsRenderLight),
+    Rect(RectRenderLight),
     // Add other light types as needed
 }
 
@@ -62,6 +65,7 @@ impl RenderLight {
             RenderLight::Sphere(light) => light.id,
             RenderLight::Disk(light) => light.id,
             RenderLight::Rects(light) => light.id,
+            RenderLight::Rect(light) => light.id,
             // Handle other light types here
         }
     }
@@ -72,6 +76,7 @@ impl RenderLight {
             RenderLight::Sphere(light) => light.edition.clone(),
             RenderLight::Disk(light) => light.edition.clone(),
             RenderLight::Rects(light) => light.edition.clone(),
+            RenderLight::Rect(light) => light.edition.clone(),
             // Handle other light types here
         }
     }

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -48,6 +48,13 @@ pub struct RectsRenderLight {
     pub rects: Vec<Arc<RenderLight>>, // Multiple rectangles
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct InfiniteRenderLight {
+    pub id: Uuid,
+    pub edition: String,
+    pub intensity: [f32; 3], // RGB intensity
+}
+
 #[derive(Debug, Clone)]
 pub enum RenderLight {
     Directional(DirectionalRenderLight),
@@ -55,6 +62,7 @@ pub enum RenderLight {
     Disk(DiskRenderLight),
     Rects(RectsRenderLight),
     Rect(RectRenderLight),
+    Infinite(InfiniteRenderLight),
     // Add other light types as needed
 }
 
@@ -66,6 +74,7 @@ impl RenderLight {
             RenderLight::Disk(light) => light.id,
             RenderLight::Rects(light) => light.id,
             RenderLight::Rect(light) => light.id,
+            RenderLight::Infinite(light) => light.id,
             // Handle other light types here
         }
     }
@@ -77,6 +86,7 @@ impl RenderLight {
             RenderLight::Disk(light) => light.edition.clone(),
             RenderLight::Rects(light) => light.edition.clone(),
             RenderLight::Rect(light) => light.edition.clone(),
+            RenderLight::Infinite(light) => light.edition.clone(),
             // Handle other light types here
         }
     }

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -419,45 +419,44 @@ impl LightingMeshRenderer {
             let mut i = 0;
             for item in render_items.iter() {
                 if let RenderItem::Light(item) = item.as_ref() {
-                    if let RenderLight::Rects(rects) = item.light.as_ref() {
-                        let matrix = item.matrix; //local_to_world
-                        for rect in rects.rects.iter() {
-                            if i >= MAX_RECT_LIGHT_NUM {
-                                break;
-                            }
-                            let position = rect.position;
-                            let position = matrix.transform_point3(glam::vec3(
-                                position[0],
-                                position[1],
-                                position[2],
-                            ));
-                            let direction = rect.direction;
-                            let direction = matrix.transform_vector3(glam::vec3(
-                                direction[0],
-                                direction[1],
-                                direction[2],
-                            ));
-                            let u_axis = rect.u_axis;
-                            let u_axis = matrix
-                                .transform_vector3(glam::vec3(u_axis[0], u_axis[1], u_axis[2]));
-                            let v_axis = rect.v_axis;
-                            let v_axis = matrix
-                                .transform_vector3(glam::vec3(v_axis[0], v_axis[1], v_axis[2]));
-                            let intensity = rect.intensity;
-                            let light = RectLight {
-                                position: [position.x, position.y, position.z, 1.0],
-                                direction: [direction.x, direction.y, direction.z, 0.0],
-                                u_axis: [u_axis.x, u_axis.y, u_axis.z, 0.0],
-                                v_axis: [v_axis.x, v_axis.y, v_axis.z, 0.0],
-                                intensity: [intensity[0], intensity[1], intensity[2], 1.0],
-                            };
-                            queue.write_buffer(
-                                &self.rect_light_buffer,
-                                (i * size_of::<RectLight>()) as wgpu::BufferAddress,
-                                bytemuck::bytes_of(&light),
-                            );
-                            i += 1;
+                    let matrix = item.matrix; //local_to_world
+                    if let RenderLight::Rect(rect) = item.light.as_ref() {
+                        //println!("Rect light item: {:?}", item);
+                        if i >= MAX_RECT_LIGHT_NUM {
+                            break;
                         }
+                        let position = rect.position;
+                        let position = matrix.transform_point3(glam::vec3(
+                            position[0],
+                            position[1],
+                            position[2],
+                        ));
+                        let direction = rect.direction;
+                        let direction = matrix.transform_vector3(glam::vec3(
+                            direction[0],
+                            direction[1],
+                            direction[2],
+                        ));
+                        let u_axis = rect.u_axis;
+                        let u_axis =
+                            matrix.transform_vector3(glam::vec3(u_axis[0], u_axis[1], u_axis[2]));
+                        let v_axis = rect.v_axis;
+                        let v_axis =
+                            matrix.transform_vector3(glam::vec3(v_axis[0], v_axis[1], v_axis[2]));
+                        let intensity = rect.intensity;
+                        let light = RectLight {
+                            position: [position.x, position.y, position.z, 1.0],
+                            direction: [direction.x, direction.y, direction.z, 0.0],
+                            u_axis: [u_axis.x, u_axis.y, u_axis.z, 0.0],
+                            v_axis: [v_axis.x, v_axis.y, v_axis.z, 0.0],
+                            intensity: [intensity[0], intensity[1], intensity[2], 1.0],
+                        };
+                        queue.write_buffer(
+                            &self.rect_light_buffer,
+                            (i * size_of::<RectLight>()) as wgpu::BufferAddress,
+                            bytemuck::bytes_of(&light),
+                        );
+                        i += 1;
                     }
                 }
             }
@@ -507,7 +506,6 @@ impl LightingMeshRenderer {
                 }
             }
         }
-
         queue.write_buffer(
             &self.light_uniform_buffer,
             0,

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -5,7 +5,7 @@ use super::mesh::RenderMesh;
 use super::render_gizmo_item::get_render_axis_gizmo_items;
 use super::render_gizmo_item::get_render_grid_gizmo_items;
 use super::render_light_item::get_render_light_gizmo_item;
-use super::render_light_item::get_render_light_item;
+use super::render_light_item::get_render_light_items;
 use super::render_mesh_item::get_render_mesh_item;
 use super::render_resource::RenderResourceComponent;
 use super::render_resource::RenderResourceManager;
@@ -160,15 +160,16 @@ pub fn get_render_items(
             }
             SceneItemType::Light => {
                 if mode == RenderMode::Lighting {
-                    if let Some(render_item) = get_render_light_item(
+                    let items = get_render_light_items(
                         device,
                         queue,
                         item,
                         mode,
                         &resource_manager,
                         &mut render_resource_manager,
-                    ) {
-                        render_items.push(Arc::new(render_item));
+                    );
+                    if !items.is_empty() {
+                        render_items.extend(items);
                     }
                 }
                 if let Some(render_item) = get_render_light_gizmo_item(

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -267,15 +267,19 @@ fn get_spot_light_item(
         let l = get_color(&props, "I", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
         let scale = get_color(&props, "scale", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
 
-        let intensity = [l[0] * scale[0], l[1] * scale[1], l[2] * scale[2]];
-        let radius = 10.0; //todo: get radius from properties
+        let p = 1.0 / std::f32::consts::PI; // Point light power normalization
+        let intensity = [
+            p * l[0] * scale[0],
+            p * l[1] * scale[1],
+            p * l[2] * scale[2],
+        ];
         let render_light = DiskRenderLight {
             id,
             edition: edition.clone(),
             position: [position.x, position.y, position.z], // Position is not used for spot lights
             direction: [direction.x, direction.y, direction.z], // Direction is not used for spot lights
             intensity: intensity,
-            radius: radius,
+            radius: 0.0,
             inner_angle, // Inner radius for spot lights
             outer_angle, // Outer radius for spot lights
         };

--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -16,6 +16,10 @@ struct LightUniforms {
     num_sphere_lights: u32,
     num_disk_lights: u32,
     num_rect_lights: u32,
+    num_infinite_lights: u32,
+    _pad1: u32,
+    _pad2: u32,
+    _pad3: u32,
 }
 
 struct DirectionalLight {
@@ -51,6 +55,13 @@ struct RectLight {
     intensity: vec4<f32>, // Light intensity
 }
 
+struct InfiniteLight {
+    intensity: vec4<f32>, // Light intensity
+    _pad1: vec4<f32>, // Padding for alignment
+    _pad2: vec4<f32>, // Padding for alignment
+    _pad3: vec4<f32>, // Padding for alignment
+}
+
 // global uniforms
 @group(0)
 @binding(0)
@@ -82,6 +93,10 @@ var<storage, read> disk_lights: array<DiskLight>;
 @group(2)
 @binding(4)
 var<storage, read> rect_lights: array<RectLight>;
+
+@group(2)
+@binding(5)
+var<storage, read> infinite_lights: array<InfiniteLight>;
 
 struct VertexOut {
     @location(0) w_position: vec3<f32>,
@@ -203,9 +218,8 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let distance = length(light_to_surface);
         var attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
-        color += intensity * attenuation * falloff;
+        color += matte(wi, wo) * intensity * attenuation * falloff;
     }
-
 
     for (var i: u32 = 0; i < light_uniforms.num_rect_lights; i++) 
     {
@@ -236,7 +250,16 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let distance = length(light_to_surface);
         var attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
-        color += intensity * attenuation * falloff;
+        color += matte(wi, wo) * intensity * attenuation * falloff;
+    }
+
+    for (var i: u32 = 0; i < light_uniforms.num_infinite_lights; i++) 
+    {
+        let light = infinite_lights[i];
+        let intensity = light.intensity.rgb;
+        let r = reflect(normalize(camera_to_surface), normal);
+        let wi = tbn * r;
+        color += matte(wi, wo) * intensity;
     }
 
     return vec4<f32>(color, 1.0);

--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -206,7 +206,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         color += intensity * attenuation * falloff;
     }
 
-    for (var i: u32 = 0; i < light_uniforms.num_rect_lights; i++) {
+
+    for (var i: u32 = 0; i < light_uniforms.num_rect_lights; i++) 
+    {
         let light = rect_lights[i];
         let position = light.position.xyz;
         let direction = normalize(light.direction.xyz);


### PR DESCRIPTION
This pull request introduces support for a new infinite light type and refactors the handling of different light types in the rendering pipeline for improved clarity and extensibility. The changes include new data structures for infinite lights, updates to buffer management, and cleaner iteration logic for all light types.

### Lighting System Extensions

* Added support for infinite lights, including the `InfiniteRenderLight` struct, an entry in the `RenderLight` enum, and corresponding buffer and uniform updates. [[1]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cL46-R55) [[2]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR64-R65) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R21-R22) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R52-R55) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R99-R107) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L113-R130) [[7]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R674-R675) [[8]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R741-R752) [[9]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L786-R828)
* Refactored buffer writing logic for all light types (sphere, disk, rect, infinite, directional) to use local buffers and batch writes, improving performance and code clarity. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L310-R334) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L346-R374) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L406-R425) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L441-R443) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R452-R504) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L500-L510)

### Light Type Struct and Enum Changes

* Renamed `RenderLightRect` to `RectRenderLight` and updated `RectsRenderLight` to store `Arc<RenderLight>` instead of a vector of rectangles, improving type consistency and future extensibility. [[1]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cL32-R36) [[2]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cL46-R55)
* Extended the `RenderLight` enum and associated methods to handle the new `Rect` and `Infinite` variants, ensuring proper ID and edition retrieval. [[1]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR64-R65) [[2]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR76-R77) [[3]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR88-R89)

### Minor Improvements

* Increased the default far clipping plane (`zfar`) in `SceneView` from 1000.0 to 10000.0 for improved scene depth handling.
* Updated buffer naming and creation for disk (formerly spot) and directional lights for clarity. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L773-R805) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L786-R828)

These changes collectively make the lighting system more flexible, maintainable, and ready for future enhancements.