### PR TITLE
Feature/object instance

### DIFF
--- a/src/io/pbrt/import/scene/render_options.rs
+++ b/src/io/pbrt/import/scene/render_options.rs
@@ -1,4 +1,10 @@
 use crate::model::base::PropertyMap;
+use crate::model::scene::Node;
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+type PrimitivesMap = HashMap<String, Arc<RwLock<Node>>>;
 
 #[derive(Debug, Clone)]
 pub struct RenderOptions {
@@ -16,6 +22,9 @@ pub struct RenderOptions {
     pub integrator_params: PropertyMap,
     pub camera_name: String,
     pub camera_params: PropertyMap,
+
+    pub instances: PrimitivesMap,
+    pub current_instance_name: Option<String>,
 }
 
 impl Default for RenderOptions {
@@ -35,6 +44,9 @@ impl Default for RenderOptions {
             integrator_params: PropertyMap::new(),
             camera_name: "perspective".to_string(),
             camera_params: PropertyMap::new(),
+
+            instances: HashMap::new(),
+            current_instance_name: None,
         }
     }
 }

--- a/src/io/pbrt/import/scene/scene_target.rs
+++ b/src/io/pbrt/import/scene/scene_target.rs
@@ -390,6 +390,20 @@ impl SceneTarget {
         }
         return None;
     }
+
+    fn instantiate_node(&self, node: &Arc<RwLock<Node>>) -> Arc<RwLock<Node>> {
+        let instanced_node = self.create_child_node(&node.read().unwrap().get_name());
+        /* 
+        {
+            let mut instanced_node = instanced_node.write().unwrap();
+            let original_node = node.read().unwrap();
+            for component in original_node.get_components().iter() {
+                instanced_node.add_component(component.clone_box());
+            }
+        }
+        */
+        return instanced_node;
+    }
 }
 
 impl PbrtTarget for SceneTarget {
@@ -847,11 +861,41 @@ impl PbrtTarget for SceneTarget {
     }
 
     fn object_end(&mut self) {
+        if let Some(name) = &self.render_options.current_instance_name {
+            if let Some(node) = self.render_options.instances.get(name) {
+                // register instance as ResourceObject to ResourceManager
+                //let resource = Arc::new(RwLock::new(InstanceResource::new(
+                //    name,
+                //    node.clone(),
+                //)));
+                //self.resources
+                //    .insert(name.to_string(), resource.clone());
+            }
+        }
         self.attribute_end();
         self.render_options.current_instance_name = None;
     }
 
-    fn object_instance(&mut self, _name: &str) {}
+    fn object_instance(&mut self, name: &str) {
+        if let Some(current_instance_name) = &self.render_options.current_instance_name {
+            if name == current_instance_name {
+                log::warn!("Cannot instance object {} within its own definition", name);
+                return;
+            }
+        }
+        if let Some(node) = self.render_options.instances.get(name) {
+            //let instanced_node = node.clone();
+            // set as node
+            //println!("Instance node: {} {}", name, node.read().unwrap().get_name());
+            let instance_node = self.instantiate_node(node);
+            //println!(
+            //    "Instance node created: {}",
+            //    instance_node.read().unwrap().get_name()
+            //);
+        } else {
+            log::warn!("Instance {} not found", name);
+        }
+    }
 
     fn world_end(&mut self) {}
 

--- a/src/io/pbrt/import/scene/scene_target.rs
+++ b/src/io/pbrt/import/scene/scene_target.rs
@@ -603,7 +603,14 @@ impl PbrtTarget for SceneTarget {
     }
 
     fn transform_begin(&mut self) {
-        {
+        if let Some(name) = &self.render_options.current_instance_name {
+            let node = self
+                .render_options
+                .instances
+                .entry(name.to_string())
+                .or_insert_with(|| Node::root_node(name));
+            self.nodes.push(node.clone());
+        } else {
             let new_node = self.create_child_node("Transform");
             self.nodes.push(new_node);
         }
@@ -833,9 +840,19 @@ impl PbrtTarget for SceneTarget {
         }
     }
     fn reverse_orientation(&mut self) {}
-    fn object_begin(&mut self, _name: &str) {}
-    fn object_end(&mut self) {}
+
+    fn object_begin(&mut self, name: &str) {
+        self.render_options.current_instance_name = Some(name.to_string());
+        self.attribute_begin();
+    }
+
+    fn object_end(&mut self) {
+        self.attribute_end();
+        self.render_options.current_instance_name = None;
+    }
+
     fn object_instance(&mut self, _name: &str) {}
+
     fn world_end(&mut self) {}
 
     fn parse_file(&mut self, _filename: &str) {


### PR DESCRIPTION
This pull request introduces support for object instancing in the scene import pipeline, specifically for PBRT scene files. The changes add new fields to track instances and their names, update the logic for handling object definitions and instantiations, and introduce a helper method to create instance nodes. This lays the groundwork for more robust and efficient scene management, especially for scenes with repeated geometry.

**Object Instancing Support:**

* Added `instances` (a map of instance names to nodes) and `current_instance_name` fields to the `RenderOptions` struct, along with their initialization in the `Default` implementation. [[1]](diffhunk://#diff-8da98a979bc977cff534e0a5863cc08a11fd34a6dc0f20bbf02514a4a2092fdbR2-R7) [[2]](diffhunk://#diff-8da98a979bc977cff534e0a5863cc08a11fd34a6dc0f20bbf02514a4a2092fdbR25-R27) [[3]](diffhunk://#diff-8da98a979bc977cff534e0a5863cc08a11fd34a6dc0f20bbf02514a4a2092fdbR47-R49)
* Implemented the `object_begin`, `object_end`, and `object_instance` methods in the `PbrtTarget` trait for `SceneTarget`, enabling proper tracking and instantiation of named objects in the scene.

**Scene Node Management:**

* Updated the `transform_begin` method to push either a new node for a named instance or a regular transform node, depending on context.
* Added the `instantiate_node` helper method to create a child node based on an existing node, preparing the structure for actual component cloning and instancing logic.