### PR TITLE
Update texture binding

### DIFF
--- a/assets/shaders/lambertian.wgsl
+++ b/assets/shaders/lambertian.wgsl
@@ -38,11 +38,11 @@ fn sample_kd(uv: vec2<f32>) -> vec3<f32> {
 
 #ifdef USE_TEXTURE_BUMPMAP
 @group(2)
-@binding(1)
+@binding(3)
 var bumpmap_texture: texture_2d<f32>;
 
 @group(2)
-@binding(2)
+@binding(4)
 var bumpmap_sampler: sampler;
 #endif
 

--- a/assets/shaders/metal.wgsl
+++ b/assets/shaders/metal.wgsl
@@ -41,11 +41,11 @@ fn sample_eta(uv: vec2<f32>) -> vec3<f32> {
 
 #ifdef USE_TEXTURE_K
 @group(2)
-@binding(1)
+@binding(3)
 var k_texture: texture_2d<f32>;
 
 @group(2)
-@binding(2)
+@binding(4)
 var k_sampler: sampler;
 
 fn sample_k(uv: vec2<f32>) -> vec3<f32> {

--- a/assets/shaders/plastic.wgsl
+++ b/assets/shaders/plastic.wgsl
@@ -41,11 +41,11 @@ fn sample_kd(uv: vec2<f32>) -> vec3<f32> {
 
 #ifdef USE_TEXTURE_KS
 @group(2)
-@binding(1)
+@binding(3)
 var ks_texture: texture_2d<f32>;
 
 @group(2)
-@binding(2)
+@binding(4)
 var ks_sampler: sampler;
 
 fn sample_ks(uv: vec2<f32>) -> vec3<f32> {

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -5,7 +5,6 @@ use super::render_item::RenderItem;
 use super::shader::RenderShader;
 use super::texture::RenderTexture;
 use crate::render::wgpu::light::RenderLight;
-use crate::render::wgpu::texture;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -5,6 +5,7 @@ use super::render_item::RenderItem;
 use super::shader::RenderShader;
 use super::texture::RenderTexture;
 use crate::render::wgpu::light::RenderLight;
+use crate::render::wgpu::texture;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -153,7 +154,7 @@ struct MaterialBindGroupEntry {
     #[allow(dead_code)]
     pub uniform_buffer: wgpu::Buffer,
     #[allow(dead_code)]
-    pub textures: Vec<Arc<RenderTexture>>,
+    pub textures: Vec<Option<Arc<RenderTexture>>>,
 
     pub ltc_bind_group: Option<wgpu::BindGroup>,
     #[allow(dead_code)]
@@ -440,14 +441,18 @@ impl LightingMeshRenderer {
 
         let material_binding_offset = 1;
         for (i, texture) in render_pass.textures.iter().enumerate() {
-            entries.push(wgpu::BindGroupEntry {
-                binding: (material_binding_offset + 2 * i + 0) as u32,
-                resource: wgpu::BindingResource::TextureView(&texture.view),
-            });
-            entries.push(wgpu::BindGroupEntry {
-                binding: (material_binding_offset + 2 * i + 1) as u32,
-                resource: wgpu::BindingResource::Sampler(&texture.sampler),
-            });
+            let binding_texture = (material_binding_offset + 2 * i + 0) as u32;
+            let binding_sampler = (material_binding_offset + 2 * i + 1) as u32;
+            if let Some(texture) = texture {
+                entries.push(wgpu::BindGroupEntry {
+                    binding: binding_texture,
+                    resource: wgpu::BindingResource::TextureView(&texture.view),
+                });
+                entries.push(wgpu::BindGroupEntry {
+                    binding: binding_sampler,
+                    resource: wgpu::BindingResource::Sampler(&texture.sampler),
+                });
+            }
         }
 
         let material_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -950,24 +955,27 @@ impl LightingMeshRenderer {
             count: None,
         }];
         let material_binding_offset = 1;
-        let texture_size = pass.textures.len();
-        for i in 0..texture_size {
-            material_bind_group_entries.push(wgpu::BindGroupLayoutEntry {
-                binding: material_binding_offset + (2 * i + 0) as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    view_dimension: wgpu::TextureViewDimension::D2,
-                    multisampled: false,
-                },
-                count: None,
-            });
-            material_bind_group_entries.push(wgpu::BindGroupLayoutEntry {
-                binding: material_binding_offset + (2 * i + 1) as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            });
+        for (i, texture) in pass.textures.iter().enumerate() {
+            let binding_texture = material_binding_offset + (2 * i + 0) as u32;
+            let binding_sampler = material_binding_offset + (2 * i + 1) as u32;
+            if let Some(_) = texture {
+                material_bind_group_entries.push(wgpu::BindGroupLayoutEntry {
+                    binding: binding_texture,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                });
+                material_bind_group_entries.push(wgpu::BindGroupLayoutEntry {
+                    binding: binding_sampler,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                });
+            }
         }
 
         let material_bind_group_layout =

--- a/src/render/wgpu/material.rs
+++ b/src/render/wgpu/material.rs
@@ -31,7 +31,7 @@ pub struct RenderPass {
     pub shader: Arc<RenderShader>,
     pub render_category: RenderCategory, //
     pub uniform_values: Arc<Vec<u8>>,    //
-    pub textures: Vec<Arc<RenderTexture>>,
+    pub textures: Vec<Option<Arc<RenderTexture>>>,
     pub ltc_texture: Option<Arc<RenderTexture>>,
 }
 

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -464,7 +464,9 @@ pub fn create_render_pass(
     let mut textures = vec![];
     for (_name, value) in uniform_values.iter() {
         if let RenderUniformValue::Texture(texture) = value {
-            textures.push(texture.clone());
+            textures.push(Some(texture.clone()));
+        } else {
+            textures.push(None);
         }
     }
 


### PR DESCRIPTION
This pull request updates the way textures are handled and bound in the rendering pipeline, allowing for optional (nullable) textures in material and render pass structures. It also updates the associated shader binding indices to match these changes. The main goal is to support materials that may not use all possible texture slots, improving flexibility and robustness.

**Texture Handling and Bindings:**

* Changed `textures` fields in both `MaterialBindGroupEntry` and `RenderPass` structs to use `Vec<Option<Arc<RenderTexture>>>`, allowing for optional textures instead of requiring all slots to be filled. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L156-R156) [[2]](diffhunk://#diff-eff909b7434cc5a627cc038db26b311b60075a4fcf4139d788dc6ce42fd04f7dL34-R34)
* Updated texture extraction in `create_render_pass` to push `None` for missing textures, ensuring the new optional texture structure is populated correctly.

**Bind Group and Layout Logic:**

* Modified bind group and layout creation in `LightingMeshRenderer` to iterate over optional textures, only creating entries for present textures, and adjusted binding index calculations accordingly. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R443-R455) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L953-R962) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L966-R978)

**Shader Binding Indices:**

* Updated binding indices for bump, k, and ks textures and samplers in WGSL shaders to match new binding assignments, ensuring consistency between shader code and Rust-side binding logic. [[1]](diffhunk://#diff-10d3d8f03ec2d8d995aef7671818219803254cca4d74dbadb3b5b72d61dff406L41-R45) [[2]](diffhunk://#diff-41f1098bc194dee9d965d73993817e75c4c8daec6b415b8c86c28a5b79272847L44-R48) [[3]](diffhunk://#diff-997cad08bd585f9ca4854a228fdf00490e3e349e0ba03970b047c83521dc1bd0L44-R48)