### PR TITLE
Update create_uniform_value_bytes

### DIFF
--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -250,9 +250,9 @@ fn create_uniform_value_bytes(
             RenderUniformValue::Float(v) => {
                 bytes.extend_from_slice(bytemuck::bytes_of(v));
                 if remain == 0 {
-                    remain = 16; //std140 vec4 alignment
+                    remain = 4; //std140 vec4 alignment
                 }
-                remain -= 4;
+                remain -= 1;
                 type_variables.push(("f32".to_string(), name.clone())); //
             }
             RenderUniformValue::Vec4(v) => {
@@ -270,18 +270,18 @@ fn create_uniform_value_bytes(
             RenderUniformValue::Int(v) => {
                 bytes.extend_from_slice(bytemuck::bytes_of(v));
                 if remain == 0 {
-                    remain = 16; //std140 vec4 alignment
+                    remain = 4; //std140 vec4 alignment
                 }
-                remain -= 4;
+                remain -= 1;
                 type_variables.push(("i32".to_string(), name.clone())); //
             }
             RenderUniformValue::Bool(v) => {
                 let int_value: u32 = if *v { 1 } else { 0 };
                 bytes.extend_from_slice(bytemuck::bytes_of(&int_value));
                 if remain == 0 {
-                    remain = 16; //std140 vec4 alignment
+                    remain = 4; //std140 vec4 alignment
                 }
-                remain -= 4;
+                remain -= 1;
                 type_variables.push(("u32".to_string(), name.clone())); //
             }
             RenderUniformValue::Mat4(v) => {
@@ -297,6 +297,14 @@ fn create_uniform_value_bytes(
                 type_variables.push(("mat4x4<f32>".to_string(), name.clone())); //
             }
             RenderUniformValue::Texture(v) => {
+                if remain != 0 {
+                    for _ in 0..remain {
+                        bytes.extend_from_slice(bytemuck::bytes_of(&0.0f32));
+                        type_variables.push(("f32".to_string(), format!("_pad{}", padding_count))); //
+                        padding_count += 1;
+                    }
+                    remain = 0;
+                }
                 let scale_offset: [f32; 4] = [v.scale[0], v.scale[1], v.delta[0], v.delta[1]];
                 bytes.extend_from_slice(bytemuck::bytes_of(&scale_offset));
                 type_variables.push(("vec4<f32>".to_string(), format!("{}_uv_factor", name))); //
@@ -456,9 +464,9 @@ pub fn create_render_pass(
         render_resource_manager,
     );
     let (_uniform_values_types, uniform_values_bytes) = create_uniform_value_bytes(uniform_values);
-    //println!(
-    //    "Create Render Pass: shader_type={}, uniform_values={:?}",
-    //    shader_type, uniform_values
+    // println!(
+    //    "Create Render Pass: uniform_values_types={:?}, uniform_values={:?}",
+    //    _uniform_values_types, uniform_values
     //);
 
     let mut textures = vec![];


### PR DESCRIPTION
This pull request updates the handling of uniform value alignment and padding in the `create_uniform_value_bytes` function in `src/render/wgpu/render_item.rs`, ensuring more accurate std140 alignment and proper padding before texture uniforms. It also improves debugging output in `create_render_pass`.

Uniform value alignment and padding improvements:

* Changed the alignment logic for `Float`, `Int`, and `Bool` uniform values to use a 4-byte alignment and decrement the alignment remainder by 1 instead of 4, improving std140 compliance. [[1]](diffhunk://#diff-3f880471284923f9333ed24e9862d42d759111d971e071c86958c20041f6bea0L253-R255) [[2]](diffhunk://#diff-3f880471284923f9333ed24e9862d42d759111d971e071c86958c20041f6bea0L273-R284)
* Added explicit padding before `Texture` uniforms if there is an alignment remainder, inserting zeroed `f32` values and updating the `type_variables` list accordingly.

Debugging and logging enhancements:

* Updated the commented debug print statement in `create_render_pass` to display both uniform value types and values for improved traceability.