### PR TITLE
Feature/rect light3

### DIFF
--- a/src/panel/views/render/fps_counter.rs
+++ b/src/panel/views/render/fps_counter.rs
@@ -1,0 +1,32 @@
+use std::time::{Duration, Instant};
+
+pub struct FpsCounter {
+    last_frame_time: Instant,
+    frame_count: u64,
+    fps: f64,
+}
+
+impl FpsCounter {
+    pub fn new() -> Self {
+        Self {
+            last_frame_time: Instant::now(),
+            frame_count: 0,
+            fps: 0.0,
+        }
+    }
+
+    pub fn update(&mut self) {
+        self.frame_count += 1;
+        let now = Instant::now();
+        let duration = now.duration_since(self.last_frame_time);
+        if duration >= Duration::from_secs(1) {
+            self.fps = self.frame_count as f64 / duration.as_secs_f64();
+            self.frame_count = 0;
+            self.last_frame_time = now;
+        }
+    }
+
+    pub fn get_fps(&self) -> f64 {
+        self.fps
+    }
+}

--- a/src/panel/views/render/mod.rs
+++ b/src/panel/views/render/mod.rs
@@ -1,3 +1,4 @@
+pub mod fps_counter;
 pub mod image_data;
 pub mod image_receiver;
 pub mod render_history;

--- a/src/panel/views/render/scene_view.rs
+++ b/src/panel/views/render/scene_view.rs
@@ -1,3 +1,4 @@
+use super::fps_counter::FpsCounter;
 use crate::model::base::Matrix4x4;
 use crate::model::base::Property;
 use crate::model::base::Quaternion;
@@ -59,6 +60,7 @@ pub struct SceneView {
     wireframe: Option<WireRenderer>,
     solid: Option<SolidRenderer>,
     shaded: Option<LightingRenderer>,
+    fps_counter: FpsCounter,
 }
 
 impl SceneView {
@@ -70,6 +72,7 @@ impl SceneView {
             wireframe,
             solid,
             shaded,
+            fps_counter: FpsCounter::new(),
         }
     }
 
@@ -190,5 +193,18 @@ impl SceneView {
             egui::Stroke::new(1.0, egui::Color32::WHITE),
             egui::StrokeKind::Inside,
         );
+
+        let show_fps = true; //TODO: add option to show/hide fps
+        if show_fps {
+            self.fps_counter.update();
+            let fps = self.fps_counter.get_fps();
+            ui.painter().text(
+                rect.right_top() + egui::vec2(-5.0, 5.0),
+                egui::Align2::RIGHT_TOP,
+                format!("FPS: {:.1}", fps),
+                egui::FontId::monospace(16.0),
+                egui::Color32::GREEN,
+            );
+        }
     }
 }

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -2,6 +2,7 @@ use super::material::RenderUniformValue;
 use super::mesh::RenderVertex;
 use super::render_item::RenderItem;
 use crate::render::wgpu::light::RenderLight;
+use core::num;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -20,7 +21,8 @@ const MAX_DISK_LIGHT_NUM: usize = 32; // Maximum number of spot lights
 const MAX_RECT_LIGHT_NUM: usize = 32; // Maximum number of rectangle lights
 const MAX_INFINITE_LIGHT_NUM: usize = 1; // Maximum number of infinite lights
 
