### PR TITLE
Update Rect Light

### DIFF
--- a/src/conversion/plane_data/rect.rs
+++ b/src/conversion/plane_data/rect.rs
@@ -67,16 +67,16 @@ pub fn create_plane_rect_from_plane_outline(
             let v1 = positions[(i + 1) % vn];
             let v2 = positions[(i + 2) % vn];
             let edge1 = v1 - v0;
-            let edge2 = v2 - v1;
+            let edge2 = v2 - v0;
             normal += Vector3::cross(&edge1, &edge2);
         }
         normal = normal.normalize();
-        let edge0 = positions[1] - positions[0];
-        let edge1 = positions[2] - positions[1];
-        let edge2 = positions[3] - positions[2];
-        let edge3 = positions[0] - positions[3];
-        let u_dir = (edge0 - edge2) * 0.5;
-        let v_dir = (edge1 - edge3) * 0.5;
+        let edge0 = positions[1] - positions[0]; //v
+        let edge1 = positions[2] - positions[1]; //u
+        let edge2 = positions[3] - positions[2]; //-v
+        let edge3 = positions[0] - positions[3]; //-u
+        let v_dir = (edge0 - edge2) * 0.5;
+        let u_dir = (edge1 - edge3) * 0.5;
         let u_axis = u_dir * 0.5;
         let v_axis = v_dir * 0.5;
         let rect = PlaneRect {

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -36,8 +36,10 @@ pub struct RectRenderLight {
     pub edition: String,
     pub position: [f32; 3],
     pub direction: [f32; 3],
-    pub u_axis: [f32; 3],    // U axis for rectangle
-    pub v_axis: [f32; 3],    // V axis for rectangle
+    pub a: [f32; 3],         //left top
+    pub b: [f32; 3],         //left bottom
+    pub c: [f32; 3],         //right bottom
+    pub d: [f32; 3],         //right top
     pub intensity: [f32; 3], // RGB intensity
 }
 

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -92,8 +92,10 @@ struct DiskLight {
 struct RectLight {
     position: [f32; 4],  // Position of the light // 4 * 4 = 16
     direction: [f32; 4], // Direction of the light // 4 * 4 = 16
-    u_axis: [f32; 4],    // U axis for rectangle // 4 * 4 = 16
-    v_axis: [f32; 4],    // V axis for rectangle // 4 * 4 = 16
+    a: [f32; 4],         //left top
+    b: [f32; 4],         //left bottom
+    c: [f32; 4],         //right bottom
+    d: [f32; 4],         //right top
     intensity: [f32; 4], // Intensity of the light // 4 * 4 = 16
 }
 
@@ -533,18 +535,22 @@ impl LightingMeshRenderer {
                             direction[1],
                             direction[2],
                         ));
-                        let u_axis = rect.u_axis;
-                        let u_axis =
-                            matrix.transform_vector3(glam::vec3(u_axis[0], u_axis[1], u_axis[2]));
-                        let v_axis = rect.v_axis;
-                        let v_axis =
-                            matrix.transform_vector3(glam::vec3(v_axis[0], v_axis[1], v_axis[2]));
+                        let a =
+                            matrix.transform_point3(glam::vec3(rect.a[0], rect.a[1], rect.a[2]));
+                        let b =
+                            matrix.transform_point3(glam::vec3(rect.b[0], rect.b[1], rect.b[2]));
+                        let c =
+                            matrix.transform_point3(glam::vec3(rect.b[0], rect.b[1], rect.b[2]));
+                        let d =
+                            matrix.transform_point3(glam::vec3(rect.d[0], rect.d[1], rect.d[2]));
                         let intensity = rect.intensity;
                         let light = RectLight {
                             position: [position.x, position.y, position.z, 1.0],
                             direction: [direction.x, direction.y, direction.z, 0.0],
-                            u_axis: [u_axis.x, u_axis.y, u_axis.z, 0.0],
-                            v_axis: [v_axis.x, v_axis.y, v_axis.z, 0.0],
+                            a: [a.x, a.y, a.z, 1.0],
+                            b: [b.x, b.y, b.z, 1.0],
+                            c: [c.x, c.y, c.z, 1.0],
+                            d: [d.x, d.y, d.z, 1.0],
                             intensity: [intensity[0], intensity[1], intensity[2], 1.0],
                         };
                         light_buffer.push(light);

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -517,6 +517,18 @@ fn get_rects_light_item(
                     let u_axis = rect.u_axis;
                     let v_axis = rect.v_axis;
 
+                    let p = Vector3::new(position[0], position[1], position[2]);
+                    let u = Vector3::new(u_axis[0], u_axis[1], u_axis[2]);
+                    let v = Vector3::new(v_axis[0], v_axis[1], v_axis[2]);
+                    let a = p - u - v;
+                    let b = p - u + v;
+                    let c = p + u + v;
+                    let d = p + u - v;
+                    let a = [a.x, a.y, a.z];
+                    let b = [b.x, b.y, b.z];
+                    let c = [c.x, c.y, c.z];
+                    let d = [d.x, d.y, d.z];
+
                     //let area = 1.0; //todo: get area from rect
                     let area = 4.0
                         * Vector3::cross(
@@ -536,8 +548,10 @@ fn get_rects_light_item(
                         edition: edition.clone(),
                         position,
                         direction,
-                        u_axis,
-                        v_axis,
+                        a,
+                        b,
+                        c,
+                        d,
                         intensity,
                     };
                     Arc::new(RenderLight::Rect(light))

--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -53,8 +53,10 @@ struct DiskLight {
 struct RectLight {
     position: vec4<f32>, // Position in world space
     direction: vec4<f32>, // Direction of the spotlight
-    u_axis: vec4<f32>,    // U axis for rectangle // 4 * 4 = 16
-    v_axis: vec4<f32>,    // V axis for rectangle // 4 * 4 = 16
+    a: vec4<f32>,         //left top
+    b: vec4<f32>,         //left bottom
+    c: vec4<f32>,         //right bottom
+    d: vec4<f32>,         //right top
     intensity: vec4<f32>, // Light intensity
 }
 
@@ -236,53 +238,27 @@ fn shade(intensity: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>) -> vec3<f32> {
 }
 //-------------------------------------------------------
 
-fn test_in_triangle(a: vec3<f32>, b: vec3<f32>, c: vec3<f32>, p: vec3<f32>) -> bool {
-    let n1 = normalize(cross(b - a, p - b));
-    let n2 = normalize(cross(c - b, p - c));
-    let n3 = normalize(cross(a - c, p - a));
-    let d0 = dot(n1, n2);
-    let d1 = dot(n2, n3);
-    if d0 > 0.99 && d1 > 0.99 {
-        return true;
-    } else {
-        return false;
-    }
-}
-
 fn closest_point_on_line_segment(a: vec3<f32>, b: vec3<f32>, p: vec3<f32>) -> vec3<f32> {
     let ab = b - a;
     let t = dot(p - a, ab) / dot(ab, ab);
     return a + saturate(t) * ab;
 }
 
-fn closest_point_on_rectangle(a: vec3<f32>, b: vec3<f32>, c: vec3<f32>, d: vec3<f32>, p: vec3<f32>) -> vec3<f32> {
-    if !test_in_triangle(a, b, c, p) && !test_in_triangle(a, c, d, p) {
-        let p1 = closest_point_on_line_segment(a, b, p);
-        let p2 = closest_point_on_line_segment(b, c, p);
-        let p3 = closest_point_on_line_segment(c, d, p);
-        let p4 = closest_point_on_line_segment(d, a, p);
-        let t1 = length(p - p1);
-        let t2 = length(p - p2);
-        let t3 = length(p - p3);
-        let t4 = length(p - p4);
-        var t = t1;
-        var closest_point = p1;
-        if t2 < t {
-            t = t2;
-            closest_point = p2;
-        }
-        if t3 < t {
-            t = t3;
-            closest_point = p3;
-        }
-        if t4 < t {
-            t = t4;
-            closest_point = p4;
-        }
-        return closest_point;
-    } else {
-        return p;
-    }
+fn test_in_half_space(a: vec3<f32>, b: vec3<f32>, p: vec3<f32>, n: vec3<f32>) -> bool {
+    let ab = b - a;
+    let ap = p - a;
+    let cross_product = cross(ab, ap);
+    let dot_product = dot(cross_product, n);
+    return dot_product >= 0.0;
+}
+
+fn closest_point_on_rectangle(a: vec3<f32>, b: vec3<f32>, c: vec3<f32>, d: vec3<f32>, p: vec3<f32>, n: vec3<f32>) -> vec3<f32> {
+    var closest_point = p;
+    closest_point = select(closest_point_on_line_segment(a, b, p), closest_point, test_in_half_space(a, b, p, n));
+    closest_point = select(closest_point_on_line_segment(b, c, p), closest_point, test_in_half_space(b, c, p, n));
+    closest_point = select(closest_point_on_line_segment(c, d, p), closest_point, test_in_half_space(c, d, p, n));
+    closest_point = select(closest_point_on_line_segment(d, a, p), closest_point, test_in_half_space(d, a, p, n));
+    return closest_point;
 }
 
 struct VertexOut {
@@ -425,12 +401,12 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         |    |
         b----c
          */
-        let a = position - light.u_axis.xyz - light.v_axis.xyz;
-        let b = position - light.u_axis.xyz + light.v_axis.xyz;
-        let c = position + light.u_axis.xyz + light.v_axis.xyz;
-        let d = position + light.u_axis.xyz - light.v_axis.xyz;
+        let a = light.a.xyz;
+        let b = light.b.xyz;
+        let c = light.c.xyz;
+        let d = light.d.xyz;
         // Find the closest point on the rectangle
-        var closest_point = closest_point_on_rectangle(a, b, c, d, p);
+        var closest_point = closest_point_on_rectangle(a, b, c, d, p, direction);
         let light_to_surface = in.w_position - closest_point;
         let cos_theta = max(dot(normalize(light_to_surface), direction), 0.0);
         let falloff = cos_theta;


### PR DESCRIPTION
This pull request refactors the representation and handling of rectangular lights in the rendering pipeline. Instead of using the previous `u_axis` and `v_axis` vectors to define the rectangle, the code now explicitly stores the four corner positions (`a`, `b`, `c`, `d`). This change affects the data structures, transformation logic, and shader code, and also revises the geometric calculations for closest-point queries on rectangles.

**Rectangular light data structure changes:**

* Replaced `u_axis` and `v_axis` fields with explicit corner positions `a`, `b`, `c`, and `d` in `RectRenderLight`, `RectLight` structs, and shader definitions (`rect.rs`, `light.rs`, `lighting_mesh_renderer.rs`, `render_light_item.rs`, `render_lighting_mesh.wgsl`). [[1]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cL39-R42) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L95-R98) [[3]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L56-R59)

**Transformation and light creation logic:**

* Updated transformation logic to compute and transform rectangle corners instead of axes, and to populate the new fields when creating `RectLight` instances (`lighting_mesh_renderer.rs`, `render_light_item.rs`). [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L536-R553) [[2]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cR520-R531) [[3]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cL539-R554)

**Shader geometric calculations:**

* Refactored the closest-point-on-rectangle logic in the shader, replacing triangle-based checks with half-space tests and updating function signatures to use the new corner representation (`render_lighting_mesh.wgsl`).

**Shader usage of rectangle corners:**

* Changed shader code to use the explicit rectangle corners for lighting calculations instead of reconstructing them from axes (`render_lighting_mesh.wgsl`).

**Plane conversion logic:**

* Adjusted the computation of `u_dir` and `v_dir` in `create_plane_rect_from_plane_outline` to clarify axis directions and support the new rectangle representation (`rect.rs`).