### PR TITLE
Add include guard

### DIFF
--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -1,3 +1,6 @@
+#ifndef LIGHTING_SURFACE_FOOTER_WGSL
+#define LIGHTING_SURFACE_FOOTER_WGSL
+
 // Lighting surface footer definitions
 //-------------------------------------------------------
 // light uniforms
@@ -712,3 +715,4 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     return vec4<f32>(color, 1.0);
 }
 
+#endif // LIGHTING_SURFACE_FOOTER_WGSL

--- a/assets/shaders/include/lighting_surface_header.wgsl
+++ b/assets/shaders/include/lighting_surface_header.wgsl
@@ -1,3 +1,6 @@
+#ifndef LIGHTING_SURFACE_HEADER_WGSL
+#define LIGHTING_SURFACE_HEADER_WGSL
+
 // Lighting surface header definitions
 struct GlobalUniforms {
     world_to_camera: mat4x4<f32>,
@@ -117,4 +120,4 @@ var<uniform> global_uniforms: GlobalUniforms;
 @group(1) @binding(0)
 var<uniform> local_uniforms: LocalUniforms;
 
-
+#endif

--- a/src/io/export/pbrt/save.rs
+++ b/src/io/export/pbrt/save.rs
@@ -19,7 +19,6 @@ use crate::model::scene::MaterialComponent;
 use crate::model::scene::MaterialProperties;
 use crate::model::scene::Node;
 use crate::model::scene::OptionProperties;
-use crate::model::scene::Properties;
 use crate::model::scene::ResourceComponent;
 use crate::model::scene::SamplerComponent;
 use crate::model::scene::SamplerProperties;
@@ -133,10 +132,10 @@ impl PbrtSaver {
 
     fn write_property(
         &self,
-        indent: usize,
-        key_type: &str,
+        _indent: usize,
+        _key_type: &str,
         key_name: &str,
-        init: &Property,
+        _init: &Property,
         props: &ParamSet,
         writer: &mut dyn Write,
     ) -> Result<(), PbrtError> {


### PR DESCRIPTION
This pull request introduces improvements to shader include files by adding include guards, and cleans up unused code and parameters in the PBRT exporter. The changes help prevent multiple inclusion issues in shaders and simplify the Rust codebase by removing unnecessary imports and unused function parameters.

Shader include guard additions:

* Added include guards to `lighting_surface_header.wgsl` and `lighting_surface_footer.wgsl` to prevent multiple inclusion and potential compilation issues. [[1]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aR1-R3) [[2]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL120-R123) [[3]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR1-R3) [[4]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR718)

Rust code cleanup in PBRT exporter:

* Removed the unused import of `Properties` from `save.rs` and updated the `write_property` function to mark unused parameters with underscores, improving code clarity and eliminating warnings. [[1]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316L22) [[2]](diffhunk://#diff-4463376b156c2b65e5e5f0e43b0c352721cb8e2e66a1bd6d99e21e78620ca316L136-R138)