### PR TITLE
Feature/ltc all2

### DIFF
--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -553,7 +553,8 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #else
         let specular = vec3<f32>(0.0);
 #endif
-        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel);
+        let wi = tbn * -direction;// object to light vector
+        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel, wo, wi);
 
         var k = 1.0;//1.0 / (2.0 * PI * PI);
         color += k * intensity * shade(shade_input);
@@ -620,6 +621,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let specular = vec3<f32>(0.0);
 #endif
 
+        let wi = tbn * -direction;// object to light vector
+        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel, wo, wi);
+
         var k = 4.0;// 1.0 / (2.0 * PI * PI);
         var area = PI * disk_radius * disk_radius;          // Area of the disk
         if is_delta {
@@ -627,7 +631,6 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
             area = 1.0;
         }
         var attenuation = calc_attenuation(disk_distance);
-        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel);
         color += k * area * intensity * attenuation * shade(shade_input);
     }
 
@@ -679,6 +682,10 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #else
         let specular = vec3<f32>(0.0);
 #endif
+
+        let wi = tbn * -direction;// object to light vector
+        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel, wo, wi);
+
         var k = 1.0 / (2.0 * PI * PI);
         var area = PI * radius * radius;
         var falloff = 1.0; // full light for disk area light
@@ -691,7 +698,6 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
             falloff = pow(falloff, 4.0);
         }
         var attenuation = calc_attenuation(distance);
-        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel);
         color += k * area * intensity * attenuation * falloff * shade(shade_input);
     }
 
@@ -733,10 +739,12 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #else   
         let specular = vec3<f32>(0.0);
 #endif
+        let wi = tbn * -direction;// object to light vector
+        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel, wo, wi);
+
         let k = 1.0 / (2.0 * PI * PI);
         let area = 1.0;
         let attenuation = calc_attenuation(distance);
-        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel);
         color += k * area * intensity * attenuation * shade(shade_input);
     }
 
@@ -761,7 +769,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let diffuse = vec3<f32>(0.0);
 #endif
         let specular = vec3<f32>(0.0);
-        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel);
+        
+        let wi = tbn * r;// object to light vector
+        let shade_input = ShadeInput(diffuse, specular, in.uv, fresnel, wo, wi);
         color += intensity * shade(shade_input);
     }
     

--- a/assets/shaders/include/lighting_surface_header.wgsl
+++ b/assets/shaders/include/lighting_surface_header.wgsl
@@ -113,6 +113,8 @@ struct ShadeInput {
     specular: vec3<f32>,
     uv: vec2<f32>,
     fresnel: vec2<f32>,
+    wo: vec3<f32>, // Viewing direction
+    wi: vec3<f32>, // Light direction
 }
 
 // global uniforms

--- a/assets/shaders/metal.wgsl
+++ b/assets/shaders/metal.wgsl
@@ -1,4 +1,4 @@
-#define ENABLE_DIFFUSE 1
+//#define ENABLE_DIFFUSE 1
 #define ENABLE_SPECULAR 1
 
 #include "lighting_surface_header.wgsl"
@@ -63,10 +63,32 @@ fn sample_roughness(uv: vec2<f32>) -> f32 {
     return max(material_uniforms.roughness, 0.08);// cannot < 0.08
 }
 
+//-------------------------------------------------------
+// BRDF functions
+fn fresnel_conductor(cos_theta: f32, eta: vec3<f32>, k: vec3<f32>) -> vec3<f32> {
+    let cos2 = cos_theta * cos_theta;
+    let sin2 = 1.0 - cos2;
+    let eta2 = eta * eta;
+    let k2 = k * k;
+
+    let t0 = eta2 - k2 - vec3<f32>(sin2, sin2, sin2);
+    let a2plusb2 = sqrt(t0 * t0 + 4.0 * eta2 * k2);
+    let t1 = a2plusb2 + vec3<f32>(cos2, cos2, cos2);
+    let a = sqrt(0.5 * (a2plusb2 + t0));
+    let t2 = 2.0 * cos_theta * a;
+    let Rs = (t1 - t2) / (t1 + t2);
+
+    let t3 = cos2 * a2plusb2 + vec3<f32>(sin2 * sin2, sin2 * sin2, sin2 * sin2);
+    let t4 = t2 * sin2;
+    let Rp = Rs * (t3 - t4) / (t3 + t4);
+
+    return 0.5 * (Rp + Rs);
+}
+
 fn shade(input: ShadeInput) -> vec3<f32> {
     let m_eta = sample_eta(input.uv);
     let m_k = sample_k(input.uv);
-    return m_eta * input.diffuse + input.specular * (m_k * input.fresnel.x + (vec3<f32>(1.0) - m_k) * input.fresnel.y);
+    return input.specular * m_eta;//fresnel_conductor(input.V, input.L, m_eta, m_k);
 }
 
 //-------------------------------------------------------

