### PR TITLE
Update WGSL

### DIFF
--- a/assets/shaders/arealight_diffuse.wgsl
+++ b/assets/shaders/arealight_diffuse.wgsl
@@ -2,22 +2,22 @@ struct GlobalUniforms {
     world_to_camera: mat4x4<f32>,
     camera_to_clip: mat4x4<f32>,
     camera_to_world: mat4x4<f32>,
-    camera_position: vec4<f32>, // Camera position in world space
+    camera_position: vec4<f32>,
+    // Camera position in world space
 }
 
 struct LocalUniforms {
     local_to_world: mat4x4<f32>,
-    world_to_local: mat4x4<f32>, // inverse of world to cameraå
+    world_to_local: mat4x4<f32>,
+    // inverse of world to cameraå
 }
 
 // global uniforms
-@group(0)
-@binding(0)
+@group(0) @binding(0)
 var<uniform> global_uniforms: GlobalUniforms;
 
 // local uniforms
-@group(1)
-@binding(0)
+@group(1) @binding(0)
 var<uniform> local_uniforms: LocalUniforms;
 
 struct MaterialUniforms {
@@ -25,15 +25,13 @@ struct MaterialUniforms {
     scale: vec4<f32>,
 }
 
-@group(2)
-@binding(0)
+@group(2) @binding(0)
 var<uniform> material_uniforms: MaterialUniforms;
 //-------------------------------------------------------
 const MAX_FLOAT: f32 = 1e+10;
 const PI: f32 = 3.14159265359;
 const INV_PI: f32 = 1.0 / 3.14159265359;
 //-------------------------------------------------------
-
 
 fn shade_nolight(wo: vec3<f32>, uv: vec2<f32>) -> vec3<f32> {
     let l = material_uniforms.l.xyz;
@@ -44,24 +42,19 @@ fn shade_nolight(wo: vec3<f32>, uv: vec2<f32>) -> vec3<f32> {
     return color;
 }
 
-
-
 //-------------------------------------------------------
 struct VertexOut {
     @location(0) w_position: vec3<f32>,
     @location(1) uv: vec2<f32>,
-    @location(2) w_normal:   vec3<f32>,
-    @location(3) w_tangent:  vec3<f32>,
+    @location(2) w_normal: vec3<f32>,
+    @location(3) w_tangent: vec3<f32>,
     @builtin(position) position: vec4<f32>,
-};
+}
+
+;
 
 @vertex
-fn vs_main(
-    @location(0) position: vec3<f32>,
-    @location(1) uvw: vec3<f32>,
-    @location(2) normal: vec3<f32>,
-    @location(3) tangent: vec3<f32>,
-) -> VertexOut {
+fn vs_main(@location(0) position: vec3<f32>, @location(1) uvw: vec3<f32>, @location(2) normal: vec3<f32>, @location(3) tangent: vec3<f32>,) -> VertexOut {
     var out: VertexOut;
     let m_world = local_uniforms.local_to_world;
     let m_clip = global_uniforms.camera_to_clip * global_uniforms.world_to_camera * local_uniforms.local_to_world;
@@ -70,7 +63,7 @@ fn vs_main(
     let w_position = (m_world * vec4<f32>(position, 1.0)).xyz;
     let w_normal = normalize((m_world_it * vec4<f32>(normal, 0.0)).xyz);
     let w_tangent = normalize((m_world_it * vec4<f32>(tangent, 0.0)).xyz);
-    
+
     out.position = m_clip * vec4<f32>(position, 1.0);
     out.w_position = w_position;
     out.uv = uvw.xy;
@@ -84,13 +77,16 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     let camera_to_surface = normalize(in.w_position - global_uniforms.camera_position.xyz);
     var normal = normalize(in.w_normal);
     if dot(normal, camera_to_surface) > 0.0 {
-        normal = -normal;
+        normal = - normal;
     }
     var tangent = normalize(in.w_tangent);
     var bitangent = normalize(cross(normal, tangent));
-    tangent = normalize(cross(bitangent, normal)); // Recompute tangent to ensure orthogonality
-    let tbn = transpose(mat3x3<f32>(tangent, bitangent, normal));//tangent space matrix
-    let wo = tbn * -camera_to_surface;// object to camera vector
+    tangent = normalize(cross(bitangent, normal));
+    // Recompute tangent to ensure orthogonality
+    let tbn = transpose(mat3x3<f32>(tangent, bitangent, normal));
+    //tangent space matrix
+    let wo = tbn * - camera_to_surface;
+    // object to camera vector
     let uv = in.uv;
 
     let color = shade_nolight(wo, uv);

--- a/assets/shaders/include/lighting_surface_header.wgsl
+++ b/assets/shaders/include/lighting_surface_header.wgsl
@@ -3,12 +3,14 @@ struct GlobalUniforms {
     world_to_camera: mat4x4<f32>,
     camera_to_clip: mat4x4<f32>,
     camera_to_world: mat4x4<f32>,
-    camera_position: vec4<f32>, // Camera position in world space
+    camera_position: vec4<f32>,
+    // Camera position in world space
 }
 
 struct LocalUniforms {
     local_to_world: mat4x4<f32>,
-    world_to_local: mat4x4<f32>, // inverse of world to cameraå
+    world_to_local: mat4x4<f32>,
+    // inverse of world to cameraå
 }
 
 struct LightUniforms {
@@ -23,50 +25,79 @@ struct LightUniforms {
 }
 
 struct DirectionalLight {
-    direction: vec4<f32>, // Example light direction
-    intensity: vec4<f32>, // Example light intensity
+    direction: vec4<f32>,
+    // Example light direction
+    intensity: vec4<f32>,
+    // Example light intensity
 }
 
 struct SphereLight {
-    position: vec4<f32>, // Position in world space
-    intensity: vec4<f32>, // Light intensity
+    position: vec4<f32>,
+    // Position in world space
+    intensity: vec4<f32>,
+    // Light intensity
     radius: f32,
     range: f32,
-    _pad1: vec2<f32>, // Padding for alignment
+    _pad1: vec2<f32>,
+    // Padding for alignment
 }
 
 struct DiskLight {
-    position: vec4<f32>, // Position in world space
-    direction: vec4<f32>, // Direction of the spotlight
-    intensity: vec4<f32>, // Light intensity
-    radius: f32,    // Radius of the disk
+    position: vec4<f32>,
+    // Position in world space
+    direction: vec4<f32>,
+    // Direction of the spotlight
+    intensity: vec4<f32>,
+    // Light intensity
+    radius: f32,
+    // Radius of the disk
     range: f32,
-    cos_inner_angle: f32,    // Angle of the spotlight
-    cos_outer_angle: f32,    // Angle of the spotlight
-    u_axis: vec4<f32>,    // U axis for rectangle // 4 * 4 = 16
-    v_axis: vec4<f32>,    // V axis for rectangle // 4 * 4 = 16
-    twosided: u32,       // Whether the rectangle emits light on both sides
-    _pad1: u32,     // Padding to ensure alignment
-    _pad2: u32,     // Padding to ensure alignment
-    _pad3: u32,     // Padding to ensure alignment
+    cos_inner_angle: f32,
+    // Angle of the spotlight
+    cos_outer_angle: f32,
+    // Angle of the spotlight
+    u_axis: vec4<f32>,
+    // U axis for rectangle // 4 * 4 = 16
+    v_axis: vec4<f32>,
+    // V axis for rectangle // 4 * 4 = 16
+    twosided: u32,
+    // Whether the rectangle emits light on both sides
+    _pad1: u32,
+    // Padding to ensure alignment
+    _pad2: u32,
+    // Padding to ensure alignment
+    _pad3: u32,
+    // Padding to ensure alignment
 }
 
 struct RectLight {
-    position: vec4<f32>, // Position in world space
-    direction: vec4<f32>, // Direction of the spotlight
-    u_axis: vec4<f32>,    // U axis for rectangle // 4 * 4 = 16
-    v_axis: vec4<f32>,    // V axis for rectangle // 4 * 4 = 16
-    intensity: vec4<f32>, // Light intensity
-    twosided: u32,       // Whether the rectangle emits light on both sides
-    _pad1: u32,     // Padding to ensure alignment
-    _pad2: u32,     // Padding to ensure alignment
-    _pad3: u32,     // Padding to ensure alignment
+    position: vec4<f32>,
+    // Position in world space
+    direction: vec4<f32>,
+    // Direction of the spotlight
+    u_axis: vec4<f32>,
+    // U axis for rectangle // 4 * 4 = 16
+    v_axis: vec4<f32>,
+    // V axis for rectangle // 4 * 4 = 16
+    intensity: vec4<f32>,
+    // Light intensity
+    twosided: u32,
+    // Whether the rectangle emits light on both sides
+    _pad1: u32,
+    // Padding to ensure alignment
+    _pad2: u32,
+    // Padding to ensure alignment
+    _pad3: u32,
+    // Padding to ensure alignment
 }
 
 struct InfiniteLight {
-    intensity: vec4<f32>, // Light intensity
-    indices: vec4<i32>, // Indices for the light texture
-    inv_matrix: mat4x4<f32>, // Inverse matrix for the light texture
+    intensity: vec4<f32>,
+    // Light intensity
+    indices: vec4<i32>,
+    // Indices for the light texture
+    inv_matrix: mat4x4<f32>,
+    // Inverse matrix for the light texture
     //_pad2: vec4<f32>,     // Padding to ensure alignment
     //_pad3: vec4<f32>,     // Padding to ensure alignment
 }
@@ -79,13 +110,11 @@ struct LTCShadeInput {
 }
 
 // global uniforms
-@group(0)
-@binding(0)
+@group(0) @binding(0)
 var<uniform> global_uniforms: GlobalUniforms;
 
 // local uniforms
-@group(1)
-@binding(0)
+@group(1) @binding(0)
 var<uniform> local_uniforms: LocalUniforms;
 
 


### PR DESCRIPTION
This pull request mainly refactors shader code in `assets/shaders/arealight_diffuse.wgsl` and `assets/shaders/include/lighting_surface_header.wgsl` for improved readability and consistency. The changes focus on formatting, code comments, and uniform declaration style, without affecting shader logic or functionality.

**Code formatting and consistency improvements:**

* Changed uniform variable group and binding annotations to use a single line format (e.g., `@group(0) @binding(0)`) for consistency across both shader files. [[1]](diffhunk://#diff-7be40d9bb6c73f98b2a28b0b3bdc3b167bbf08e745f70f754cf264f78de242b8L5-L37) [[2]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL82-R117)
* Moved inline comments to their own lines in struct definitions for `GlobalUniforms`, `LocalUniforms`, and all light types, making the code easier to read and maintain. [[1]](diffhunk://#diff-7be40d9bb6c73f98b2a28b0b3bdc3b167bbf08e745f70f754cf264f78de242b8L5-L37) [[2]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL6-R13) [[3]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL26-R100)

**Minor syntax and style adjustments:**

* Reformatted function and struct declarations for improved clarity, such as collapsing parameters to a single line and adjusting struct closing syntax.
* Added spacing and line breaks in shader code to enhance readability, especially in the vertex and fragment shader functions. [[1]](diffhunk://#diff-7be40d9bb6c73f98b2a28b0b3bdc3b167bbf08e745f70f754cf264f78de242b8L47-R57) [[2]](diffhunk://#diff-7be40d9bb6c73f98b2a28b0b3bdc3b167bbf08e745f70f754cf264f78de242b8L91-R89)
* Broke up compound statements and added explanatory comments for key vector math operations in the fragment shader.

No functional or logic changes were made in this PR.