### PR TITLE
Feature/shader input

### DIFF
--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -469,13 +469,6 @@ fn vs_main(
     return out;
 }
 
-struct LTCShadeInput {
-    diffuse: vec3<f32>,
-    specular: vec3<f32>,
-    uv: vec2<f32>,
-    fresnel: vec2<f32>,
-}
-
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     let camera_to_surface = normalize(in.w_position - global_uniforms.camera_position.xyz);

--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -252,11 +252,6 @@ fn LTC_Evaluate_Polygon(N: vec3<f32>, V: vec3<f32>, P: vec3<f32>, MinvOrg: mat3x
     return Lo_i;
 }
 
-fn isqrt(x: f32) -> f32 {
-    return inverseSqrt(x);
-    //return 1.0 / sqrt(x);
-}
-
 fn LTC_Evaluate_Disk(N: vec3<f32>, V: vec3<f32>, P: vec3<f32>, Minv: mat3x3<f32>, points: array<vec3<f32>, 4>) -> vec3<f32>
 {
     // construct orthonormal basis around N
@@ -400,7 +395,7 @@ fn LTC_Evaluate_Disk(N: vec3<f32>, V: vec3<f32>, P: vec3<f32>, Minv: mat3x3<f32>
         let L2 = sqrt(-e2/e1);
 
         // projected solid angle E, like the length(F) in rectangle light
-        let formFactor = L1 * L2 * isqrt((1.0 + L1 * L1) * (1.0 + L2 * L2)) ;
+        let formFactor = L1 * L2 * inverseSqrt((1.0 + L1 * L1) * (1.0 + L2 * L2)) ;
         // use tabulated horizon-clipped sphere
         var uv = vec2<f32>(avgDir.z*0.5 + 0.5, formFactor);
         // uv = saturate(uv);
@@ -413,6 +408,8 @@ fn LTC_Evaluate_Disk(N: vec3<f32>, V: vec3<f32>, P: vec3<f32>, Minv: mat3x3<f32>
         return Lo_i;
     }
 }
+
+
 
 //-------------------------------------------------------
 fn spherical_texture_lookup(direction: vec3<f32>) -> vec2<f32> {
@@ -472,6 +469,13 @@ fn vs_main(
     return out;
 }
 
+struct LTCShadeInput {
+    diffuse: vec3<f32>,
+    specular: vec3<f32>,
+    uv: vec2<f32>,
+    fresnel: vec2<f32>,
+}
+
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     let camera_to_surface = normalize(in.w_position - global_uniforms.camera_position.xyz);
@@ -503,6 +507,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         vec3<f32>(t1.z, 0.0, t1.w)
     );
     let t2 = textureSample(ltc_texture_array, ltc_sampler, ltc_uv, 1);
+    let fresnel = vec2<f32>(t2.x, t2.y);
+#else 
+    let fresnel = vec2<f32>(1.0, 0.0);
 #endif
     // Accumulate lighting
     
@@ -560,16 +567,15 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #endif
 #ifdef ENABLE_SPECULAR
             let specular = LTC_Evaluate_Disk(N, V, P, Minv, lightPoints);
-            let fresnel = t2.xy;
 #else
             let specular = vec3<f32>(0.0);
-            let fresnel = vec2<f32>(1.0, 0.0);
 #endif
 
             let k = 4.0;// 1.0 / (2.0 * PI * PI);
             var area = PI * disk_radius * disk_radius;          // Area of the disk
             var attenuation = calc_attenuation(disk_distance);
-            color += k * area * intensity * attenuation * shade_ltc(diffuse, specular, in.uv, fresnel);
+            let ltc_input = LTCShadeInput(diffuse, specular, in.uv, fresnel);
+            color += k * area * intensity * attenuation * shade_ltc(ltc_input);
         } else {
             let light_to_surface = in.w_position - position;
             let distance = length(light_to_surface);
@@ -621,15 +627,14 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #endif
 #ifdef ENABLE_SPECULAR
             let specular = LTC_Evaluate_Disk(N, V, P, Minv, lightPoints);
-            let fresnel = t2.xy;
 #else
             let specular = vec3<f32>(0.0);
-            let fresnel = vec2<f32>(1.0, 0.0);
 #endif
             let k = 1.0 / (2.0 * PI * PI);
             let area = PI * radius * radius;
-            var attenuation = calc_attenuation(distance); // Simple attenuation
-            color += k * area * intensity * attenuation * shade_ltc(diffuse, specular, in.uv, fresnel);
+            var attenuation = calc_attenuation(distance);
+            let ltc_input = LTCShadeInput(diffuse, specular, in.uv, fresnel);
+            color += k * area * intensity * attenuation * shade_ltc(ltc_input);
         } else {
             var closest_point = position;
             let light_to_surface = in.w_position - closest_point;
@@ -681,16 +686,15 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #endif
 #ifdef ENABLE_SPECULAR
         let specular = LTC_Evaluate_Polygon(N, V, P, Minv, lightPoints);
-        let fresnel = t2.xy;
         //let specular = specular * (mSpecular * t2.x + (1.0 - mSpecular) * t2.y);//
 #else   
         let specular = vec3<f32>(0.0);
-        let fresnel = vec2<f32>(1.0, 0.0);
 #endif
         let k = 1.0 / (2.0 * PI * PI);
         let area = 1.0;
-        let attenuation = calc_attenuation(distance); // Simple quadratic attenuation
-        color += k * area * intensity * attenuation * shade_ltc(diffuse, specular, in.uv, fresnel);
+        let attenuation = calc_attenuation(distance);
+        let ltc_input = LTCShadeInput(diffuse, specular, in.uv, fresnel);
+        color += k * area * intensity * attenuation * shade_ltc(ltc_input);
     }
 
     for (var i: u32 = 0; i < light_uniforms.num_infinite_lights; i++) 

