### PR TITLE
Format ltc

### DIFF
--- a/src/bin/fit-ltc.rs
+++ b/src/bin/fit-ltc.rs
@@ -39,7 +39,12 @@ struct Options {
     #[arg(short = 'h', long = "height", default_value_t = N, help = "Table height (default: 64)")]
     table_height: usize,
 
-    #[arg(short = 'n', long, default_value_t = 32, help = "Number of samples for fitting (default: 32)")]
+    #[arg(
+        short = 'n',
+        long,
+        default_value_t = 32,
+        help = "Number of samples for fitting (default: 32)"
+    )]
     nsample: usize,
 }
 
@@ -88,7 +93,12 @@ fn main() -> Result<(), String> {
     println!("Number of samples: {}", options.nsample);
     println!();
 
-    let (tab, tab_mag_fresnel) = fit_tab(brdf.as_ref(), options.width, options.table_height, options.nsample);
+    let (tab, tab_mag_fresnel) = fit_tab(
+        brdf.as_ref(),
+        options.width,
+        options.table_height,
+        options.nsample,
+    );
 
     println!();
     println!("Generating sphere table...");

--- a/src/ltc/fit_tab.rs
+++ b/src/ltc/fit_tab.rs
@@ -16,7 +16,12 @@ use glam::{Mat3, Vec2, Vec3};
 ///
 /// # Returns
 /// * Tuple of (tab, tab_mag_fresnel) where both are flattened width*height vectors
-pub fn fit_tab(brdf: &dyn Brdf, width: usize, height: usize, nsample: usize) -> (Vec<Mat3>, Vec<Vec2>) {
+pub fn fit_tab(
+    brdf: &dyn Brdf,
+    width: usize,
+    height: usize,
+    nsample: usize,
+) -> (Vec<Mat3>, Vec<Vec2>) {
     let mut tab = vec![Mat3::IDENTITY; width * height];
     let mut tab_mag_fresnel = vec![Vec2::ZERO; width * height];
 

--- a/src/ltc/fitter.rs
+++ b/src/ltc/fitter.rs
@@ -9,7 +9,12 @@ use glam::Vec3;
 /// - norm (albedo) of the BRDF
 /// - average Schlick Fresnel value
 /// - average direction of the BRDF
-pub fn compute_avg_terms(brdf: &dyn Brdf, V: &Vec3, alpha: f32, nsample: usize) -> (f32, f32, Vec3) {
+pub fn compute_avg_terms(
+    brdf: &dyn Brdf,
+    V: &Vec3,
+    alpha: f32,
+    nsample: usize,
+) -> (f32, f32, Vec3) {
     let mut norm = 0.0;
     let mut fresnel = 0.0;
     let mut average_dir = Vec3::ZERO;
@@ -115,7 +120,14 @@ pub struct FitLTC<'a> {
 }
 
 impl<'a> FitLTC<'a> {
-    pub fn new(ltc: &'a mut LTC, brdf: &'a dyn Brdf, V: Vec3, alpha: f32, isotropic: bool, nsample: usize) -> Self {
+    pub fn new(
+        ltc: &'a mut LTC,
+        brdf: &'a dyn Brdf,
+        V: Vec3,
+        alpha: f32,
+        isotropic: bool,
+        nsample: usize,
+    ) -> Self {
         Self {
             ltc,
             brdf,

--- a/tests/ltc_fit_cli.rs
+++ b/tests/ltc_fit_cli.rs
@@ -291,7 +291,10 @@ fn test_ltc_fit_custom_nsample() {
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Verify that the output mentions the custom nsample value
-        assert!(stdout.contains("Number of samples: 16"), "Should show custom nsample value");
+        assert!(
+            stdout.contains("Number of samples: 16"),
+            "Should show custom nsample value"
+        );
 
         let code_path = temp_dir.path().join("ltc_ggx.rs");
         assert!(code_path.exists(), "Code file should be created");
@@ -321,7 +324,10 @@ fn test_ltc_fit_default_nsample() {
     if output.status.success() {
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Verify that the output mentions the default nsample value
-        assert!(stdout.contains("Number of samples: 32"), "Should show default nsample value of 32");
+        assert!(
+            stdout.contains("Number of samples: 32"),
+            "Should show default nsample value of 32"
+        );
 
         let code_path = temp_dir.path().join("ltc_ggx.rs");
         assert!(code_path.exists(), "Code file should be created");


### PR DESCRIPTION
This pull request focuses on improving code readability and maintainability by reformatting function and method signatures to use multi-line argument lists, and by enhancing test assertion formatting for clarity. No functional changes to logic or behavior are introduced.

Formatting improvements:

* Reformatted function signatures in `fit_tab`, `compute_avg_terms`, and the `FitLTC::new` constructor to use multi-line argument lists for better readability. [[1]](diffhunk://#diff-8b67b3e37f49307c4644faedc142eeaa4b66ed4ae4295121a08faad47ed7c060L19-R24) [[2]](diffhunk://#diff-e32def431e5b0955b044abb51e6966575ceb98128f2bcfa849f1c1564829ef59L12-R17) [[3]](diffhunk://#diff-e32def431e5b0955b044abb51e6966575ceb98128f2bcfa849f1c1564829ef59L118-R130)

Test clarity enhancements:

* Reformatted assertions in `test_ltc_fit_custom_nsample` and `test_ltc_fit_default_nsample` to use multi-line formatting, improving readability of test failure messages. [[1]](diffhunk://#diff-8088082eda43dfbaee1361e5061417471b63839602982c3ff7e21fe7d77fc49eL294-R297) [[2]](diffhunk://#diff-8088082eda43dfbaee1361e5061417471b63839602982c3ff7e21fe7d77fc49eL324-R330)