### PR TITLE
Feature/bump

### DIFF
--- a/src/conversion/texture_node/create_image_variants.rs
+++ b/src/conversion/texture_node/create_image_variants.rs
@@ -3,7 +3,7 @@ use image::DynamicImage;
 
 use super::render_texture_image::render_texture_image;
 use super::texture_node::TextureNode;
-use super::texture_node::TexturePurpose;
+use super::texture_node::TextureSizeType;
 use crate::model::scene::ResourceCacheManager;
 use crate::model::scene::ResourceManager;
 
@@ -12,8 +12,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-fn is_no_variant(node: &TextureNode, purpose: TexturePurpose) -> bool {
-    return node.image_variants.get(&purpose).is_none();
+fn is_no_variant(node: &TextureNode, size_type: TextureSizeType) -> bool {
+    return node.image_variants.get(&size_type).is_none();
 }
 
 fn sort_texture_nodes_by_dependency(
@@ -60,61 +60,14 @@ fn sort_texture_nodes_by_dependency(
     return ordered_nodes;
 }
 
-fn linear_to_srgb(value: f32) -> u8 {
-    if value <= 0.0031308 {
-        (value * 12.92 * 255.0).round() as u8
-    } else {
-        ((1.055 * value.powf(1.0 / 2.4) - 0.055) * 255.0).round() as u8
-    }
-}
-
-fn convert_float_to_u8(image: &image::Rgb32FImage) -> image::RgbImage {
-    let (width, height) = image.dimensions();
-    let mut u8_image = image::RgbImage::new(width, height);
-    for (x, y, pixel) in image.enumerate_pixels() {
-        let r = linear_to_srgb(pixel[0].clamp(0.0, 1.0));
-        let g = linear_to_srgb(pixel[1].clamp(0.0, 1.0));
-        let b = linear_to_srgb(pixel[2].clamp(0.0, 1.0));
-        u8_image.put_pixel(x, y, image::Rgb([r, g, b]));
-    }
-    u8_image
-}
-
-fn convert_to_srgb_u8_image(image: &DynamicImage) -> image::RgbImage {
-    match image {
-        DynamicImage::ImageRgb8(img) => img.clone(),
-        DynamicImage::ImageRgba8(_img) => {
-            let rgb_image = image.to_rgb8();
-            return rgb_image;
-        }
-        DynamicImage::ImageRgb32F(img) => {
-            let rgb_image = convert_float_to_u8(img);
-            return rgb_image;
-        }
-        DynamicImage::ImageRgba32F(_img) => {
-            let img = image.to_rgb32f();
-            let rgb_image = convert_float_to_u8(&img);
-            return rgb_image;
-        }
-        DynamicImage::ImageLuma16(_img) => {
-            let rgb_image = image.to_rgb8();
-            return rgb_image;
-        }
-        _ => {
-            let rgb_image = image.to_rgb8();
-            return rgb_image;
-        }
-    }
-}
-
 fn create_image_variants_for_nodes(
     texture_nodes: &Vec<Arc<RwLock<TextureNode>>>,
     resource_manager: &ResourceManager,
-    purpose: TexturePurpose,
+    size_type: TextureSizeType,
 ) {
     let ordered_nodes = sort_texture_nodes_by_dependency(&texture_nodes);
     /*
-    println!("Creating image variants for purpose: {:?}", purpose);
+    println!("Creating image variants for size_type: {:?}", size_type);
     for (i, node) in texture_nodes.iter().enumerate() {
         let node = node.read().unwrap();
         let id = node.id;
@@ -139,7 +92,7 @@ fn create_image_variants_for_nodes(
             if let Some(dep_node) = dep.as_ref() {
                 let dep_node = dep_node.upgrade().unwrap();
                 let dep_node = dep_node.read().unwrap();
-                if let Some(image) = dep_node.image_variants.get(&purpose) {
+                if let Some(image) = dep_node.image_variants.get(&size_type) {
                     dependencies.insert(key.clone(), image.clone());
                 } else {
                     // should not happen
@@ -152,23 +105,10 @@ fn create_image_variants_for_nodes(
         }
         let texture = resource_manager.textures.get(&texture_id).unwrap();
         let texture = texture.read().unwrap();
-        if let Some(image) = render_texture_image(&texture, &dependencies, purpose) {
-            if purpose == TexturePurpose::Render {
-                texture_node
-                    .image_variants
-                    .insert(purpose, Arc::new(RwLock::new(image)));
-            } else {
-                //let srgb_purpose = purpose.add_srgb();
-                //let srgb_image = DynamicImage::ImageRgb8(convert_to_srgb_u8_image(&image));
-
-                texture_node
-                    .image_variants
-                    .insert(purpose, Arc::new(RwLock::new(image)));
-
-                //texture_node
-                //    .image_variants
-                //    .insert(srgb_purpose, Arc::new(RwLock::new(srgb_image)));
-            }
+        if let Some(image) = render_texture_image(&texture, &dependencies, size_type) {
+            texture_node
+                .image_variants
+                .insert(size_type, Arc::new(RwLock::new(image)));
         }
     }
 }
@@ -176,14 +116,14 @@ fn create_image_variants_for_nodes(
 pub fn create_image_variant(
     texture_node: &Arc<RwLock<TextureNode>>,
     resource_manager: &ResourceManager,
-    purpose: TexturePurpose,
+    size_type: TextureSizeType,
 ) -> Option<Arc<RwLock<DynaImage>>> {
-    if let Some(image) = texture_node.read().unwrap().image_variants.get(&purpose) {
+    if let Some(image) = texture_node.read().unwrap().image_variants.get(&size_type) {
         return Some(image.clone());
     } else {
         let texture_nodes = vec![texture_node.clone()];
-        create_image_variants_for_nodes(&texture_nodes, resource_manager, purpose);
-        if let Some(image) = texture_node.read().unwrap().image_variants.get(&purpose) {
+        create_image_variants_for_nodes(&texture_nodes, resource_manager, size_type);
+        if let Some(image) = texture_node.read().unwrap().image_variants.get(&size_type) {
             return Some(image.clone());
         }
         return None;
@@ -193,13 +133,13 @@ pub fn create_image_variant(
 pub fn create_image_variants(
     resource_manager: &ResourceManager,
     resource_cache_manager: &mut ResourceCacheManager,
-    purpose: TexturePurpose,
+    size_type: TextureSizeType,
 ) {
     let mut texture_nodes = Vec::new();
     for (_id, texture_node) in resource_cache_manager.textures.iter() {
-        if is_no_variant(&texture_node.read().unwrap(), purpose) {
+        if is_no_variant(&texture_node.read().unwrap(), size_type) {
             texture_nodes.push(texture_node.clone());
         }
     }
-    create_image_variants_for_nodes(&texture_nodes, resource_manager, purpose);
+    create_image_variants_for_nodes(&texture_nodes, resource_manager, size_type);
 }

--- a/src/conversion/texture_node/mod.rs
+++ b/src/conversion/texture_node/mod.rs
@@ -9,4 +9,4 @@ pub use create_texture_nodes::create_texture_nodes;
 pub use dyna_image::DynaImage;
 pub use render_texture_image::render_texture_image;
 pub use texture_node::TextureNode;
-pub use texture_node::TexturePurpose;
+pub use texture_node::TextureSizeType;

--- a/src/conversion/texture_node/render_texture_image.rs
+++ b/src/conversion/texture_node/render_texture_image.rs
@@ -1,4 +1,4 @@
-use super::texture_node::TexturePurpose;
+use super::texture_node::TextureSizeType;
 use crate::conversion::spectrum::Spectrum;
 use crate::model::base::Property;
 use crate::model::scene::Texture;
@@ -13,7 +13,7 @@ use image::buffer::ConvertBuffer as _;
 
 const ICON_SIZE: u32 = 64;
 const DISPLAY_SIZE: u32 = 256;
-const RENDER_SIZE: u32 = 1024;
+//const RENDER_SIZE: u32 = 1024;
 
 fn get_color_texture_image(texture: &Texture, key: &str) -> Option<DynaImage> {
     let props = texture.as_property_map();
@@ -79,13 +79,13 @@ fn convert_to_linear_float_image(image: &DynaImage) -> DynaImage {
     }
 }
 
-fn resize_image_for_purpose(
+fn resize_image_for_size_type(
     image: image::DynamicImage,
-    purpose: TexturePurpose,
+    size_type: TextureSizeType,
 ) -> image::DynamicImage {
-    match purpose {
-        TexturePurpose::Render => image,
-        TexturePurpose::Display | TexturePurpose::DisplaySrgb => {
+    match size_type {
+        TextureSizeType::Render => image,
+        TextureSizeType::Display => {
             let resized = image.resize_exact(
                 DISPLAY_SIZE,
                 DISPLAY_SIZE,
@@ -93,7 +93,7 @@ fn resize_image_for_purpose(
             );
             return resized;
         }
-        TexturePurpose::Icon | TexturePurpose::IconSrgb => {
+        TextureSizeType::Icon => {
             let resized = image.resize_exact(
                 ICON_SIZE,
                 ICON_SIZE,
@@ -159,14 +159,14 @@ fn get_dependent_image(
     return None;
 }
 
-fn load_imagemap_texture_image(texture: &Texture, purpose: TexturePurpose) -> Option<DynaImage> {
+fn load_imagemap_texture_image(texture: &Texture, size_type: TextureSizeType) -> Option<DynaImage> {
     // let scale = get_float(texture.as_property_map(), "scale").unwrap_or(1.0); --- IGNORE ---
     // if scale != 1.0 { --- IGNORE ---
     //     println!("Imagemap scale other than 1.0 is not supported yet."); --- IGNORE ---
     // } --- IGNORE ---
     if let Some(path) = texture.get_fullpath() {
         if let Ok(image) = image::open(path) {
-            let image = resize_image_for_purpose(image, purpose);
+            let image = resize_image_for_size_type(image, size_type);
             match image {
                 image::DynamicImage::ImageLuma8(img) => {
                     return Some(DynaImage::ImageLuma8(img));
@@ -394,12 +394,12 @@ fn render_scale_texture_image(
 pub fn render_texture_image(
     texture: &Texture,
     dependencies: &HashMap<String, Arc<RwLock<DynaImage>>>,
-    purpose: TexturePurpose,
+    size_type: TextureSizeType,
 ) -> Option<DynaImage> {
     let texture_type = texture.get_type();
     match texture_type.as_str() {
         "imagemap" => {
-            return load_imagemap_texture_image(texture, purpose);
+            return load_imagemap_texture_image(texture, size_type);
         }
         "constant" => {
             return render_constant_texture_image(texture);

--- a/src/conversion/texture_node/texture_node.rs
+++ b/src/conversion/texture_node/texture_node.rs
@@ -6,32 +6,13 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::Weak;
 
-use image::DynamicImage;
 use uuid::Uuid;
 
-pub enum TextureType {
-    Color,
-    Bump,
-    Normal,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TexturePurpose {
+pub enum TextureSizeType {
     Render,
     Display,
-    DisplaySrgb,
     Icon,
-    IconSrgb,
-}
-
-impl TexturePurpose {
-    pub fn add_srgb(&self) -> TexturePurpose {
-        match self {
-            TexturePurpose::Display => TexturePurpose::DisplaySrgb,
-            TexturePurpose::Icon => TexturePurpose::IconSrgb,
-            _ => *self,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -43,7 +24,7 @@ pub struct TextureNode {
     pub properties: PropertyMap,
     pub inputs: HashMap<String, Option<Weak<RwLock<TextureNode>>>>,
     pub outputs: HashMap<Uuid, Weak<RwLock<TextureNode>>>,
-    pub image_variants: HashMap<TexturePurpose, Arc<RwLock<DynaImage>>>, // key is variant name
+    pub image_variants: HashMap<TextureSizeType, Arc<RwLock<DynaImage>>>, // key is variant name
 }
 
 impl TextureNode {

--- a/src/panel/manage/debug_textures.rs
+++ b/src/panel/manage/debug_textures.rs
@@ -1,5 +1,5 @@
 use crate::controller::AppController;
-use crate::conversion::texture_node::TexturePurpose;
+use crate::conversion::texture_node::TextureSizeType;
 use crate::conversion::texture_node::create_image_variants;
 use crate::conversion::texture_node::create_texture_nodes;
 use crate::model::scene::ResourceCacheComponent;
@@ -151,7 +151,7 @@ impl DebugTexturesPanel {
         create_image_variants(
             &resource_manager,
             &mut resource_cache_manager,
-            TexturePurpose::Render,
+            TextureSizeType::Render,
         );
         let texture_views = create_texture_views(&resource_manager, &resource_cache_manager);
 

--- a/src/panel/manage/resources.rs
+++ b/src/panel/manage/resources.rs
@@ -3,7 +3,7 @@ use crate::model::scene::ResourceCacheComponent;
 use crate::model::scene::ResourceComponent;
 
 use crate::conversion::texture_node::DynaImage;
-use crate::conversion::texture_node::TexturePurpose;
+use crate::conversion::texture_node::TextureSizeType;
 use crate::conversion::texture_node::create_image_variants;
 use crate::conversion::texture_node::create_texture_nodes;
 
@@ -104,7 +104,7 @@ impl ResourcesPanel {
                         create_image_variants(
                             &resource_manager,
                             &mut resource_cache_manager,
-                            crate::conversion::texture_node::TexturePurpose::Icon,
+                            crate::conversion::texture_node::TextureSizeType::Icon,
                         );
 
                         for (id, texture) in resource_manager.textures.iter() {
@@ -126,7 +126,7 @@ impl ResourcesPanel {
                             if let Some(texture_node) = resource_cache_manager.textures.get(id) {
                                 let texture_node = texture_node.read().unwrap();
                                 if let Some(image) =
-                                    texture_node.image_variants.get(&TexturePurpose::Icon)
+                                    texture_node.image_variants.get(&TextureSizeType::Icon)
                                 {
                                     let image = image.read().unwrap();
                                     if let Some(color_image) = get_image_data(&image) {

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -32,6 +32,7 @@ use crate::render::scene_item::*;
 
 //use crate::render::wgpu::texture;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::vec;
@@ -499,10 +500,6 @@ fn get_resource_cache_manager(node: &Arc<RwLock<Node>>) -> Arc<RwLock<ResourceCa
     return component.get_resource_cache_manager();
 }
 
-fn get_image_data(image: &DynaImage) -> image::Rgba32FImage {
-    return image.to_rgba32f();
-}
-
 fn convert_to_f16(data: &[f32]) -> Vec<half::f16> {
     let mut f16_data = Vec::with_capacity(data.len());
     for &value in data.iter() {
@@ -585,25 +582,43 @@ fn get_texture_from_rgba32f_image(
     return texture;
 }
 
-fn get_texture_from_image(
+fn get_color_texture_from_image(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
     texture_image: &DynaImage,
-) -> wgpu::Texture {
+) -> Option<wgpu::Texture> {
     match &texture_image {
         DynaImage::ImageRgb32F(_) => {
             let img = texture_image.to_rgba32f();
-            return get_texture_from_rgba32f_image(device, queue, &img);
+            return Some(get_texture_from_rgba32f_image(device, queue, &img));
         }
         DynaImage::ImageRgb8(_) => {
             let img = texture_image.to_rgba8();
-            return get_texture_from_rgba_image(device, queue, &img);
+            return Some(get_texture_from_rgba_image(device, queue, &img));
         }
         _ => {
             let img = texture_image.to_rgba32f();
-            return get_texture_from_rgba32f_image(device, queue, &img);
+            return Some(get_texture_from_rgba32f_image(device, queue, &img));
         }
     }
+}
+
+fn get_normal_texture_from_image(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    texture_image: &DynaImage,
+) -> Option<wgpu::Texture> {
+    println!("get_normal_texture_from_image called");
+    match &texture_image {
+        DynaImage::ImageLuma8(img) => {
+            //
+            assert!(false, "Unexpected Luma8 image for normal map");
+        }
+        _ => {
+            //
+        }
+    }
+    return None;
 }
 
 fn convert_address_mode(wrap: &str) -> wgpu::AddressMode {
@@ -623,6 +638,20 @@ fn create_render_textures(
     render_resource_manager: &mut RenderResourceManager,
     size_type: TextureSizeType,
 ) {
+    let mut is_bump_map: HashSet<Uuid> = HashSet::new();
+    {
+        for (_id, material) in resource_manager.materials.iter() {
+            let material = material.read().unwrap();
+            if let Some(bump) = get_string(material.as_property_map(), "bumpmap") {
+                if let Some(texture) = resource_manager.find_texture_by_name(&bump) {
+                    let texture = texture.read().unwrap();
+                    let texture_id = texture.get_id();
+                    is_bump_map.insert(texture_id);
+                }
+            }
+        }
+    }
+
     for (_id, texture) in resource_manager.textures.iter() {
         let texture = texture.read().unwrap();
         let texture_id = texture.get_id();
@@ -647,28 +676,33 @@ fn create_render_textures(
             let texture_node = texture_node.read().unwrap();
             if let Some(image) = texture_node.image_variants.get(&size_type) {
                 let image = image.read().unwrap();
-                let texture = get_texture_from_image(device, queue, &image);
-                let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-                let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-                    label: Some("Render Texture Sampler"),
-                    address_mode_u: address_mode_u,
-                    address_mode_v: address_mode_v,
-                    min_filter: wgpu::FilterMode::Linear,
-                    mag_filter: wgpu::FilterMode::Linear,
-                    ..Default::default()
-                });
-
-                let render_texture = RenderTexture {
-                    id: texture_id,
-                    edition: texture_edition.clone(),
-                    texture,
-                    view,
-                    sampler,
-                    scale: [uscale, vscale],
-                    delta: [udelta, vdelta],
+                let texture = if is_bump_map.get(&texture_id).is_some() {
+                    get_normal_texture_from_image(device, queue, &image) //calculate normal map texture
+                } else {
+                    get_color_texture_from_image(device, queue, &image)
                 };
-                let render_texture = Arc::new(render_texture);
-                render_resource_manager.add_texture(&render_texture);
+                if let Some(texture) = texture {
+                    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+                    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                        label: Some("Render Texture Sampler"),
+                        address_mode_u: address_mode_u,
+                        address_mode_v: address_mode_v,
+                        min_filter: wgpu::FilterMode::Linear,
+                        mag_filter: wgpu::FilterMode::Linear,
+                        ..Default::default()
+                    });
+                    let render_texture = RenderTexture {
+                        id: texture_id,
+                        edition: texture_edition.clone(),
+                        texture,
+                        view,
+                        sampler,
+                        scale: [uscale, vscale],
+                        delta: [udelta, vdelta],
+                    };
+                    let render_texture = Arc::new(render_texture);
+                    render_resource_manager.add_texture(&render_texture);
+                }
             }
         }
     }

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -16,7 +16,7 @@ use super::shader::RenderShader;
 use super::texture::RenderTexture;
 use crate::conversion::spectrum::Spectrum;
 use crate::conversion::texture_node::DynaImage;
-use crate::conversion::texture_node::TexturePurpose;
+use crate::conversion::texture_node::TextureSizeType;
 use crate::conversion::texture_node::create_image_variants;
 use crate::conversion::texture_node::create_texture_nodes;
 use crate::model::base::Property;
@@ -621,7 +621,7 @@ fn create_render_textures(
     resource_manager: &ResourceManager,
     resource_cache_manager: &ResourceCacheManager,
     render_resource_manager: &mut RenderResourceManager,
-    purpose: TexturePurpose,
+    size_type: TextureSizeType,
 ) {
     for (_id, texture) in resource_manager.textures.iter() {
         let texture = texture.read().unwrap();
@@ -645,7 +645,7 @@ fn create_render_textures(
 
         if let Some(texture_node) = resource_cache_manager.textures.get(&texture_id) {
             let texture_node = texture_node.read().unwrap();
-            if let Some(image) = texture_node.image_variants.get(&purpose) {
+            if let Some(image) = texture_node.image_variants.get(&size_type) {
                 let image = image.read().unwrap();
                 let texture = get_texture_from_image(device, queue, &image);
                 let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -694,7 +694,7 @@ pub fn get_render_items(
         create_image_variants(
             &resource_manager,
             &mut resource_cache_manager,
-            TexturePurpose::Render,
+            TextureSizeType::Render,
         );
         create_render_textures(
             device,
@@ -702,7 +702,7 @@ pub fn get_render_items(
             &resource_manager,
             &resource_cache_manager,
             &mut render_resource_manager,
-            TexturePurpose::Render,
+            TextureSizeType::Render,
         );
     }
 

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -21,7 +21,7 @@ use crate::conversion::plane_data::create_plane_meshes_from_mesh;
 use crate::conversion::plane_data::create_plane_outline_from_plane_mesh;
 use crate::conversion::plane_data::create_plane_rect_from_plane_outline;
 use crate::conversion::texture_node::DynaImage;
-use crate::conversion::texture_node::TexturePurpose;
+use crate::conversion::texture_node::TextureSizeType;
 use crate::conversion::texture_node::create_image_variant;
 use crate::model::base::Matrix4x4;
 use crate::model::base::Vector3;
@@ -719,7 +719,7 @@ fn get_render_texture(
         if let Some(texture_node) = resource_cache_manager.textures.get(&texture_id) {
             // println!("Loading texture: {} (ID: {})", mapname, texture_id);
             if let Some(image) =
-                create_image_variant(texture_node, resource_manager, TexturePurpose::Render)
+                create_image_variant(texture_node, resource_manager, TextureSizeType::Render)
             {
                 // println!("Texture image created: {} (ID: {})", mapname, texture_id);
                 let image = image.read().unwrap();


### PR DESCRIPTION
This pull request refactors the texture image variant system to use a new enum, `TextureSizeType`, instead of the previous `TexturePurpose` throughout the codebase. This change improves clarity and simplifies the handling of texture variants by removing unnecessary SRGB-related variants and associated logic. Additionally, the PR introduces some code cleanups and minor improvements for texture handling and resource management.

**Texture variant system refactor:**

* Replaced the `TexturePurpose` enum with `TextureSizeType` in `texture_node.rs` and all related modules, removing SRGB-related variants and simplifying the enum. All functions and data structures that previously used `TexturePurpose` now use `TextureSizeType`. [[1]](diffhunk://#diff-94538d1f11ddaaa723fc494fd6cc87de327fc99e05478bf505c0aa064de75befL9-L34) [[2]](diffhunk://#diff-94538d1f11ddaaa723fc494fd6cc87de327fc99e05478bf505c0aa064de75befL46-R27) [[3]](diffhunk://#diff-8d3ab5996b79c14c4983bc21eb69270435d3f55b2711a1317075d6b676272efeL6-R6) [[4]](diffhunk://#diff-8d3ab5996b79c14c4983bc21eb69270435d3f55b2711a1317075d6b676272efeL15-R16) [[5]](diffhunk://#diff-56bb7384fc9a0a63c61c81423fd68ebb5677582fd99d05b653264864cf32a0d8L12-R12) [[6]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L1-R1) [[7]](diffhunk://#diff-2de648cecd1fa9a4abb615d2ba2554f49d578053f99a9fac58f4f3088eb56d3bL2-R2) [[8]](diffhunk://#diff-b3c9fe918218cd2efcdae96a8ff9ddb87c601f1b3c1cf88496332d7a0a35fb8fL6-R6) [[9]](diffhunk://#diff-3f880471284923f9333ed24e9862d42d759111d971e071c86958c20041f6bea0L19-R19)
* Updated all usages, function parameters, and logic to use `TextureSizeType` instead of `TexturePurpose` in texture image variant creation, retrieval, and storage. [[1]](diffhunk://#diff-8d3ab5996b79c14c4983bc21eb69270435d3f55b2711a1317075d6b676272efeL63-R70) [[2]](diffhunk://#diff-8d3ab5996b79c14c4983bc21eb69270435d3f55b2711a1317075d6b676272efeL142-R95) [[3]](diffhunk://#diff-8d3ab5996b79c14c4983bc21eb69270435d3f55b2711a1317075d6b676272efeL155-R126) [[4]](diffhunk://#diff-8d3ab5996b79c14c4983bc21eb69270435d3f55b2711a1317075d6b676272efeL196-R144) [[5]](diffhunk://#diff-2de648cecd1fa9a4abb615d2ba2554f49d578053f99a9fac58f4f3088eb56d3bL154-R154) [[6]](diffhunk://#diff-b3c9fe918218cd2efcdae96a8ff9ddb87c601f1b3c1cf88496332d7a0a35fb8fL107-R107) [[7]](diffhunk://#diff-b3c9fe918218cd2efcdae96a8ff9ddb87c601f1b3c1cf88496332d7a0a35fb8fL129-R129) [[8]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L16-R16) [[9]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L82-R96) [[10]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L162-R169) [[11]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L397-R402) [[12]](diffhunk://#diff-3f880471284923f9333ed24e9862d42d759111d971e071c86958c20041f6bea0L624-R654)

**Code simplification and cleanup:**

* Removed SRGB conversion logic and related functions from `create_image_variants.rs`, since SRGB variants are no longer needed.
* Cleaned up the image resizing logic to use `resize_image_for_size_type` instead of the previous `resize_image_for_purpose`, matching the new enum. [[1]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L82-R96) [[2]](diffhunk://#diff-2b6873dab9d5db19584dfe2443a97aeb33ce6aff90c2b3c32809d4ff0c351550L162-R169)

**Resource and texture handling improvements:**

* Updated resource panels and rendering code to use the new texture variant system, ensuring correct variant selection and improved clarity. [[1]](diffhunk://#diff-2de648cecd1fa9a4abb615d2ba2554f49d578053f99a9fac58f4f3088eb56d3bL154-R154) [[2]](diffhunk://#diff-b3c9fe918218cd2efcdae96a8ff9ddb87c601f1b3c1cf88496332d7a0a35fb8fL107-R107) [[3]](diffhunk://#diff-b3c9fe918218cd2efcdae96a8ff9ddb87c601f1b3c1cf88496332d7a0a35fb8fL129-R129) [[4]](diffhunk://#diff-3f880471284923f9333ed24e9862d42d759111d971e071c86958c20041f6bea0L624-R654)
* Added a bump map tracking mechanism in `create_render_textures` to identify bump map textures for rendering.

**Texture conversion and creation changes:**

* Refactored texture image conversion functions and their usages to match the new variant system and improve error handling.
* Added new helper functions for color and normal texture creation from images, with improved handling for unexpected image types.

Overall, these changes make the texture variant system more robust and easier to maintain, while removing unnecessary complexity and improving resource handling.