### PR TITLE
Update ltc

### DIFF
--- a/src/ltc/brdf_ggx.rs
+++ b/src/ltc/brdf_ggx.rs
@@ -12,7 +12,7 @@ impl BrdfGGX {
 }
 
 fn lambda(alpha: f32, cosTheta: f32) -> f32 {
-    if cosTheta < 0.0 {
+    if cosTheta < 1.0 {
         let a = 1.0 / (alpha * cosTheta.acos().tan());
         return 0.5 * (-1.0 + (1.0 + 1.0 / (a * a)).sqrt());
     } else {


### PR DESCRIPTION
This pull request makes a small change to the `BrdfGGX` implementation to update the condition in the `lambda` function. The check now uses `cosTheta < 1.0` instead of `cosTheta < 0.0`, which likely corrects the logic for handling certain input values.

- Updated the conditional in the `lambda` function of `BrdfGGX` to check for `cosTheta < 1.0` instead of `cosTheta < 0.0` in `src/ltc/brdf_ggx.rs`