### PR TITLE
Update material

### DIFF
--- a/assets/shaders/metal.wgsl
+++ b/assets/shaders/metal.wgsl
@@ -63,11 +63,11 @@ fn sample_k(uv: vec2<f32>) -> vec3<f32> {
 
 #ifdef USE_TEXTURE_BUMPMAP
 @group(2)
-@binding(5)
+@binding(7)
 var bumpmap_texture: texture_2d<f32>;
 
 @group(2)
-@binding(6)
+@binding(8)
 var bumpmap_sampler: sampler;
 #endif
 


### PR DESCRIPTION
This pull request updates the binding indices for bump map resources in the `assets/shaders/metal.wgsl` shader file. The bindings for both the bump map texture and sampler have been incremented to new indices to align with updated resource layouts.

Shader resource binding updates:

* Changed the binding index of `bumpmap_texture` from 5 to 7.
* Changed the binding index of `bumpmap_sampler` from 6 to 8.