### PR TITLE
Update MicrofacetReflection

### DIFF
--- a/src/ltc/brdf_microfacet_reflection.rs
+++ b/src/ltc/brdf_microfacet_reflection.rs
@@ -138,7 +138,7 @@ fn safe_div(a: f32, b: f32) -> f32 {
     if b.abs() < 1e-6 {
         0.0
     } else {
-        (a / b).clamp(0.0, 1.0)
+        (a / b)
     }
 }
 
@@ -253,7 +253,7 @@ impl Brdf for BrdfMicrofacetReflection {
         // BRDF formula: f(wo, wi) = F * D * G / (4 * cos_theta_o * cos_theta_i)
         let value = safe_div(f * d * g, 4.0 * cos_theta_o * cos_theta_i);
         // Compute PDF
-        let pdf = distribution.pdf(&wo, &wh) / (4.0 * v_dot_wh.abs());
+        let pdf = safe_div(distribution.pdf(&wo, &wh), 4.0 * v_dot_wh.abs());
 
         (value, pdf)
     }

--- a/src/ltc/parameters.rs
+++ b/src/ltc/parameters.rs
@@ -6,7 +6,7 @@ use std::f32::consts::PI;
 pub const N: usize = 64;
 
 // Number of samples used to compute the error during fitting
-pub const NSAMPLE: usize = 32;
+pub const NSAMPLE: usize = 128;
 
 // Minimal roughness (avoid singularities)
 pub const MIN_ALPHA: f32 = 0.00001;


### PR DESCRIPTION
This pull request makes targeted improvements to the microfacet reflection BRDF implementation and parameter fitting process. The main changes involve increasing the number of fitting samples for better accuracy and refining how division is handled in the BRDF calculations.

Parameter fitting update:
* Increased the number of samples used for error computation during fitting by changing `NSAMPLE` from 32 to 128 in `src/ltc/parameters.rs`, which should improve the accuracy of the fitting process.

BRDF calculation improvements:
* Removed clamping from the result of the division in the `safe_div` function in `src/ltc/brdf_microfacet_reflection.rs`, allowing the output to be unconstrained and potentially more physically accurate.
* Updated the PDF computation in the `BrdfMicrofacetReflection` implementation to use the new `safe_div` logic, ensuring consistency and improved numerical stability.