-const TEST_PIPELINE_ID: &str = "basic_pipeline";
+const MIN_MATERIAL_BUFFER_NUM: usize = 8;
+const BASIC_MATERIAL_ENTRY_ID: &str = "basic_material";
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
@@ -36,10 +38,10 @@ struct GlobalUniforms {
 struct LocalUniforms {
     local_to_world: [[f32; 4]; 4], // 4 * 4 * 4 = 64
     world_to_local: [[f32; 4]; 4], // 4 * 4 * 4 = 64
-    base_color: [f32; 4],          // Base color for the mesh
-    _pad1: [f32; 4],               // Padding to ensure alignment
-    _pad2: [f32; 4],               // Padding to ensure alignment
-    _pad3: [f32; 4],               // Padding to ensure alignment
+    _pad1: [f32; 4],
+    _pad2: [f32; 4],
+    _pad3: [f32; 4],
+    _pad4: [f32; 4],
 }
 
 #[repr(C)]
@@ -105,6 +107,53 @@ struct InfiniteLight {
     _pad3: [f32; 4],     // Padding to ensure alignment
 }
 
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
+struct BasicMaterialUniforms {
+    kd: [f32; 4],    // Diffuse color
+    ks: [f32; 4],    // Specular color
+    _pad1: [f32; 4], // Padding to ensure alignment
+    _pad2: [f32; 4], // Padding to ensure alignment
+}
+
+#[derive(Debug, Clone)]
+struct MaterialEntry {
+    pub pipeline: wgpu::RenderPipeline,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+    pub bind_group: wgpu::BindGroup,
+    pub uniform_buffer: wgpu::Buffer,
+    pub alignment: wgpu::BufferAddress,
+    pub count: usize,
+}
+
+impl MaterialEntry {
+    fn recreate_buffer(&mut self, device: &wgpu::Device, num_items: usize) {
+        let alignment = self.alignment;
+        let required_size = alignment * num_items as wgpu::BufferAddress;
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Item Matrices Buffer"),
+            size: required_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+            mapped_at_creation: false,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Lighting Material Bind Group"),
+            layout: &self.bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &uniform_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(size_of::<BasicMaterialUniforms>() as _),
+                }),
+            }],
+        });
+        self.uniform_buffer = uniform_buffer;
+        self.bind_group = bind_group;
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct LightingMeshRenderer {
     target_format: wgpu::TextureFormat,
@@ -130,8 +179,8 @@ pub struct LightingMeshRenderer {
     infinite_light_buffer: wgpu::Buffer,
     // Mesh items to render
     mesh_items: Vec<Arc<RenderItem>>,
-    //
-    pipelines: HashMap<String, wgpu::RenderPipeline>,
+    // Material entries
+    materials: HashMap<String, MaterialEntry>,
 }
 
 fn create_local_uniform_buffer(device: &wgpu::Device, num_items: usize) -> wgpu::Buffer {
@@ -180,7 +229,7 @@ impl LightingMeshRenderer {
     ) {
         self.prepare_global(device, queue, world_to_camera, camera_to_clip);
         self.prepare_lights(device, queue, render_items);
-        self.prepare_local(device, queue, render_items);
+        self.prepare_local_and_mateials(device, queue, render_items);
     }
 
     pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
@@ -197,18 +246,25 @@ impl LightingMeshRenderer {
                 alignment,
             )
         };
-        let pipeline = self
-            .pipelines
-            .get(TEST_PIPELINE_ID)
+
+        let material_entry = self
+            .materials
+            .get(BASIC_MATERIAL_ENTRY_ID)
             .expect("Pipeline for basic material not found");
-        render_pass.set_pipeline(pipeline); //
+        render_pass.set_pipeline(&material_entry.pipeline); //
         render_pass.set_bind_group(0, &self.global_bind_group, &[]);
         render_pass.set_bind_group(2, &self.light_bind_group, &[]);
         for (i, item) in render_items.iter().enumerate() {
             let i = i as wgpu::DynamicOffset;
             if let RenderItem::Mesh(mesh_item) = item.as_ref() {
                 let local_uniform_offset = i * local_uniform_alignment as wgpu::DynamicOffset;
+                let material_uniform_offset = i * material_entry.alignment as wgpu::DynamicOffset;
                 render_pass.set_bind_group(1, &self.local_bind_group, &[local_uniform_offset]);
+                render_pass.set_bind_group(
+                    3,
+                    &material_entry.bind_group,
+                    &[material_uniform_offset],
+                );
                 render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
                 render_pass.set_index_buffer(
                     mesh_item.mesh.index_buffer.slice(..),
@@ -242,7 +298,7 @@ impl LightingMeshRenderer {
         );
     }
 
-    pub fn prepare_local(
+    pub fn prepare_local_and_mateials(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -283,14 +339,10 @@ impl LightingMeshRenderer {
         for (i, item) in mesh_items.iter().enumerate() {
             let local_to_world = item.get_matrix();
             let world_to_local = local_to_world.inverse();
-            let base_color = get_base_color(item);
             let uniform = LocalUniforms {
                 local_to_world: local_to_world.to_cols_array_2d(),
                 world_to_local: world_to_local.to_cols_array_2d(),
-                base_color: base_color,
-                _pad1: [0.0; 4],
-                _pad2: [0.0; 4],
-                _pad3: [0.0; 4],
+                ..Default::default()
             };
             let offset = i as wgpu::BufferAddress * local_uniform_alignment;
             queue.write_buffer(
@@ -299,15 +351,39 @@ impl LightingMeshRenderer {
                 bytemuck::bytes_of(&uniform),
             );
         }
-        //for (i, item) in mesh_items.iter().enumerate() {
-        //
-        //}
+
         {
-            if !self.pipelines.contains_key(TEST_PIPELINE_ID) {
-                self.pipelines.insert(
-                    TEST_PIPELINE_ID.to_string(),
-                    self.create_pipeline(device, TEST_PIPELINE_ID),
+            let uniform_alignment = {
+                let alignment =
+                    device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+                align_to(
+                    std::mem::size_of::<BasicMaterialUniforms>() as wgpu::BufferAddress,
+                    alignment,
+                )
+            };
+            let num_items = mesh_items.len();
+            if !self.materials.contains_key(BASIC_MATERIAL_ENTRY_ID) {
+                self.materials.insert(
+                    BASIC_MATERIAL_ENTRY_ID.to_string(),
+                    self.create_material_entry(device, BASIC_MATERIAL_ENTRY_ID, num_items),
                 );
+            }
+            let entry = self
+                .materials
+                .get_mut(BASIC_MATERIAL_ENTRY_ID)
+                .expect("Pipeline for basic material not found");
+            if entry.count < num_items {
+                entry.recreate_buffer(device, num_items);
+            }
+            for (i, item) in mesh_items.iter().enumerate() {
+                let base_color = get_base_color(item);
+                let uniform = BasicMaterialUniforms {
+                    kd: base_color,
+                    ks: [1.0, 1.0, 1.0, 0.0], //todo
+                    ..Default::default()
+                };
+                let offset = i as wgpu::BufferAddress * uniform_alignment;
+                queue.write_buffer(&entry.uniform_buffer, offset, bytemuck::bytes_of(&uniform));
             }
         }
 
@@ -533,18 +609,12 @@ impl LightingMeshRenderer {
         );
     }
 
-    pub fn create_pipeline(
+    fn create_material_entry(
         &self,
         device: &wgpu::Device,
         _material_id: &str,
-    ) -> wgpu::RenderPipeline {
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Lighting Shader"),
-            source: wgpu::ShaderSource::Wgsl(
-                include_str!("shaders/render_lighting_mesh.wgsl").into(),
-            ),
-        });
-
+        num_items: usize,
+    ) -> MaterialEntry {
         let vertex_buffer_layout = [wgpu::VertexBufferLayout {
             array_stride: size_of::<RenderVertex>() as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
@@ -572,12 +642,37 @@ impl LightingMeshRenderer {
             ],
         }];
 
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Lighting Shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("shaders/render_lighting_mesh.wgsl").into(),
+            ),
+        });
+
+        let bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Material Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(
+                            size_of::<BasicMaterialUniforms>() as _
+                        ),
+                    },
+                    count: None,
+                }],
+            });
+
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Lighting Pipeline Layout"),
             bind_group_layouts: &[
                 &self.global_bind_group_layout,
                 &self.local_bind_group_layout,
                 &self.light_bind_group_layout,
+                &bind_group_layout,
             ],
             push_constant_ranges: &[],
         });
