### PR TITLE
Refactor node components storage and inspector access

### DIFF
--- a/src/model/scene/node.rs
+++ b/src/model/scene/node.rs
@@ -1,11 +1,14 @@
 use super::components::*;
 
-use std::any::Any;
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::Weak;
 
 use uuid::Uuid;
+
+type Components = HashMap<TypeId, Box<dyn Component>>;
 
 #[derive(Debug)]
 pub struct Node {
@@ -14,12 +17,16 @@ pub struct Node {
     pub name: String,
     pub parent: Option<Weak<RwLock<Node>>>,
     pub children: Vec<Arc<RwLock<Node>>>,
-    pub components: Vec<Box<dyn Any>>,
+    pub components: Components,
 }
 
 impl Node {
     pub fn root_node(name: &str) -> Arc<RwLock<Node>> {
-        let components = vec![Box::new(TransformComponent::default()) as Box<dyn Any>];
+        let mut components = Components::new();
+        components.insert(
+            TypeId::of::<TransformComponent>(),
+            Box::new(TransformComponent::default()),
+        );
         let node = Node {
             enable: true,
             name: name.to_string(),
@@ -32,7 +39,11 @@ impl Node {
     }
 
     pub fn child_node(name: &str, parent: &Arc<RwLock<Node>>) -> Arc<RwLock<Node>> {
-        let components = vec![Box::new(TransformComponent::default()) as Box<dyn Any>];
+        let mut components = Components::new();
+        components.insert(
+            TypeId::of::<TransformComponent>(),
+            Box::new(TransformComponent::default()),
+        );
         let node = Node {
             enable: true,
             name: name.to_string(),
@@ -70,26 +81,21 @@ impl Node {
         self.id
     }
 
-    pub fn add_component<T: Component>(&mut self, component: T) {
-        self.components.push(Box::new(component));
+    pub fn add_component<T: Component + 'static>(&mut self, component: T) {
+        self.components
+            .insert(TypeId::of::<T>(), Box::new(component));
     }
 
-    pub fn get_component<T: Component>(&self) -> Option<&T> {
-        for component in self.components.iter() {
-            if let Some(c) = component.downcast_ref::<T>() {
-                return Some(c);
-            }
-        }
-        None
+    pub fn get_component<T: Component + 'static>(&self) -> Option<&T> {
+        self.components
+            .get(&TypeId::of::<T>())
+            .and_then(|component| (component.as_ref() as &dyn Any).downcast_ref::<T>())
     }
 
-    pub fn get_component_mut<T: Component>(&mut self) -> Option<&mut T> {
-        for component in self.components.iter_mut() {
-            if let Some(c) = component.downcast_mut::<T>() {
-                return Some(c);
-            }
-        }
-        None
+    pub fn get_component_mut<T: Component + 'static>(&mut self) -> Option<&mut T> {
+        self.components
+            .get_mut(&TypeId::of::<T>())
+            .and_then(|component| (component.as_mut() as &mut dyn Any).downcast_mut::<T>())
     }
 
     // --------------------------------------------------------------------------------------------- //
@@ -126,10 +132,8 @@ impl Node {
     }
 
     pub fn update(&mut self) {
-        for component in self.components.iter_mut() {
-            if let Some(c) = component.downcast_mut::<&mut dyn Component>() {
-                c.update();
-            }
+        for component in self.components.values_mut() {
+            component.update();
         }
     }
 }

--- a/src/panel/inspector/panel.rs
+++ b/src/panel/inspector/panel.rs
@@ -27,7 +27,6 @@ use crate::model::scene::TextureProperties;
 use crate::model::scene::TransformComponent;
 use crate::panel::Panel;
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -95,84 +94,104 @@ impl InspectorPanel {
                 node.set_name(&name);
             }
         }
-        self.show_components(ui, &mut node.components, &resource_selector);
+        self.show_components(ui, &mut node, &resource_selector);
     }
 
     pub fn show_components(
         &self,
         ui: &mut egui::Ui,
-        components: &mut [Box<dyn Any>],
+        node: &mut Node,
         resource_selector: &ResourceSelector,
     ) {
-        for (i, component) in components.iter_mut().enumerate() {
-            if let Some(component) = component.downcast_mut::<TransformComponent>() {
-                self.show_transform_component(i, ui, component, resource_selector);
-            } else if let Some(component) = component.downcast_mut::<ShapeComponent>() {
-                self.show_shape_component(i, ui, component, resource_selector);
-            } else if let Some(component) = component.downcast_mut::<LightComponent>() {
-                self.show_light_component(i, ui, component, resource_selector);
-            } else if let Some(component) = component.downcast_mut::<MaterialComponent>() {
-                self.show_material_component(i, ui, component, resource_selector);
-            } else if let Some(component) = component.downcast_mut::<CameraComponent>() {
-                let camera_properties = CameraProperties::get_instance();
-                self.show_typed_component(
-                    i,
-                    ui,
-                    "Camera",
-                    &mut component.props,
-                    &camera_properties,
-                    resource_selector,
-                );
-            } else if let Some(component) = component.downcast_mut::<FilmComponent>() {
-                self.show_option_component(i, ui, "film", &mut component.props, resource_selector);
-            } else if let Some(component) = component.downcast_mut::<SamplerComponent>() {
-                let sampler_properties = SamplerProperties::get_instance();
-                self.show_typed_component(
-                    i,
-                    ui,
-                    "Sampler",
-                    &mut component.props,
-                    &sampler_properties,
-                    resource_selector,
-                );
-            } else if let Some(component) = component.downcast_mut::<IntegratorComponent>() {
-                let integrator_properties = IntegratorProperties::get_instance();
-                self.show_typed_component(
-                    i,
-                    ui,
-                    "Integrator",
-                    &mut component.props,
-                    &integrator_properties,
-                    resource_selector,
-                );
-            } else if let Some(component) = component.downcast_mut::<AcceleratorComponent>() {
-                let accelerator_properties = AcceleratorProperties::get_instance();
-                self.show_typed_component(
-                    i,
-                    ui,
-                    "Accelerator",
-                    &mut component.props,
-                    &accelerator_properties,
-                    resource_selector,
-                );
-            } else if let Some(component) = component.downcast_mut::<CoordinateSystemComponent>() {
-                let mut props = PropertyMap::new();
-                let up = component.get_up_vector();
-                props.add_floats("float up", &[up.x, up.y, up.z]);
-                self.show_other_component(i, ui, "CoordinateSystem", &mut props, resource_selector);
-            } else if let Some(_component) = component.downcast_mut::<AnimationComponent>() {
-                let mut props = PropertyMap::new(); //todo
-                show_component_props(i, "Animation", ui, &mut props, &[], resource_selector);
-            } else if let Some(component) = component.downcast_mut::<ObjectInstanceComponent>() {
-                let object_node = component.get_node();
-                let object_node = object_node.read().unwrap();
-                let object_name = object_node.get_name();
-                let mut props = PropertyMap::new();
-                props.add_string("string name", &object_name);
-                self.show_other_component(i, ui, "ObjectInstance", &mut props, resource_selector);
-            } else {
-                //log::warn!("Unknown component type");
-            }
+        let mut i = 0;
+
+        if let Some(component) = node.get_component_mut::<TransformComponent>() {
+            self.show_transform_component(i, ui, component, resource_selector);
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<ShapeComponent>() {
+            self.show_shape_component(i, ui, component, resource_selector);
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<LightComponent>() {
+            self.show_light_component(i, ui, component, resource_selector);
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<MaterialComponent>() {
+            self.show_material_component(i, ui, component, resource_selector);
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<CameraComponent>() {
+            let camera_properties = CameraProperties::get_instance();
+            self.show_typed_component(
+                i,
+                ui,
+                "Camera",
+                &mut component.props,
+                &camera_properties,
+                resource_selector,
+            );
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<FilmComponent>() {
+            self.show_option_component(i, ui, "film", &mut component.props, resource_selector);
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<SamplerComponent>() {
+            let sampler_properties = SamplerProperties::get_instance();
+            self.show_typed_component(
+                i,
+                ui,
+                "Sampler",
+                &mut component.props,
+                &sampler_properties,
+                resource_selector,
+            );
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<IntegratorComponent>() {
+            let integrator_properties = IntegratorProperties::get_instance();
+            self.show_typed_component(
+                i,
+                ui,
+                "Integrator",
+                &mut component.props,
+                &integrator_properties,
+                resource_selector,
+            );
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<AcceleratorComponent>() {
+            let accelerator_properties = AcceleratorProperties::get_instance();
+            self.show_typed_component(
+                i,
+                ui,
+                "Accelerator",
+                &mut component.props,
+                &accelerator_properties,
+                resource_selector,
+            );
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<CoordinateSystemComponent>() {
+            let mut props = PropertyMap::new();
+            let up = component.get_up_vector();
+            props.add_floats("float up", &[up.x, up.y, up.z]);
+            self.show_other_component(i, ui, "CoordinateSystem", &mut props, resource_selector);
+            i += 1;
+        }
+        if let Some(_component) = node.get_component_mut::<AnimationComponent>() {
+            let mut props = PropertyMap::new(); //todo
+            show_component_props(i, "Animation", ui, &mut props, &[], resource_selector);
+            i += 1;
+        }
+        if let Some(component) = node.get_component_mut::<ObjectInstanceComponent>() {
+            let object_node = component.get_node();
+            let object_node = object_node.read().unwrap();
+            let object_name = object_node.get_name();
+            let mut props = PropertyMap::new();
+            props.add_string("string name", &object_name);
+            self.show_other_component(i, ui, "ObjectInstance", &mut props, resource_selector);
         }
     }
 


### PR DESCRIPTION
This pull request refactors how components are stored and accessed in the `Node` struct to improve type safety and performance. Instead of using a `Vec<Box<dyn Any>>`, components are now stored in a `HashMap<TypeId, Box<dyn Component>>`. This change simplifies component retrieval and mutation, and the inspector panel has been updated to use the new API.

**Core refactoring of component storage and access:**

* Changed the `Node` struct's `components` field from a `Vec<Box<dyn Any>>` to a `HashMap<TypeId, Box<dyn Component>>`, improving type safety and lookup performance. (`src/model/scene/node.rs`)
* Updated the `add_component`, `get_component`, and `get_component_mut` methods in `Node` to use the new `HashMap`-based storage, enabling direct access by component type. (`src/model/scene/node.rs`)
* Modified the `update` method in `Node` to iterate over the values of the component map. (`src/model/scene/node.rs`)

**Inspector panel updates:**

* Refactored the inspector panel to use the new `Node` API for accessing and displaying components, replacing iteration over a vector with direct type-based lookups. (`src/panel/inspector/panel.rs`) [[1]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL98-R124) [[2]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL126-R140) [[3]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL138-R152) [[4]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL148-R164) [[5]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL158-L175)

**Code cleanup:**

* Removed unused imports of `Any` in `panel.rs` since component type downcasting is now handled via the new API. (`src/panel/inspector/panel.rs`)