--- a/assets/shaders/include/lighting_surface_header.wgsl
+++ b/assets/shaders/include/lighting_surface_header.wgsl
@@ -71,6 +71,13 @@ struct InfiniteLight {
     //_pad3: vec4<f32>,     // Padding to ensure alignment
 }
 
+struct LTCShadeInput {
+    diffuse: vec3<f32>,
+    specular: vec3<f32>,
+    uv: vec2<f32>,
+    fresnel: vec2<f32>,
+}
+
 // global uniforms
 @group(0)
 @binding(0)
@@ -80,3 +87,5 @@ var<uniform> global_uniforms: GlobalUniforms;
 @group(1)
 @binding(0)
 var<uniform> local_uniforms: LocalUniforms;
+
+

--- a/assets/shaders/lambertian.wgsl
+++ b/assets/shaders/lambertian.wgsl
@@ -50,9 +50,9 @@ fn shade(intensity: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>, uv: vec2<f32>) -> v
     return matte(wo, wi, uv) * intensity;
 }
 
-fn shade_ltc(diffuse: vec3<f32>, specular: vec3<f32>, uv: vec2<f32>, fresnel: vec2<f32>) -> vec3<f32> {
-    let m_kd = sample_kd(uv);
-    return m_kd * diffuse;
+fn shade_ltc(input: LTCShadeInput) -> vec3<f32> {
+    let m_kd = sample_kd(input.uv);
+    return m_kd * input.diffuse;
 }
 
 //-------------------------------------------------------

--- a/assets/shaders/lambertian_ggx.wgsl
+++ b/assets/shaders/lambertian_ggx.wgsl
@@ -78,10 +78,10 @@ fn sample_roughness(uv: vec2<f32>) -> f32 {
     return max(material_uniforms.roughness, 0.08);// cannot < 0.08
 }
 
-fn shade_ltc(diffuse: vec3<f32>, specular: vec3<f32>, uv: vec2<f32>, fresnel: vec2<f32>) -> vec3<f32> {
-    let m_kd = sample_kd(uv);
-    let m_ks = sample_ks(uv);
-    return m_kd * diffuse + specular * 0.5 * (m_ks * fresnel.x + (vec3<f32>(1.0) - m_ks) * fresnel.y);
+fn shade_ltc(input: LTCShadeInput) -> vec3<f32> {
+    let m_kd = sample_kd(input.uv);
+    let m_ks = sample_ks(input.uv);
+    return m_kd * input.diffuse + input.specular * 0.5 * (m_ks * input.fresnel.x + (vec3<f32>(1.0) - m_ks) * input.fresnel.y);
 }
 
 //-------------------------------------------------------

--- a/assets/shaders/oren_nayar.wgsl
+++ b/assets/shaders/oren_nayar.wgsl
@@ -57,9 +57,9 @@ fn sample_roughness(uv: vec2<f32>) -> f32 {
     return material_uniforms.sigma;//normalized sigma
 }
 
-fn shade_ltc(diffuse: vec3<f32>, specular: vec3<f32>, uv: vec2<f32>, fresnel: vec2<f32>) -> vec3<f32> {
-    let m_kd = sample_kd(uv);
-    return m_kd * (diffuse + specular) / 2.0;// combined
+fn shade_ltc(input: LTCShadeInput) -> vec3<f32> {
+    let m_kd = sample_kd(input.uv);
+    return m_kd * (input.diffuse + input.specular) / 2.0;// combined
 }
 
 //-------------------------------------------------------


### PR DESCRIPTION
This pull request refactors the way LTC shading parameters are passed and used in the shader codebase, improving code clarity and maintainability. The main change is the introduction of the `LTCShadeInput` struct, which replaces multiple individual parameters with a single input object for LTC shading functions. Related code is updated to use this new struct, and some minor cleanups are made to function usage and formatting.

### LTC shading refactor

* Introduced the `LTCShadeInput` struct to encapsulate `diffuse`, `specular`, `uv`, and `fresnel` parameters for LTC shading, replacing the previous approach of passing these as separate arguments. (`assets/shaders/include/lighting_surface_header.wgsl`)
* Updated all `shade_ltc` function signatures and their usages in `lambertian.wgsl`, `lambertian_ggx.wgsl`, and `oren_nayar.wgsl` to accept a single `LTCShadeInput` parameter instead of separate values. (`assets/shaders/lambertian.wgsl`, `assets/shaders/lambertian_ggx.wgsl`, `assets/shaders/oren_nayar.wgsl`) [[1]](diffhunk://#diff-10d3d8f03ec2d8d995aef7671818219803254cca4d74dbadb3b5b72d61dff406L53-R55) [[2]](diffhunk://#diff-e8bc9e26de1116efc98135d477cd73e6dc4f51d265d44b3fc2765ea0bbd616b6L81-R84) [[3]](diffhunk://#diff-dd1d10be73307487ea3af4f70a83aad91d7dde1c40a938aa7f26829e2a334faaL60-R62)
* Refactored calls to `shade_ltc` in `lighting_surface_footer.wgsl` to construct and pass an `LTCShadeInput` object, replacing previous usage of separate variables. (`assets/shaders/include/lighting_surface_footer.wgsl`) [[1]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL563-R571) [[2]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL624-R630) [[3]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL684-R690)

### Minor cleanups and fixes

* Removed the unused `isqrt` function and replaced its usage with a direct call to `inverseSqrt`, simplifying the code. (`assets/shaders/include/lighting_surface_footer.wgsl`) [[1]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL255-L259) [[2]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL403-R398)
* Minor formatting and whitespace improvements in header files for better readability. (`assets/shaders/include/lighting_surface_header.wgsl`)