@@ -627,7 +722,46 @@ impl LightingMeshRenderer {
             multiview: None,
             cache: None,
         });
-        return pipeline;
+
+        // Create a uniform buffer for material properties
+        let alignment = {
+            let alignment =
+                device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+            align_to(
+                std::mem::size_of::<BasicMaterialUniforms>() as wgpu::BufferAddress,
+                alignment,
+            )
+        };
+        let required_size = alignment * num_items as wgpu::BufferAddress;
+        let uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Item Matrices Buffer"),
+            size: required_size,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+            mapped_at_creation: false,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Lighting Local Bind Group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &uniform_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(size_of::<BasicMaterialUniforms>() as _),
+                }),
+            }],
+        });
+
+        let entry = MaterialEntry {
+            pipeline: pipeline,
+            bind_group_layout,
+            bind_group,
+            uniform_buffer,
+            alignment,
+            count: num_items,
+        };
+        return entry;
     }
 }
 
@@ -862,7 +996,7 @@ impl LightingMeshRenderer {
             device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
 
         let mesh_items = Vec::with_capacity(MIN_LOCAL_BUFFER_NUM);
-        let pipelines = HashMap::new();
+        let materials = HashMap::new();
         let mut pass = LightingMeshRenderer {
             target_format,
             min_uniform_buffer_offset_alignment,
@@ -881,17 +1015,21 @@ impl LightingMeshRenderer {
             rect_light_buffer,
             infinite_light_buffer,
             mesh_items,
-            pipelines,
+            materials,
         };
         pass.init(device);
         return pass;
     }
 
     pub fn init(&mut self, device: &wgpu::Device) {
-        if self.pipelines.is_empty() {
-            self.pipelines.insert(
-                TEST_PIPELINE_ID.to_string(),
-                self.create_pipeline(device, TEST_PIPELINE_ID),
+        if self.materials.is_empty() {
+            self.materials.insert(
+                BASIC_MATERIAL_ENTRY_ID.to_string(),
+                self.create_material_entry(
+                    device,
+                    BASIC_MATERIAL_ENTRY_ID,
+                    MIN_MATERIAL_BUFFER_NUM,
+                ),
             );
         }
     }

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -375,11 +375,12 @@ impl LightingMeshRenderer {
             if entry.count < num_items {
                 entry.recreate_buffer(device, num_items);
             }
+            let ks = 0.1;
             for (i, item) in mesh_items.iter().enumerate() {
                 let base_color = get_base_color(item);
                 let uniform = BasicMaterialUniforms {
                     kd: base_color,
-                    ks: [1.0, 1.0, 1.0, 0.0], //todo
+                    ks: [ks, ks, ks, 0.0],
                     ..Default::default()
                 };
                 let offset = i as wgpu::BufferAddress * uniform_alignment;

--- a/src/render/wgpu/material.rs
+++ b/src/render/wgpu/material.rs
@@ -1,5 +1,15 @@
 use uuid::Uuid;
 
+#[repr(u32)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RenderCategory {
+    #[default]
+    Opaque = 1000, //use for opaque surfaces
+    Emissive = 1500,    //use for light diffuse no lighting
+    Masked = 2500,      //use for masked surfaces
+    Transparent = 3000, //use for transparent surfaces
+}
+
 #[derive(Debug, Clone)]
 pub enum RenderUniformValue {
     Float(f32),
@@ -9,10 +19,11 @@ pub enum RenderUniformValue {
     Bool(bool),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct RenderMaterial {
     pub id: Uuid,
     pub edition: String,
+    pub render_type: RenderCategory,
     pub uniform_values: Vec<(String, RenderUniformValue)>, //key, value
 }
 

--- a/src/render/wgpu/render_gizmo_item.rs
+++ b/src/render/wgpu/render_gizmo_item.rs
@@ -1,4 +1,5 @@
 use super::lines::RenderLines;
+use super::material::RenderCategory;
 use super::material::RenderMaterial;
 use super::material::RenderUniformValue;
 use super::render_item::LinesRenderItem;
@@ -35,7 +36,9 @@ fn get_lines_material(
     let render_material = RenderMaterial {
         id: id,
         edition: edition.to_string(),
+        render_type: RenderCategory::Opaque,
         uniform_values,
+
     };
     let render_material = Arc::new(render_material);
     render_resource_manager.add_material(&render_material);

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -669,7 +669,7 @@ fn get_infinite_light_item(
         let l = get_color(&props, "L", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
         let scale = get_color(&props, "scale", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
 
-        let p = 1.0 / std::f32::consts::PI; // Point light power normalization
+        let p = 1.0; // / std::f32::consts::PI; // Point light power normalization
         let intensity = [
             p * l[0] * scale[0],
             p * l[1] * scale[1],

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -182,7 +182,8 @@ fn get_point_light_item(
         let l = get_color(&props, "I", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
         let scale = get_color(&props, "scale", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
 
-        let intensity = [l[0] * scale[0], l[1] * scale[1], l[2] * scale[2]];
+        let p = 4.0;//std::f32::consts::PI;//1.0 / (4.0 * std::f32::consts::PI); // Point light power normalization
+        let intensity = [p * l[0] * scale[0], p * l[1] * scale[1], p * l[2] * scale[2]];
 
         let render_light = SphereRenderLight {
             id,
@@ -268,7 +269,7 @@ fn get_spot_light_item(
         let l = get_color(&props, "I", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
         let scale = get_color(&props, "scale", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
 
-        let p = 1.0 / std::f32::consts::PI; // Point light power normalization
+        let p = 1.0;// / std::f32::consts::PI; // Point light power normalization
         let intensity = [
             p * l[0] * scale[0],
             p * l[1] * scale[1],
@@ -345,7 +346,7 @@ fn get_sphere_light_item(
         //std::f32::consts::PI * radius * (zmax - zmin) // Area of the sphere segment
         2.0 * std::f32::consts::PI * radius // Area of the sphere
     } else {
-        1.0 // Default area if radius is not specified
+        4.0 // Default area if radius is not specified
     };
 
     let props = light.as_property_map();
@@ -712,6 +713,7 @@ fn get_lines_material(
         id: id,
         edition: edition.to_string(),
         uniform_values,
+        ..Default::default()
     };
     let render_material = Arc::new(render_material);
     render_resource_manager.add_material(&render_material);

--- a/src/render/wgpu/render_mesh_item.rs
+++ b/src/render/wgpu/render_mesh_item.rs
@@ -1,4 +1,5 @@
 use super::material::RenderMaterial;
+use super::material::RenderCategory;
 use super::material::RenderUniformValue;
 use super::mesh::RenderMesh;
 use super::render_item::MeshRenderItem;
@@ -96,6 +97,7 @@ fn create_surface_material(
             let render_material = RenderMaterial {
                 id,
                 edition,
+                render_type: RenderCategory::Opaque, //todo
                 uniform_values,
             };
             return render_material;
@@ -113,6 +115,7 @@ fn create_surface_material(
         let render_material = RenderMaterial {
             id,
             edition,
+            render_type: RenderCategory::Opaque,
             uniform_values,
         };
         return render_material;

--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -144,6 +144,7 @@ fn cos_2_theta(w: vec3<f32>) -> f32 {
 }
 
 fn sin_2_theta(w: vec3<f32>) -> f32 {
+    //return max(0.0, 1.0 - w.z * w.z);
     return w.x * w.x + w.y * w.y;//max(0.0, 1.0 - w.z * w.z);
 }
 
@@ -169,9 +170,10 @@ fn trowbridge_reitz_d(w: vec3<f32>, alpha: f32) -> f32 {
     let cos_2_theta = cos_2_theta(w);
     let cos_4_theta = cos_2_theta * cos_2_theta;
     //let cos_2_phi = cos_2_phi(wh);
-    let e = tan_2_theta / alpha2;
+    let e = tan_2_theta * alpha2;
+    //let e = (cos_2_phi(w) / (alpha2) + sin_2_phi(w) / (alpha2)) * tan_2_theta;
     let e2 = pow(1.0 + e, 2.0);
-    return 1.0 / (PI * alpha2 * cos_4_theta * e2);
+    return clamp(1.0 / (PI * cos_4_theta * e2), 0.0, 1.0);
 }
 
 fn trowbridge_reitz_lambda(w: vec3<f32>, alpha: f32) -> f32 {
@@ -191,16 +193,16 @@ fn micro_facet_reflection(r: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>) -> vec3<f3
     let cos_theta_o = abs(wo.z);
     let cos_theta_i = abs(wi.z);
     var wh = wo + wi;
-    if wh.z < 0.0 {
+    if wh.z <= 0.0 {
         return vec3<f32>(0.0);
     }
     wh = normalize(wh);
-    let roughness = max(0.001, 0.1);//<roughness>
-    let cos_theta_d = max(dot(wh, wi), 0.0);
-    let f = fr_dielectric(cos_theta_i, 1.5, 1.0);
-    let d = trowbridge_reitz_d(wh, roughness) / 12.0;
-    let g = trowbridge_reitz_g(wo, wi, roughness) / 12.0;
-    return r * f * d * g / (4.0 * cos_theta_i * cos_theta_o);
+    let wi_wh = dot(wi, wh);
+    let roughness = max(0.001, 0.2);//<roughness>
+    let f = fr_dielectric(wi_wh, 1.5, 1.0);
+    let d = trowbridge_reitz_d(wh, roughness);
+    let g = trowbridge_reitz_g(wo, wi, roughness);
+    return r * d * g * f;
 }
 
 fn matte(wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
@@ -213,14 +215,14 @@ fn matte(wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
 fn plastic(wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
     let diffuse = max(dot(vec3<f32>(0.0, 0.0, 1.0), wi), 0.0);
     let kd = material_uniforms.kd.rgb;
-    let ks = material_uniforms.ks.rgb * 0.2;
+    let ks = material_uniforms.ks.rgb;
     let c1 = lambertian_reflection(kd);
     let c2 = micro_facet_reflection(ks, wo, wi);
     return diffuse * (c1 + c2);
 }
 
 fn shade(intensity: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
-    return plastic(wo, wi) * intensity;
+    return matte(wo, wi) * intensity;
 }
 //-------------------------------------------------------
 
@@ -375,7 +377,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     {
         let light = infinite_lights[i];
         let intensity = light.intensity.rgb;
-        let r = reflect(normalize(camera_to_surface), normal);
+        let r = reflect(camera_to_surface, normal);
         let wi = tbn * r;
         color += shade(intensity, wo, wi);
     }

--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -8,7 +8,10 @@ struct GlobalUniforms {
 struct LocalUniforms {
     local_to_world: mat4x4<f32>,
     world_to_local: mat4x4<f32>, // inverse of world to camera
-    base_color: vec4<f32>,
+    _pad1: vec4<f32>,
+    _pad2: vec4<f32>,
+    _pad3: vec4<f32>,
+    _pad4: vec4<f32>,
 }
 
 struct LightUniforms {
@@ -98,6 +101,132 @@ var<storage, read> rect_lights: array<RectLight>;
 @binding(5)
 var<storage, read> infinite_lights: array<InfiniteLight>;
 
+//-------------------------------------------------------
+//Material specific definitions
+struct BasicMaterialUniforms {
+    kd: vec4<f32>,
+    ks: vec4<f32>,
+    _pad1: vec4<f32>,
+    _pad2: vec4<f32>,
+}
+
+@group(3)
+@binding(0)
+var<uniform> material_uniforms: BasicMaterialUniforms;
+
+const PI: f32 = 3.14159265359;
+const INV_PI: f32 = 1.0 / 3.14159265359;
+
+fn lambertian_reflection(r: vec3<f32>) -> vec3<f32> {;
+    return r * INV_PI;
+}
+
+fn fr_dielectric_(cos_i: f32, eta_i: f32, eta_t: f32) -> f32 {
+    let cos_theta_i = cos_i;
+    let sin_theta_i = sqrt(max(0.0, 1.0 - cos_theta_i * cos_theta_i));
+    let sin_theta_t = eta_i / eta_t * sin_theta_i;
+    if sin_theta_t >= 1.0 {
+        return 1.0; // Total internal reflection
+    }
+    let cos_theta_t = sqrt(max(0.0, 1.0 - sin_theta_t * sin_theta_t));
+    let rparl = ((eta_t * cos_theta_i) - (eta_i * cos_theta_t)) / ((eta_t * cos_theta_i) + (eta_i * cos_theta_t));
+    let rperp = ((eta_i * cos_theta_i) - (eta_t * cos_theta_t)) / ((eta_i * cos_theta_i) + (eta_t * cos_theta_t));
+    return (rparl * rparl + rperp * rperp) / 2.0;
+}
+
+fn fr_dielectric(cos_i: f32, eta_i: f32, eta_t: f32) -> f32 {
+    let cos_theta_i = clamp(cos_i, -1.0, 1.0);
+    return select(fr_dielectric_(-cos_theta_i, eta_t, eta_i), fr_dielectric_(cos_theta_i, eta_i, eta_t), cos_theta_i >= 0.0);
+}
+
+fn cos_2_theta(w: vec3<f32>) -> f32 {
+    return w.z * w.z;
+}
+
+fn sin_2_theta(w: vec3<f32>) -> f32 {
+    return w.x * w.x + w.y * w.y;//max(0.0, 1.0 - w.z * w.z);
+}
+
+fn tan_2_theta(w: vec3<f32>) -> f32 {
+    return sin_2_theta(w) / cos_2_theta(w);
+}
+
+fn cos_phi(w: vec3<f32>) -> f32 {
+    return w.x / sqrt(w.x * w.x + w.y * w.y);
+}
+
+fn cos_2_phi(w: vec3<f32>) -> f32 {
+    return (w.x * w.x) / (w.x * w.x + w.y * w.y);
+}
+
+fn sin_2_phi(w: vec3<f32>) -> f32 {
+    return (w.y * w.y) / (w.x * w.x + w.y * w.y);
+}
+
+fn trowbridge_reitz_d(w: vec3<f32>, alpha: f32) -> f32 {
+    let alpha2 = alpha * alpha;
+    let tan_2_theta = tan_2_theta(w);//sin_2_theta(w) / cos_2_theta(w)
+    let cos_2_theta = cos_2_theta(w);
+    let cos_4_theta = cos_2_theta * cos_2_theta;
+    //let cos_2_phi = cos_2_phi(wh);
+    let e = tan_2_theta / alpha2;
+    let e2 = pow(1.0 + e, 2.0);
+    return 1.0 / (PI * alpha2 * cos_4_theta * e2);
+}
+
+fn trowbridge_reitz_lambda(w: vec3<f32>, alpha: f32) -> f32 {
+    let alpha2 = alpha * alpha;
+    let tan_2_theta = tan_2_theta(w);
+    let alpha_2_tan_2_theta = alpha2 * tan_2_theta;
+    return (-1.0 + sqrt(1.0 + alpha_2_tan_2_theta)) / 2.0;
+}
+
+fn trowbridge_reitz_g(wo: vec3<f32>, wi: vec3<f32>, alpha: f32) -> f32 {
+    let lambda_o = trowbridge_reitz_lambda(wo, alpha);
+    let lambda_i = trowbridge_reitz_lambda(wi, alpha);
+    return 1.0 / (1.0 + lambda_o + lambda_i);
+}
+
+fn micro_facet_reflection(r: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
+    let cos_theta_o = abs(wo.z);
+    let cos_theta_i = abs(wi.z);
+    var wh = wo + wi;
+    if wh.z < 0.0 {
+        return vec3<f32>(0.0);
+    }
+    wh = normalize(wh);
+    let roughness = max(0.001, 0.1);//<roughness>
+    let cos_theta_d = max(dot(wh, wi), 0.0);
+    let f = fr_dielectric(cos_theta_i, 1.5, 1.0);
+    let d = trowbridge_reitz_d(wh, roughness) / 12.0;
+    let g = trowbridge_reitz_g(wo, wi, roughness) / 12.0;
+    return r * f * d * g / (4.0 * cos_theta_i * cos_theta_o);
+}
+
+fn matte(wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
+    let diffuse = max(dot(vec3<f32>(0.0, 0.0, 1.0), wi), 0.0);
+    let kd = material_uniforms.kd.rgb;
+    let c1 = lambertian_reflection(kd);
+    return diffuse * c1;
+}
+
+fn plastic(wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
+    let diffuse = max(dot(vec3<f32>(0.0, 0.0, 1.0), wi), 0.0);
+    let kd = material_uniforms.kd.rgb;
+    let ks = material_uniforms.ks.rgb * 0.2;
+    let c1 = lambertian_reflection(kd);
+    let c2 = micro_facet_reflection(ks, wo, wi);
+    return diffuse * (c1 + c2);
+}
+
+fn shade(intensity: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
+    return plastic(wo, wi) * intensity;
+}
+//-------------------------------------------------------
+
+
+
+
 struct VertexOut {
     @location(0) w_position: vec3<f32>,
     @location(1) uv: vec2<f32>,
@@ -130,17 +259,6 @@ fn vs_main(
     return out;
 }
 
-fn lambertian_reflection(reflectance: vec3<f32>) -> vec3<f32> {;
-    return reflectance;
-}
-
-fn matte(wi: vec3<f32>, wo: vec3<f32>) -> vec3<f32> {
-    // This is a placeholder for a more complex matte reflection model
-    let diffuse = max(dot(vec3<f32>(0.0, 0.0, 1.0), wi), 0.0);
-    let reflectance = local_uniforms.base_color.rgb;
-    return diffuse * lambertian_reflection(reflectance);
-}
-
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     let camera_to_surface = normalize(in.w_position - global_uniforms.camera_position.xyz);
@@ -159,7 +277,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let light = directional_lights[i];
         let intensity = light.intensity.rgb;
         var wi = tbn * -normalize(light.direction.xyz);
-        color += matte(wi, wo) * intensity;
+        color += shade(intensity, wo, wi);
     }
     for (var i: u32 = 0; i < light_uniforms.num_sphere_lights; i++) {
         let light = sphere_lights[i];
@@ -178,7 +296,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let distance = length(light_to_surface);
         let attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
-        color += matte(wi, wo) * intensity * attenuation;
+        color += shade(intensity * attenuation, wo, wi);
     }
     for (var i: u32 = 0; i < light_uniforms.num_disk_lights; i++) {
         let light = disk_lights[i];
@@ -218,7 +336,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let distance = length(light_to_surface);
         var attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
-        color += matte(wi, wo) * intensity * attenuation * falloff;
+        color += shade(intensity * attenuation * falloff, wo, wi);
     }
 
     for (var i: u32 = 0; i < light_uniforms.num_rect_lights; i++) 
@@ -250,7 +368,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let distance = length(light_to_surface);
         var attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
-        color += matte(wi, wo) * intensity * attenuation * falloff;
+        color += shade(intensity * attenuation * falloff, wo, wi);
     }
 
     for (var i: u32 = 0; i < light_uniforms.num_infinite_lights; i++) 
@@ -259,22 +377,8 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let intensity = light.intensity.rgb;
         let r = reflect(normalize(camera_to_surface), normal);
         let wi = tbn * r;
-        color += matte(wi, wo) * intensity;
+        color += shade(intensity, wo, wi);
     }
 
     return vec4<f32>(color, 1.0);
 }
-
-/*
-let a0 = cos(light.inner_angle);
-let a1 = cos(light.outer_angle);
-var light_to_surface = in.w_position - light.position.xyz;
-var distance = length(light_to_surface);
-light_to_surface = normalize(light_to_surface);
-let cos_theta = max(dot(light_to_surface, direction), 0.0);
-var falloff = select(step(a1, cos_theta), pow(clamp((cos_theta - a1) / (a0 - a1), 0.0, 1.0), 4.0), (a0 - a1) > 0.0);//select(FALSE, TRUE, condition)
-let attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
-var wi = tbn * -light_to_surface;
-color += matte(wi, wo) * intensity * attenuation * falloff;
-
-*/


### PR DESCRIPTION
This pull request introduces two major improvements: a new FPS counter for the scene view panel and a refactor of the lighting mesh renderer to support per-material uniform buffers and material management. Additionally, it adds a `RenderCategory` to materials for better categorization. These changes improve rendering diagnostics and lay the foundation for more flexible material handling in the rendering pipeline.

#### Rendering diagnostics

* Added a new `FpsCounter` utility (`src/panel/views/render/fps_counter.rs`) and integrated it into `SceneView` to display the current FPS in the UI, aiding performance monitoring. [[1]](diffhunk://#diff-360cfb15347f2b5c1d20a90f05e09836372317e5f2d05699200ceb833c24eee0R1-R32) [[2]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029R1) [[3]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029R63) [[4]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029R75) [[5]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029R196-R208) [[6]](diffhunk://#diff-a44cec8582eb9c0a6fc67cc55335f9915ebd138e23c6c21f81de941ac3d25979R1)

#### Material management and renderer refactor

* Refactored `LightingMeshRenderer` to use a new `MaterialEntry` structure, enabling dynamic per-material uniform buffers and bind groups, replacing the previous pipeline-only approach. This supports future extensibility for multiple materials. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L133-R183) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R110-R156) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L200-R267) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L302-R388) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L536-R618) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L630-R765) [[7]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L884-R1033) [[8]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L865-R1000)
* Added `BasicMaterialUniforms` struct and logic to write per-mesh material data to GPU buffers, enabling per-object material customization in the render pass. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R110-R156) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L302-R388)
* Replaced the legacy pipeline management with a material-centric approach, including buffer alignment and resizing logic for material uniform buffers. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L133-R183) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L302-R388) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L536-R618) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L630-R765) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L884-R1033) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L865-R1000)

#### Material type and usage

* Introduced the `RenderCategory` enum to categorize materials (opaque, emissive, masked, transparent) and integrated it into `RenderMaterial` for improved material handling and future rendering logic. [[1]](diffhunk://#diff-eff909b7434cc5a627cc038db26b311b60075a4fcf4139d788dc6ce42fd04f7dR3-R12) [[2]](diffhunk://#diff-eff909b7434cc5a627cc038db26b311b60075a4fcf4139d788dc6ce42fd04f7dL12-R26) [[3]](diffhunk://#diff-301987b684703c74f077299f943386142f43a5696e193ab5d7131c6052dbc241R2) [[4]](diffhunk://#diff-301987b684703c74f077299f943386142f43a5696e193ab5d7131c6052dbc241R39-R41)

#### Code cleanup

* Removed unused fields and padding from `LocalUniforms`, centralizing color data in material uniforms for cleaner code and separation of concerns. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L39-R44) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L286-R345)