### PR TITLE
Add Metal Material

### DIFF
--- a/assets/shaders/metal.wgsl
+++ b/assets/shaders/metal.wgsl
@@ -1,0 +1,89 @@
+#define ENABLE_DIFFUSE 1
+#define ENABLE_SPECULAR 1
+
+#include "lighting_surface_header.wgsl"
+//-------------------------------------------------------
+// material definitions
+
+// material uniforms
+struct MaterialUniforms {
+    eta: vec4<f32>,
+    k: vec4<f32>,
+    roughness: f32,
+    _pad1: i32,
+    _pad2: i32,
+    _pad3: i32,
+}
+
+@group(2)
+@binding(0)
+var<uniform> material_uniforms: MaterialUniforms;
+
+#ifdef USE_TEXTURE_ETA
+@group(2)
+@binding(1)
+var eta_texture: texture_2d<f32>;
+
+@group(2)
+@binding(2)
+var eta_sampler: sampler;
+
+fn sample_eta(uv: vec2<f32>) -> vec3<f32> {
+    let modified_uv = material_uniforms.eta.xy * uv + material_uniforms.eta.zw;
+    let diff = textureSample(eta_texture, eta_sampler, modified_uv).rgb;
+    return diff;
+}
+#else
+fn sample_eta(uv: vec2<f32>) -> vec3<f32> {
+    return material_uniforms.eta.xyz;
+}
+#endif
+
+#ifdef USE_TEXTURE_K
+@group(2)
+@binding(1)
+var k_texture: texture_2d<f32>;
+
+@group(2)
+@binding(2)
+var k_sampler: sampler;
+
+fn sample_k(uv: vec2<f32>) -> vec3<f32> {
+    let modified_uv = material_uniforms.k.xy * uv + material_uniforms.k.zw;
+    let spec = textureSample(k_texture, k_sampler, modified_uv).rgb;
+    return spec;
+}
+#else
+fn sample_k(uv: vec2<f32>) -> vec3<f32> {
+    return material_uniforms.k.xyz;
+}
+#endif
+
+fn lambertian_reflection(r: vec3<f32>) -> vec3<f32> {;
+    return r * INV_PI;
+}
+
+fn matte(wo: vec3<f32>, wi: vec3<f32>, uv: vec2<f32>) -> vec3<f32> {
+    let diffuse = max(dot(vec3<f32>(0.0, 0.0, 1.0), wi), 0.0);
+    let m_kd = sample_eta(uv);
+    let c1 = lambertian_reflection(m_kd);
+    return diffuse * c1;
+}
+
+fn shade(intensity: vec3<f32>, wo: vec3<f32>, wi: vec3<f32>, uv: vec2<f32>) -> vec3<f32> {
+    return matte(wo, wi, uv) * intensity;
+}
+
+fn sample_roughness(uv: vec2<f32>) -> f32 {
+    return max(material_uniforms.roughness, 0.08);// cannot < 0.08
+}
+
+fn shade_ltc(input: LTCShadeInput) -> vec3<f32> {
+    let m_eta = sample_eta(input.uv);
+    let m_k = sample_k(input.uv);
+    return m_eta * input.diffuse + input.specular * (m_k * input.fresnel.x + (vec3<f32>(1.0) - m_k) * input.fresnel.y);
+}
+
+//-------------------------------------------------------
+
+#include "lighting_surface_footer.wgsl"

--- a/src/render/wgpu/render_mesh_item.rs
+++ b/src/render/wgpu/render_mesh_item.rs
@@ -320,6 +320,60 @@ fn create_glass_render_passes(
     return passes;
 }
 
+fn create_metal_render_passes(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    material: &Material,
+    resource_manager: &ResourceManager,
+    render_resource_manager: &mut RenderResourceManager,
+) -> Vec<Arc<RenderPass>> {
+    let keys = ["eta", "k"];
+    let mut uniform_values = vec![];
+    for key in keys {
+        if let Some(color) = get_color(&material.props, key, resource_manager) {
+            uniform_values.push((key.to_lowercase(), RenderUniformValue::Vec4(color)));
+        } else if let Some(texture) = get_texture(
+            &material.props,
+            key,
+            resource_manager,
+            render_resource_manager,
+        ) {
+            let texture = render_resource_manager
+                .get_texture(texture.get_id())
+                .unwrap();
+            uniform_values.push((
+                key.to_lowercase(),
+                RenderUniformValue::Texture(texture.clone()),
+            ));
+        } else {
+            uniform_values.push((
+                key.to_lowercase(),
+                RenderUniformValue::Vec4([1.0, 1.0, 1.0, 1.0]),
+            ));
+        }
+    }
+    let mut roughness = get_float(&material.props, "roughness").unwrap_or(0.1);
+    let remaproughness = get_bool(&material.props, "remaproughness").unwrap_or(true);
+    if remaproughness {
+        roughness = roughness_to_alpha(roughness);
+    }
+    uniform_values.push((
+        "roughness".to_string(),
+        RenderUniformValue::Float(roughness),
+    ));
+    //println!("{}: Plastic Shader Type: {}", material.get_name(),shader_type);
+    let render_pass = create_render_pass(
+        device,
+        queue,
+        "metal",
+        RenderCategory::Opaque,
+        &uniform_values,
+        "microfacet_reflection",
+        render_resource_manager,
+    );
+    return vec![render_pass];
+}
+
 fn create_render_material_from_material(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
@@ -384,6 +438,16 @@ fn create_render_material_from_material(
             passes.extend(new_passes);
         }
         */
+        "metal" => {
+            let new_passes = create_metal_render_passes(
+                device,
+                queue,
+                material,
+                resource_manager,
+                render_resource_manager,
+            );
+            passes.extend(new_passes);
+        }
         _ => {
             let new_passes = create_basic_render_passes(
                 device,


### PR DESCRIPTION
This pull request introduces support for rendering "metal" materials in the rendering pipeline. The main changes include adding a new WGSL shader for metal materials, implementing logic to handle metal material properties and uniforms, and integrating the new metal render pass into the material system.

**Metal material support:**

* Added a new shader file `metal.wgsl` that defines uniforms and functions for handling metal material properties, including support for eta, k, and roughness parameters, as well as optional texture sampling for these properties. (`assets/shaders/metal.wgsl`)

**Render pipeline integration:**

* Implemented the `create_metal_render_passes` function in `render_mesh_item.rs` to set up the appropriate uniforms and textures for metal materials and create the corresponding render pass. (`src/render/wgpu/render_mesh_item.rs`)
* Updated the `create_render_material_from_material` function to invoke the new metal render pass creation logic when a material of type "metal" is encountered. (`src/render/wgpu/render_mesh_item.rs`)