--- a/assets/shaders/metal.wgsl
+++ b/assets/shaders/metal.wgsl
@@ -67,18 +67,19 @@ fn sample_roughness(uv: vec2<f32>) -> f32 {
 // BRDF functions
 fn fresnel_conductor(cos_theta: f32, eta: vec3<f32>, k: vec3<f32>) -> vec3<f32> {
     let cos2 = cos_theta * cos_theta;
-    let sin2 = 1.0 - cos2;
+    let sin2 = max(1.0 - cos2, 0.0);
     let eta2 = eta * eta;
     let k2 = k * k;
 
     let t0 = eta2 - k2 - vec3<f32>(sin2, sin2, sin2);
     let a2plusb2 = sqrt(t0 * t0 + 4.0 * eta2 * k2);
     let t1 = a2plusb2 + vec3<f32>(cos2, cos2, cos2);
-    let a = sqrt(0.5 * (a2plusb2 + t0));
+    let a = sqrt(0.5 * abs(a2plusb2 + t0));
     let t2 = 2.0 * cos_theta * a;
     let Rs = (t1 - t2) / (t1 + t2);
 
-    let t3 = cos2 * a2plusb2 + vec3<f32>(sin2 * sin2, sin2 * sin2, sin2 * sin2);
+    let sin4 = sin2 * sin2;
+    let t3 = cos2 * a2plusb2 + vec3<f32>(sin4, sin4, sin4);
     let t4 = t2 * sin2;
     let Rp = Rs * (t3 - t4) / (t3 + t4);
 
@@ -88,7 +89,9 @@ fn fresnel_conductor(cos_theta: f32, eta: vec3<f32>, k: vec3<f32>) -> vec3<f32> 
 fn shade(input: ShadeInput) -> vec3<f32> {
     let m_eta = sample_eta(input.uv);
     let m_k = sample_k(input.uv);
-    return input.specular * m_eta;//fresnel_conductor(input.V, input.L, m_eta, m_k);
+    let h = normalize(input.wi + input.wo);
+    let cos_theta_i = max(dot(input.wi, h), 0.0);
+    return input.specular * fresnel_conductor(cos_theta_i, m_eta, m_k);
 }
 
 //-------------------------------------------------------

--- a/src/ltc/fitter.rs
+++ b/src/ltc/fitter.rs
@@ -30,7 +30,7 @@ pub fn compute_avg_terms(
             // Eval
             let (eval, pdf) = brdf.eval(V, &L, alpha);
 
-            if pdf > 0.0 && eval > 0.0 {
+            if pdf > 0.0 {
                 let weight = eval / pdf;
                 let fresnel_val = brdf.fresnel(V, &L);
                 // Accumulate


### PR DESCRIPTION
This pull request updates the shading pipeline to support a more physically accurate BRDF for metals, specifically by adding support for conductor Fresnel calculations and updating the data passed to the shading function. The most significant changes are the addition of new fields to the `ShadeInput` struct, updates to how the shading function is called throughout the lighting code, and the introduction of a conductor Fresnel function in the metal shader.

**Shading pipeline improvements:**

* Added `wo` (view direction) and `wi` (light direction) fields to the `ShadeInput` struct in `lighting_surface_header.wgsl`, enabling more accurate BRDF calculations.
* Updated all calls to `ShadeInput` in `lighting_surface_footer.wgsl` to include the new `wo` and `wi` parameters, ensuring all lighting calculations use the correct directions. [[1]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL556-R557) [[2]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR624-L630) [[3]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR685-R688) [[4]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL694) [[5]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR742-L739) [[6]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faL764-R774)

**Physically-based metal shading:**

* Implemented a `fresnel_conductor` function in `metal.wgsl` for accurate conductor (metal) Fresnel reflection calculations, and updated the `shade` function to use this for specular reflection.
* Disabled diffuse shading for metals in `metal.wgsl` by commenting out the `ENABLE_DIFFUSE` define, ensuring only specular reflection is used for metals.

**Minor improvements:**

* Relaxed a check in `ltc/fitter.rs` so that BRDF samples with `pdf > 0.0` are included, even if the evaluation is zero, potentially improving robustness of LTC fitting.