### PR TITLE
Update glass material

### DIFF
--- a/assets/shaders/glass_reflection.wgsl
+++ b/assets/shaders/glass_reflection.wgsl
@@ -3,6 +3,8 @@
 
 #include "lighting_surface_header.wgsl"
 //-------------------------------------------------------
+#include "fresnel_functions.wgsl"
+//-------------------------------------------------------
 // material definitions
 
 // material uniforms
@@ -37,30 +39,6 @@ fn sample_kr(uv: vec2<f32>) -> vec3<f32> {
     return material_uniforms.kr.xyz;
 }
 #endif
-
-fn fresnel_dielectric(cos_theta_i_: f32, eta_i_: f32, eta_t_: f32) -> f32 {
-    var cos_theta_i = clamp(cos_theta_i_, -1.0, 1.0);
-    var eta_i = eta_i_;
-    var eta_t = eta_t_;
-    let entering = cos_theta_i > 0.0;
-    if (!entering) {
-        let temp = eta_i;
-        eta_i = eta_t;
-        eta_t = temp;
-        cos_theta_i = abs(cos_theta_i);
-    }
-    let sin_theta_i = sqrt(max(0.0, 1.0 - cos_theta_i * cos_theta_i));
-    let sin_theta_t = eta_i / eta_t * sin_theta_i;
-    if (sin_theta_t >= 1.0) {
-        return 1.0; // total internal reflection
-    }
-    let cos_theta_t = sqrt(max(0.0, 1.0 - sin_theta_t * sin_theta_t));
-    let r_parl = ((eta_t * cos_theta_i) - (eta_i * cos_theta_t)) /
-                 ((eta_t * cos_theta_i) + (eta_i * cos_theta_t));
-    let r_perp = ((eta_i * cos_theta_i) - (eta_t * cos_theta_t)) /
-                 ((eta_i * cos_theta_i) + (eta_t * cos_theta_t));
-    return (r_parl * r_parl + r_perp * r_perp) * 0.5;
-}
 
 fn sample_roughness(uv: vec2<f32>) -> f32 {
     return max(material_uniforms.roughness, 0.08);// cannot < 0.08

--- a/assets/shaders/glass_transmission.wgsl
+++ b/assets/shaders/glass_transmission.wgsl
@@ -4,6 +4,8 @@
 
 #include "lighting_surface_header.wgsl"
 //-------------------------------------------------------
+#include "fresnel_functions.wgsl"
+//-------------------------------------------------------
 // material definitions
 
 // material uniforms
@@ -18,30 +20,6 @@ struct MaterialUniforms {
 @group(2)
 @binding(0)
 var<uniform> material_uniforms: MaterialUniforms;
-
-fn fresnel_dielectric(cos_theta_i_: f32, eta_i_: f32, eta_t_: f32) -> f32 {
-    var cos_theta_i = clamp(cos_theta_i_, -1.0, 1.0);
-    var eta_i = eta_i_;
-    var eta_t = eta_t_;
-    let entering = cos_theta_i > 0.0;
-    if (!entering) {
-        let temp = eta_i;
-        eta_i = eta_t;
-        eta_t = temp;
-        cos_theta_i = abs(cos_theta_i);
-    }
-    let sin_theta_i = sqrt(max(0.0, 1.0 - cos_theta_i * cos_theta_i));
-    let sin_theta_t = eta_i / eta_t * sin_theta_i;
-    if (sin_theta_t >= 1.0) {
-        return 1.0; // total internal reflection
-    }
-    let cos_theta_t = sqrt(max(0.0, 1.0 - sin_theta_t * sin_theta_t));
-    let r_parl = ((eta_t * cos_theta_i) - (eta_i * cos_theta_t)) /
-                 ((eta_t * cos_theta_i) + (eta_i * cos_theta_t));
-    let r_perp = ((eta_i * cos_theta_i) - (eta_t * cos_theta_t)) /
-                 ((eta_i * cos_theta_i) + (eta_t * cos_theta_t));
-    return (r_parl * r_parl + r_perp * r_perp) * 0.5;
-}
 
 fn sample_roughness(uv: vec2<f32>) -> f32 {
     return max(material_uniforms.roughness, 0.08);// cannot < 0.08

--- a/assets/shaders/include/fresnel_functions.wgsl
+++ b/assets/shaders/include/fresnel_functions.wgsl
@@ -1,0 +1,28 @@
+#ifndef FRESNEL_FUNCTIONS_WGSL
+#define FRESNEL_FUNCTIONS_WGSL
+
+fn fresnel_dielectric(cos_theta_i_: f32, eta_i_: f32, eta_t_: f32) -> f32 {
+    var cos_theta_i = clamp(cos_theta_i_, -1.0, 1.0);
+    var eta_i = eta_i_;
+    var eta_t = eta_t_;
+    let entering = cos_theta_i > 0.0;
+    if (!entering) {
+        let temp = eta_i;
+        eta_i = eta_t;
+        eta_t = temp;
+        cos_theta_i = abs(cos_theta_i);
+    }
+    let sin_theta_i = sqrt(max(0.0, 1.0 - cos_theta_i * cos_theta_i));
+    let sin_theta_t = eta_i / eta_t * sin_theta_i;
+    if (sin_theta_t >= 1.0) {
+        return 1.0; // total internal reflection
+    }
+    let cos_theta_t = sqrt(max(0.0, 1.0 - sin_theta_t * sin_theta_t));
+    let r_parl = ((eta_t * cos_theta_i) - (eta_i * cos_theta_t)) /
+                 ((eta_t * cos_theta_i) + (eta_i * cos_theta_t));
+    let r_perp = ((eta_i * cos_theta_i) - (eta_t * cos_theta_t)) /
+                 ((eta_i * cos_theta_i) + (eta_t * cos_theta_t));
+    return (r_parl * r_parl + r_perp * r_perp) * 0.5;
+}
+
+#endif


### PR DESCRIPTION
This pull request refactors how the `fresnel_dielectric` function is shared between the glass reflection and transmission shaders. The function is now defined in a new shared include file, which is then imported by both shaders to avoid code duplication and improve maintainability.

**Shader code deduplication and maintainability:**

* Created a new shared file, `fresnel_functions.wgsl`, containing the `fresnel_dielectric` function to centralize Fresnel logic and prevent code duplication.
* Updated both `glass_reflection.wgsl` and `glass_transmission.wgsl` to include the new `fresnel_functions.wgsl` file, removing their local copies of the `fresnel_dielectric` function. [[1]](diffhunk://#diff-0407e9ac46086fbb2f4a348dc1f24306b79f45cfc1f79e8d2fe3c2b7a6c01067R6-R7) [[2]](diffhunk://#diff-965e9ea54990fc17cf5da8795db54227f7f28e426f81ae9a65ea02abbd97ae76R7-R8) [[3]](diffhunk://#diff-0407e9ac46086fbb2f4a348dc1f24306b79f45cfc1f79e8d2fe3c2b7a6c01067L41-L64) [[4]](diffhunk://#diff-965e9ea54990fc17cf5da8795db54227f7f28e426f81ae9a65ea02abbd97ae76L22-L45)