### PR TITLE
Update bump

### DIFF
--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -491,9 +491,9 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     tangent = normalize(cross(bitangent, normal)); // Recompute tangent to ensure orthogonality
     
     // Apply bump map (normal map) if available
-    #ifdef USE_TEXTURE_BUMPMAP
+#ifdef USE_TEXTURE_BUMPMAP
     normal = apply_bump_map(normal, tangent, bitangent, in.uv, material_uniforms.bumpmap);
-    #endif
+#endif
     
     // Apply faceforward after bumpmap
     if dot(normal, camera_to_surface) > 0.0 {

--- a/assets/shaders/plastic.wgsl
+++ b/assets/shaders/plastic.wgsl
@@ -2,6 +2,7 @@
 #define ENABLE_SPECULAR 1
 
 #include "lighting_surface_header.wgsl"
+#include "bump_map.wgsl"
 //-------------------------------------------------------
 // material definitions
 
@@ -13,6 +14,7 @@ struct MaterialUniforms {
     _pad1: i32,
     _pad2: i32,
     _pad3: i32,
+    bumpmap: vec4<f32>,
 }
 
 @group(2)
@@ -57,6 +59,18 @@ fn sample_ks(uv: vec2<f32>) -> vec3<f32> {
 fn sample_ks(uv: vec2<f32>) -> vec3<f32> {
     return material_uniforms.ks.xyz;
 }
+#endif
+
+//
+
+#ifdef USE_TEXTURE_BUMPMAP
+@group(2)
+@binding(7)
+var bumpmap_texture: texture_2d<f32>;
+
+@group(2)
+@binding(8)
+var bumpmap_sampler: sampler;
 #endif
 
 fn sample_roughness(uv: vec2<f32>) -> f32 {

--- a/src/conversion/normal_map/convert_to_normal_map.rs
+++ b/src/conversion/normal_map/convert_to_normal_map.rs
@@ -1,9 +1,9 @@
 use image::{ImageBuffer, Luma, Rgba};
 
 /// Converts a grayscale heightmap (Luma8) to a normal map (RGBA8).
-/// 
+///
 /// The function calculates surface normals from the heightmap by computing
-/// the gradient at each pixel. The resulting normal vectors are stored in 
+/// the gradient at each pixel. The resulting normal vectors are stored in
 /// the RGB channels of the output image, with the alpha channel set to 255.
 ///
 /// # Arguments

--- a/src/conversion/texture_node/render_texture_image.rs
+++ b/src/conversion/texture_node/render_texture_image.rs
@@ -79,11 +79,7 @@ fn convert_to_linear_float_image(image: &DynaImage) -> DynaImage {
     }
 }
 
-fn resize_image(
-    image: &DynaImage,
-    width: u32,
-    height: u32,
-) -> DynaImage {
+fn resize_image(image: &DynaImage, width: u32, height: u32) -> DynaImage {
     if (1, 1) == image.dimensions() {
         let mut resized = image.resize(width, height, image::imageops::FilterType::Nearest);
         if let DynaImage::ImageLuma32F(dst) = &mut resized {

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -650,6 +650,42 @@ fn get_color_texture_from_image(
     }
 }
 
+fn covert_rgb32f_to_luma32f(
+    image: &image::Rgb32FImage,
+) -> image::ImageBuffer<image::Luma<f32>, Vec<f32>> {
+    let (width, height) = image.dimensions();
+    let mut luma_image = image::ImageBuffer::<image::Luma<f32>, Vec<f32>>::new(width, height);
+    for y in 0..height {
+        for x in 0..width {
+            let pixel = image.get_pixel(x, y);
+            let r = pixel[0];
+            let g = pixel[1];
+            let b = pixel[2];
+            // Convert RGB to luminance using standard weights
+            let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            luma_image.put_pixel(x, y, image::Luma([luma]));
+        }
+    }
+    return luma_image;
+}
+
+fn convert_rgb8_to_luma8(image: &image::RgbImage) -> image::ImageBuffer<image::Luma<u8>, Vec<u8>> {
+    let (width, height) = image.dimensions();
+    let mut luma_image = image::ImageBuffer::<image::Luma<u8>, Vec<u8>>::new(width, height);
+    for y in 0..height {
+        for x in 0..width {
+            let pixel = image.get_pixel(x, y);
+            let r = pixel[0] as f32;
+            let g = pixel[1] as f32;
+            let b = pixel[2] as f32;
+            // Convert RGB to luminance using standard weights
+            let luma = (0.2126 * r + 0.7152 * g + 0.0722 * b).min(255.0).max(0.0) as u8;
+            luma_image.put_pixel(x, y, image::Luma([luma]));
+        }
+    }
+    return luma_image;
+}
+
 fn get_normal_texture_from_image(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
@@ -674,17 +710,24 @@ fn get_normal_texture_from_image(
                 &normal_map,
             ));
         }
-        DynaImage::ImageRgb8(_) => {
-            //let img = texture_image.to_rgba8();
-            //return Some(get_normal_map_texture_from_rgba_image(device, queue, &img));
-            return None;
+        DynaImage::ImageRgb8(img) => {
+            let img = convert_rgb8_to_luma8(img);
+            let normal_map = convert_luma8_to_normal_map(&img);
+            return Some(get_normal_map_texture_from_rgba_image(
+                device,
+                queue,
+                &normal_map,
+            ));
         }
-        DynaImage::ImageRgb32F(_img) => {
+        DynaImage::ImageRgb32F(img) => {
             // todo : convert to luma32f first
-            // let img = covert_to_luma32f(img);
-            // let normal_map = convert_luma8_to_normal_map(img);
-            //return Some(get_normal_map_texture_from_rgba_image(device, queue, &img));
-            return None;
+            let img = covert_rgb32f_to_luma32f(img);
+            let normal_map = convert_luma32f_to_normal_map(&img);
+            return Some(get_normal_map_texture_from_rgba_image(
+                device,
+                queue,
+                &normal_map,
+            ));
         }
         _ => {
             return None;

--- a/src/render/wgpu/render_mesh_item.rs
+++ b/src/render/wgpu/render_mesh_item.rs
@@ -244,6 +244,29 @@ fn create_plastic_render_passes(
         "roughness".to_string(),
         RenderUniformValue::Float(roughness),
     ));
+
+    if let Some(texture) = get_texture(
+        &material.props,
+        "bumpmap",
+        resource_manager,
+        render_resource_manager,
+    ) {
+        //println!("Found bumpmap texture for plastic material");
+        let texture = render_resource_manager
+            .get_texture(texture.get_id())
+            .unwrap();
+        uniform_values.push((
+            "bumpmap".to_string(),
+            RenderUniformValue::Texture(texture.clone()),
+        ));
+    } else {
+        // Add default bumpmap uniform with identity UV transform (scale=1, offset=0)
+        // This ensures consistent MaterialUniforms structure regardless of texture presence
+        uniform_values.push((
+            "bumpmap".to_string(),
+            RenderUniformValue::Vec4([1.0, 1.0, 0.0, 0.0]), // scale=(1,1), offset=(0,0)
+        ));
+    }
     //println!("{}: Plastic Shader Type: {}", material.get_name(),shader_type);
     let render_pass = create_render_pass(
         device,


### PR DESCRIPTION
This pull request adds support for bump map textures to the plastic material shader and improves normal map generation from various image formats. The changes introduce new uniforms and shader bindings for bump mapping, and enhance the image conversion pipeline to handle RGB images for normal map creation.

**Bump Map Support in Plastic Shader:**
- Added `bumpmap` as a new uniform in the `MaterialUniforms` struct and included it in the shader via `bump_map.wgsl`. [[1]](diffhunk://#diff-997cad08bd585f9ca4854a228fdf00490e3e349e0ba03970b047c83521dc1bd0R5) [[2]](diffhunk://#diff-997cad08bd585f9ca4854a228fdf00490e3e349e0ba03970b047c83521dc1bd0R17)
- Introduced new shader bindings for bump map textures and samplers, guarded by `USE_TEXTURE_BUMPMAP`.
- Updated `create_plastic_render_passes` to support an optional bump map texture, defaulting to an identity transform if not provided.

**Normal Map Generation Improvements:**
- Added functions to convert `Rgb32FImage` and `RgbImage` to luminance images, enabling normal map generation from these formats.
- Updated `get_normal_texture_from_image` to use the new conversion functions for RGB8 and RGB32F images, allowing normal maps to be generated from a wider range of input textures.

**Minor Code Cleanup:**
- Reformatted the `resize_image` function for improved readability.