### PR TITLE
Use Uuid

### DIFF
--- a/src/ltc/brdf_oren_nayar.rs
+++ b/src/ltc/brdf_oren_nayar.rs
@@ -48,7 +48,7 @@ impl Brdf for BrdfOrenNayar {
         // Project V and L onto the tangent plane and compute the angle between them
         let V_tangent = glam::Vec3::new(V.x, V.y, 0.0);
         let L_tangent = glam::Vec3::new(L.x, L.y, 0.0);
-        
+
         let cos_phi_diff = if V_tangent.length() > 1e-6 && L_tangent.length() > 1e-6 {
             let V_norm = V_tangent.normalize();
             let L_norm = L_tangent.normalize();
@@ -151,11 +151,11 @@ mod tests {
         let brdf = BrdfOrenNayar::new();
         let V = glam::Vec3::new(0.0, 0.0, 1.0);
         let L = glam::Vec3::new(0.0, 0.0, 1.0);
-        
+
         // With alpha = 0 (smooth surface), should approach Lambertian
         let (value, pdf) = brdf.eval(&V, &L, 0.0);
         let lambertian_value = L.z / std::f32::consts::PI;
-        
+
         assert!((value - lambertian_value).abs() < 1e-5);
         assert!(pdf > 0.0);
     }

--- a/src/ltc/export.rs
+++ b/src/ltc/export.rs
@@ -87,7 +87,11 @@ pub fn generate_ltc_array_code(
             let idx = i + j * width;
             // Writing to a String cannot fail, so unwrap is safe
             let v = data[idx];
-            let _ = write!(&mut code, "    {}, {}, {}, {}, // [{}, {}] \n", v.x, v.y, v.z, v.w, i, j);
+            let _ = write!(
+                &mut code,
+                "    {}, {}, {}, {}, // [{}, {}] \n",
+                v.x, v.y, v.z, v.w, i, j
+            );
         }
     }
 

--- a/src/ltc/fitter.rs
+++ b/src/ltc/fitter.rs
@@ -57,11 +57,7 @@ pub fn compute_avg_terms(brdf: &dyn Brdf, V: &Vec3, alpha: f32) -> (f32, f32, Ve
 
 /// Helper function for compute_error to avoid code duplication
 fn compute_error_helper(error: f32, pdf: f32) -> f32 {
-    if pdf > 0.0 {
-        error / pdf
-    } else {
-        0.0
-    }
+    if pdf > 0.0 { error / pdf } else { 0.0 }
 }
 
 /// Compute the error between the BRDF and the LTC using Multiple Importance Sampling

--- a/src/model/scene/material.rs
+++ b/src/model/scene/material.rs
@@ -22,7 +22,7 @@ impl Material {
     pub fn new(name: &str, t: &str, props: &PropertyMap) -> Self {
         let id = Uuid::new_v4();
         let mut props = props.clone();
-        props.insert("string id", Property::from(Uuid::new_v4().to_string()));
+        props.insert("string id", Property::from(id.to_string()));
         props.insert("string name_", Property::from(name));
         props.insert("string type", Property::from(t));
         replace_properties(&mut props);

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -28,7 +28,7 @@ const MAX_RECT_LIGHT_NUM: usize = 32; // Maximum number of rectangle lights
 const MAX_INFINITE_LIGHT_NUM: usize = 1; // Maximum number of infinite lights
 const MAX_LIGHT_TEXTURE_NUM: usize = 1; // Maximum number of light textures
 
-const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0x00000000_0000_0000_FFFF_000000000000);
+const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8_40a5fa168488);
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]

--- a/src/render/wgpu/ltc/register_ltc_textures.rs
+++ b/src/render/wgpu/ltc/register_ltc_textures.rs
@@ -6,7 +6,7 @@ use eframe::wgpu;
 //use std::sync::Arc;
 use uuid::Uuid;
 
-pub const DEFAULT_LTC_UUID: Uuid = Uuid::from_u128(0x123e4567_e89b_12d3_a456_426614174000);
+pub const DEFAULT_LTC_UUID: Uuid = Uuid::from_u128(0x52eca5d6_c228_4136_8840_f3517bb488a3);
 
 pub fn create_ltc_texture(
     device: &wgpu::Device,

--- a/src/render/wgpu/render_gizmo_item.rs
+++ b/src/render/wgpu/render_gizmo_item.rs
@@ -67,9 +67,9 @@ pub fn get_render_axis_gizmo_items(
     render_resource_manager: &mut RenderResourceManager,
 ) -> Vec<Arc<RenderItem>> {
     const IDS: [Uuid; 3] = [
-        Uuid::from_u128(0x00000000_1000_0000_0000_000000000001), // X Axis
-        Uuid::from_u128(0x00000000_1000_0000_0000_000000000002), // Y Axis
-        Uuid::from_u128(0x00000000_1000_0000_0000_000000000003), // Z Axis
+        Uuid::from_u128(0x8b854e3d_1cc3_471e_8611_5d641851b397), // X Axis
+        Uuid::from_u128(0xf0f5376b_aafe_4d98_b38b_204080a85aaf), // Y Axis
+        Uuid::from_u128(0x06131ab9_8798_41ae_8fb3_077e51034087), // Z Axis
     ];
     let mut render_items = Vec::new();
     for i in 0..3 {
@@ -135,7 +135,7 @@ pub fn get_render_grid_gizmo_items(
     _resource_manager: &ResourceManager,
     render_resource_manager: &mut RenderResourceManager,
 ) -> Vec<Arc<RenderItem>> {
-    const ID: Uuid = Uuid::from_u128(0x00000000_1000_0000_0000_000000000004); // Unique ID for the grid
+    const ID: Uuid = Uuid::from_u128(0xbf90d763_6731_49c3_9cf2_6f1ca5c58171); // Unique ID for the grid
     const GRID_SIZE: f32 = 1000.0; // Size of the grid
     const GRID_STEP: f32 = 10.0; // Step size for grid lines
     enum PlaneType {


### PR DESCRIPTION
This pull request updates several unique identifier (UUID) constants across different modules to new values, ensuring consistency and possibly resolving conflicts or improving traceability. There are also minor code style improvements and a bug fix in the material creation logic.

**UUID Updates for Resource Identification:**

* Updated the default light texture UUID in `src/render/wgpu/lighting_mesh_renderer.rs` to a new value, which is used to identify the default light texture resource.
* Changed the default LTC (Linearly Transformed Cosines) texture UUID in `src/render/wgpu/ltc/register_ltc_textures.rs` to a new value for better resource management.
* Updated the UUIDs for axis gizmo items (X, Y, Z) in `src/render/wgpu/render_gizmo_item.rs` to new, unique values.
* Changed the grid gizmo item UUID in `src/render/wgpu/render_gizmo_item.rs` to a new value, ensuring uniqueness for the grid resource.

**Bug Fixes and Code Quality Improvements:**

* Fixed a bug in `Material::new` in `src/model/scene/material.rs` by ensuring the inserted `"string id"` property matches the newly generated material ID, rather than generating a second, unrelated UUID.
* Improved code readability in `compute_error_helper` in `src/ltc/fitter.rs` by simplifying the conditional expression.
* Reformatted the code for writing LTC array data in `src/ltc/export.rs` for better readability and maintainability.