### PR TITLE
Fix Rect Light

### DIFF
--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -17,7 +17,7 @@ const MIN_LOCAL_BUFFER_NUM: usize = 64;
 const MAX_DIRECTIONAL_LIGHT_NUM: usize = 4; // Maximum number of directional lights
 const MAX_SPHERE_LIGHT_NUM: usize = 256; // Maximum number of point lights
 const MAX_DISK_LIGHT_NUM: usize = 32; // Maximum number of spot lights
-const MAX_RECT_LIGHT_NUM: usize = 16; // Maximum number of rectangle lights
+const MAX_RECT_LIGHT_NUM: usize = 32; // Maximum number of rectangle lights
 const MAX_INFINITE_LIGHT_NUM: usize = 1; // Maximum number of infinite lights
 
 const TEST_PIPELINE_ID: &str = "basic_pipeline";


### PR DESCRIPTION
This pull request makes a small adjustment to the lighting mesh renderer configuration. The maximum number of rectangle lights supported has been increased.

* Increased `MAX_RECT_LIGHT_NUM` from 16 to 32 in `src/render/wgpu/lighting_mesh_renderer.rs`, allowing for more rectangle lights in the scene.