### PR TITLE
Fix Light Attenuation

### DIFF
--- a/src/render/wgpu/shaders/render_lighting_mesh.wgsl
+++ b/src/render/wgpu/shaders/render_lighting_mesh.wgsl
@@ -340,7 +340,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
             light_to_surface = in.w_position - closest_point;
         }
         let distance = length(light_to_surface);
-        let attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
+        let attenuation = 1.0 / pow(1.0 + distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
         color += shade(intensity * attenuation, wo, wi);
     }
@@ -380,7 +380,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
             falloff = pow(falloff, 4.0);
         }
         let distance = length(light_to_surface);
-        var attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
+        var attenuation = 1.0 / pow(1.0 + distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
         color += shade(intensity * attenuation * falloff, wo, wi);
     }
@@ -424,7 +424,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let falloff = cos_theta;//pow(cos_theta, 1.0);
 
         let distance = length(light_to_surface);
-        var attenuation = 1.0 / pow(distance, 2.0); // Simple quadratic attenuation
+        var attenuation = 1.0 / pow(1.0 + distance, 2.0); // Simple quadratic attenuation
         var wi = tbn * -normalize(light_to_surface);
         color += shade(intensity * attenuation * falloff, wo, wi);
     }


### PR DESCRIPTION
This pull request updates the attenuation calculation for lighting in the `render_lighting_mesh.wgsl` shader. The main change is to modify the attenuation formula to include a constant offset, which helps prevent excessively high intensity when the light source is very close to the surface.

Lighting attenuation improvements:

* Updated the attenuation calculation in three places to use `1.0 / pow(1.0 + distance, 2.0)` instead of `1.0 / pow(distance, 2.0)` to avoid singularity and improve visual results for close light sources. (`src/render/wgpu/shaders/render_lighting_mesh.wgsl`, [[1]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L343-R343) [[2]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L383-R383) [[3]](diffhunk://#diff-764b7ad2f24506079a0dc0f4aa4b5b55874ec852232bcf15d4edd5425163d697L427-R427)