### PR TITLE
Update render_mesh_item

### DIFF
--- a/src/render/wgpu/render_mesh_item.rs
+++ b/src/render/wgpu/render_mesh_item.rs
@@ -39,9 +39,10 @@ pub fn get_mesh(
         let shape = shape.read().unwrap();
         let mesh_id = shape.get_id();
         if let Some(mesh) = render_resource_manager.get_mesh(mesh_id)
-            && mesh.edition == shape.get_edition() {
-                return Some(mesh.clone());
-            }
+            && mesh.edition == shape.get_edition()
+        {
+            return Some(mesh.clone());
+        }
         if let Some(mesh) = RenderMesh::from_shape(device, queue, &shape) {
             let mesh = Arc::new(mesh);
             render_resource_manager.add_mesh(&mesh);
@@ -165,9 +166,6 @@ fn create_matte_render_passes(
         resource_manager,
         render_resource_manager,
     ) {
-        let texture = render_resource_manager
-            .get_texture(texture.get_id())
-            .unwrap();
         uniform_values.push((
             "bumpmap".to_string(),
             RenderUniformValue::Texture(texture.clone()),
@@ -181,7 +179,7 @@ fn create_matte_render_passes(
         ));
     }
     let mut shader_type = "lambertian".to_string();
-    let mut ltc_type = "ggx".to_string();
+    let mut ltc_type = "microfacet_reflection".to_string();
     let sigma = get_float(&material.props, "sigma").unwrap_or(0.0);
     if sigma > 0.0 {
         let sigma = sigma.to_radians() / (0.5 * std::f32::consts::PI);
@@ -250,10 +248,6 @@ fn create_plastic_render_passes(
         resource_manager,
         render_resource_manager,
     ) {
-        //println!("Found bumpmap texture for plastic material");
-        let texture = render_resource_manager
-            .get_texture(texture.get_id())
-            .unwrap();
         uniform_values.push((
             "bumpmap".to_string(),
             RenderUniformValue::Texture(texture.clone()),
@@ -343,7 +337,7 @@ fn create_glass_render_passes(
             "glass_transmission",
             RenderCategory::Transparent,
             &uniform_values,
-            "ggx",
+            "microfacet_reflection",
             render_resource_manager,
         );
         passes.push(render_pass);
@@ -362,7 +356,7 @@ fn create_glass_render_passes(
             "glass_reflection",
             RenderCategory::TransparentSpecular,
             &uniform_values,
-            "ggx",
+            "microfacet_reflection",
             render_resource_manager,
         );
         passes.push(render_pass);
@@ -411,7 +405,7 @@ fn create_metal_render_passes(
         "roughness".to_string(),
         RenderUniformValue::Float(roughness),
     ));
-    
+
     // Handle bumpmap texture and uniform
     if let Some(texture) = get_texture(
         &material.props,
@@ -601,9 +595,10 @@ pub fn get_render_material(
         let light = light.read().unwrap();
         let light_id = light.get_id();
         if let Some(mat) = render_resource_manager.get_material(light_id)
-            && mat.edition == light.get_edition() {
-                return Some(mat.clone());
-            }
+            && mat.edition == light.get_edition()
+        {
+            return Some(mat.clone());
+        }
         let render_material = create_render_material_from_light(
             device,
             queue,
@@ -620,9 +615,10 @@ pub fn get_render_material(
         let material = material.read().unwrap();
         let material_id = material.get_id();
         if let Some(mat) = render_resource_manager.get_material(material_id)
-            && mat.edition == material.get_edition() {
-                return Some(mat.clone());
-            }
+            && mat.edition == material.get_edition()
+        {
+            return Some(mat.clone());
+        }
         let render_material = create_render_material_from_material(
             device,
             queue,


### PR DESCRIPTION
This pull request updates the rendering pipeline to use a more descriptive shader type for microfacet-based materials and removes redundant texture lookups for bump maps. It also includes minor formatting improvements for readability in conditional expressions.

Shader type updates:

* Changed the shader type from `"ggx"` to `"microfacet_reflection"` in glass and matte rendering passes, reflecting a more accurate description of the microfacet reflection model. [[1]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L184-R182) [[2]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L346-R340) [[3]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L365-R359)

Texture lookup simplification:

* Removed unnecessary texture lookups for bump maps in both matte and plastic material rendering passes, relying on the existing texture reference instead. [[1]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L168-L170) [[2]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L253-L256)

Code readability improvements:

* Reformatted multi-condition `if let` statements in `get_mesh` and `get_render_material` functions for better readability and maintainability. [[1]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L42-R43) [[2]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L604-R599) [[3]](diffhunk://#diff-ffcb06e3483cea6400d4cd5dedf4cc08a41254e7cb67d1db0b90bc1a6eef53a3L623-R619)