### PR TITLE
Use f16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,13 +1826,15 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2922,6 +2924,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "glam",
+ "half",
  "image",
  "log",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bytemuck = "1.23.1"
 glam = { version = "0.30.4", features = ["bytemuck", "serde"] }
 wgpu-types = "26.0.0"
 rust-embed = {version = "8.9.0", features = ["include-exclude"]}
+half = { version = "2.7.1", features = ["bytemuck"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wgpu = { version = "25.0.2", default-features = true, features = ["vulkan"] }

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -451,10 +451,10 @@ pub fn create_render_pass(
         render_resource_manager,
     );
     let (_uniform_values_types, uniform_values_bytes) = create_uniform_value_bytes(uniform_values);
-    println!(
-        "Create Render Pass: shader_type={}, uniform_values={:?}",
-        shader_type, uniform_values
-    );
+    //println!(
+    //    "Create Render Pass: shader_type={}, uniform_values={:?}",
+    //    shader_type, uniform_values
+    //);
 
     let mut textures = vec![];
     for (_name, value) in uniform_values.iter() {
@@ -503,6 +503,14 @@ fn get_image_data(image: &DynaImage) -> image::Rgba32FImage {
     return image.to_rgba32f();
 }
 
+fn convert_to_f16(data: &[f32]) -> Vec<half::f16> {
+    let mut f16_data = Vec::with_capacity(data.len());
+    for &value in data.iter() {
+        f16_data.push(half::f16::from_f32(value));
+    }
+    return f16_data;
+}
+
 fn get_texture_from_image(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
@@ -520,19 +528,19 @@ fn get_texture_from_image(
         mip_level_count: 1,
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::Rgba32Float,
+        format: wgpu::TextureFormat::Rgba16Float,
         usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
     });
     // y-flip
     let image = image::imageops::flip_vertical(image);
-    let image_raw = image.as_raw();
+    let image_raw = convert_to_f16(image.as_raw());
     queue.write_texture(
         texture.as_image_copy(),
-        bytemuck::cast_slice(image_raw),
+        bytemuck::cast_slice(&image_raw),
         wgpu::TexelCopyBufferLayout {
             offset: 0,
-            bytes_per_row: Some(4 * 4 * dimensions.0),
+            bytes_per_row: Some(2 * 4 * dimensions.0),
             rows_per_image: None,
         },
         size,


### PR DESCRIPTION
This pull request updates the texture handling logic in the rendering pipeline to use half-precision floating point formats for image textures, which can improve performance and reduce memory usage. It also introduces a helper function for converting image data to half-precision and removes some debug logging.

**Texture format and data conversion improvements:**

* Changed the texture format in `get_texture_from_image` from `Rgba32Float` to `Rgba16Float`, and updated the byte layout to match the new format. This reduces memory usage and may improve performance on supported hardware.
* Added a new helper function `convert_to_f16` to convert image data from `f32` to `half::f16` before uploading to the GPU.
* Updated the texture upload logic to use the converted half-precision data and adjusted the `bytes_per_row` calculation accordingly.

**Dependency changes:**

* Added the `half` crate (with `bytemuck` feature) to `Cargo.toml` to support half-precision float conversions.

**Code cleanup:**

* Commented out a debug `println!` statement in `create_render_pass` to reduce console noise.