### PR TITLE
Update ltc

### DIFF
--- a/src/ltc/export.rs
+++ b/src/ltc/export.rs
@@ -82,13 +82,12 @@ pub fn generate_ltc_array_code(
         const_name, total_floats
     ));
 
-    for (i, v) in data.iter().enumerate() {
-        // Writing to a String cannot fail, so unwrap is safe
-        let _ = write!(&mut code, "    {}, {}, {}, {},", v.x, v.y, v.z, v.w);
-        if (i + 1) % width == 0 {
-            code.push('\n');
-        } else {
-            code.push(' ');
+    for j in 0..height {
+        for i in 0..width {
+            let idx = i + j * width;
+            // Writing to a String cannot fail, so unwrap is safe
+            let v = data[idx];
+            let _ = write!(&mut code, "    {}, {}, {}, {}, // [{}, {}] \n", v.x, v.y, v.z, v.w, i, j);
         }
     }
 

--- a/src/ltc/fit_tab.rs
+++ b/src/ltc/fit_tab.rs
@@ -56,7 +56,8 @@ pub fn fit_tab(brdf: &dyn Brdf, width: usize, height: usize) -> (Vec<Mat3>, Vec<
                     // roughness = 1
                     ltc.m11 = 1.0;
                     ltc.m22 = 1.0;
-                } else if a + 1 < height {
+                } else{
+                    assert!(a + 1 < height);
                     // Init with roughness of previous fit
                     ltc.m11 = tab[a + 1 + t * height].col(0).x;
                     ltc.m22 = tab[a + 1 + t * height].col(1).y;

--- a/src/ltc/fitter.rs
+++ b/src/ltc/fitter.rs
@@ -60,11 +60,7 @@ fn compute_error_helper(error: f32, pdf: f32) -> f32 {
     if pdf > 0.0 {
         error / pdf
     } else {
-        if error > 0.0 {
-            return 1e6;
-        } else {
-            return 1.0;
-        }
+        0.0
     }
 }
 

--- a/src/ltc/ltc.rs
+++ b/src/ltc/ltc.rs
@@ -58,9 +58,9 @@ impl LTC {
 
         // Create scale/shear matrix
         let scale = Mat3::from_cols(
-            Vec3::new(self.m11, 0.0, self.m13),
+            Vec3::new(self.m11, 0.0, 0.0),
             Vec3::new(0.0, self.m22, 0.0),
-            Vec3::new(0.0, 0.0, 1.0),
+            Vec3::new(self.m13, 0.0, 1.0),
         );
 
         self.M = basis * scale;

--- a/src/ltc/pack_tab.rs
+++ b/src/ltc/pack_tab.rs
@@ -48,15 +48,19 @@ pub fn pack_tab(
     let mut tex2 = vec![Vec4::ZERO; expected_len];
 
     for i in 0..expected_len {
-        let invM = tab[i]; // Already inverse matrix from fit_tab
+        let m = &tab[i];
+        let mut invM = m.inverse();
+        // normalize by the middle element
+        invM *= 1.0 / invM.col(1)[1];
+
         let mag_fresnel = tab_mag_fresnel[i];
 
         // Pack inverse matrix into tex1
         // tex1: (invM[0][0], invM[0][2], invM[2][0], invM[2][2])
         tex1[i] = Vec4::new(
             invM.col(0).x, // invM[0][0]
-            invM.col(2).x, // invM[0][2]
-            invM.col(0).z, // invM[2][0]
+            invM.col(0).z, // invM[0][2]
+            invM.col(2).x, // invM[2][0]
             invM.col(2).z, // invM[2][2]
         );
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the LTC (Linearly Transformed Cosines) codebase, focusing on the accuracy of matrix computations, error handling, and code clarity. The main changes include corrections to matrix construction and packing, improved error calculation, enhanced code generation for LTC arrays, and a safer initialization process in the fitting routine.

**Matrix computation and packing improvements:**
- Fixed construction of the scale/shear matrix in the `LTC` implementation by correcting the placement of `m13` and zero values, ensuring the resulting matrix is accurate for subsequent computations.
- In `pack_tab`, now explicitly computes and normalizes the inverse matrix before packing, and corrected the mapping of matrix elements to the output texture vectors for improved accuracy.

**Error calculation and handling:**
- Simplified error computation in `compute_error_helper` to return `0.0` if the PDF is zero, removing arbitrary large/small return values and making the function behavior clearer and more predictable.

**Code generation and output clarity:**
- Enhanced the `generate_ltc_array_code` function to output LTC array values in a more readable 2D format, including explicit `[i, j]` indices as comments for easier debugging and inspection.

**Fitting routine safety:**
- In the LTC fitting routine, replaced a conditional with an assertion to ensure safe initialization of matrix elements, making the code more robust against out-of-bounds errors.