### PR TITLE
Feature/curves

### DIFF
--- a/src/conversion/mesh_data/mod.rs
+++ b/src/conversion/mesh_data/mod.rs
@@ -54,6 +54,11 @@ fn create_mesh_data_core(shape: &Shape) -> Option<MeshData> {
         "loopsubdiv" => {
             return create_mesh_data_from_loopsubdiv(shape);
         }
+        "curves" => {
+            // Handle curves shape
+            // You can implement the logic for curves shape here
+            return None;
+        }
         _ => {
             println!("Unknown shape type: {}", mesh_type);
         }

--- a/src/io/pbrt/import/scene/curves.rs
+++ b/src/io/pbrt/import/scene/curves.rs
@@ -1,16 +1,79 @@
 use crate::model::base::ParamSet;
+use crate::model::base::Matrix4x4;
+use crate::model::base::Property;
+use crate::model::base::PropertyMap;
+use crate::model::scene::Material;
+
+use std::sync::Arc;
+use std::sync::RwLock;
+
+const APPENDABLE_KEYS: [&str; 9] = ["P", "N", "width", "width0", "width1", "normal", "u", "v", "uv"];
 
 #[derive(Default)]
 pub struct CurvesState {
     pub curve_edition: String,
     pub curves: Vec<ParamSet>,
+    pub transform: Option<Matrix4x4>,
+    pub material: Option<Arc<RwLock<Material>>>,
 }
 
 impl CurvesState {
-    pub fn create_curve_edition(params: &ParamSet) -> String {
+    pub fn create_curve_edition(material_id: Option<&str>, transform: &Matrix4x4) -> String {
+        let mut transform_text = String::new();
+        for value in transform.m.iter() {
+            let value = if value.abs() < 1e-8 { 0.0 } else { *value };
+            transform_text.push_str(&format!("{:.9},", value));
+        }
+        let material_id = material_id.unwrap_or("none");
+        format!("material={};transform={}", material_id, transform_text)
+    }
 
-        //let curve_type = params.get()
+    pub fn clear(&mut self) {
+        self.curve_edition.clear();
+        self.curves.clear();
+        self.transform = None;
+        self.material = None;
+    }
 
-        todo!()
+    pub fn push(&mut self, params: &ParamSet) {
+        self.curves.push(params.clone());
+    }
+
+    pub fn merged_params(&self) -> Option<ParamSet> {
+        let mut merged = self.curves.first()?.clone();
+        for curve in self.curves.iter().skip(1) {
+            append_curve_params(&mut merged, curve);
+        }
+        Some(merged)
+    }
+}
+
+fn append_curve_params(dst: &mut PropertyMap, src: &ParamSet) {
+    for (key_type, key_name, src_prop) in src.0.iter() {
+        if !APPENDABLE_KEYS.contains(&key_name.as_str()) {
+            continue;
+        }
+        if let Some(dst_prop) = dst.get_mut(key_name) {
+            match (dst_prop, src_prop) {
+                (Property::Strings(dst_values), Property::Strings(src_values)) => {
+                    dst_values.extend(src_values.clone());
+                }
+                (Property::Floats(dst_values), Property::Floats(src_values)) => {
+                    dst_values.extend(src_values.clone());
+                }
+                (Property::Ints(dst_values), Property::Ints(src_values)) => {
+                    dst_values.extend(src_values.clone());
+                }
+                (Property::Bools(dst_values), Property::Bools(src_values)) => {
+                    dst_values.extend(src_values.clone());
+                }
+                _ => {
+                    // Type mismatch is ignored; keep original property.
+                }
+            }
+        } else {
+            let key = PropertyMap::get_key(key_type, key_name);
+            dst.insert(&key, src_prop.clone());
+        }
     }
 }

--- a/src/io/pbrt/import/scene/curves.rs
+++ b/src/io/pbrt/import/scene/curves.rs
@@ -1,0 +1,16 @@
+use crate::model::base::ParamSet;
+
+#[derive(Default)]
+pub struct CurvesState {
+    pub curve_edition: String,
+    pub curves: Vec<ParamSet>,
+}
+
+impl CurvesState {
+    pub fn create_curve_edition(params: &ParamSet) -> String {
+
+        //let curve_type = params.get()
+
+        todo!()
+    }
+}

--- a/src/io/pbrt/import/scene/mod.rs
+++ b/src/io/pbrt/import/scene/mod.rs
@@ -2,5 +2,6 @@ mod graphics_state;
 mod render_options;
 mod scene_target;
 mod transform;
+mod curves;
 
 pub use scene_target::SceneTarget;

--- a/src/io/pbrt/import/scene/scene_target.rs
+++ b/src/io/pbrt/import/scene/scene_target.rs
@@ -336,10 +336,38 @@ impl SceneTarget {
         }
     }
 
+    fn emit_curve_batch_node(&mut self) {
+        if let Some(mut merged) = self.curves_state.merged_params() {
+            let curve_count = self.curves_state.curves.len() as i32;
+            merged.add_ints("integer curve_count", &[curve_count]);
+            let node = self.create_child_node("Curves");
+            {
+                let mut node = node.write().unwrap();
+                if let Some(local_matrix) = self.curves_state.transform
+                    && let Some(transform) = node.get_component_mut::<TransformComponent>()
+                {
+                    transform.set_local_matrix(local_matrix);
+                }
+                node.add_component(ShapeComponent::new("curves", "Curves", &merged));
+                if let Some(material) = self.curves_state.material.as_ref() {
+                    node.add_component(MaterialComponent::from_material(material));
+                }
+            }
+        }
+    }
+
+    fn finalize_curve_batch(&mut self) {
+        self.emit_curve_batch_node();
+        self.curves_state.clear();
+    }
+
     fn make_shape(&mut self, name: &str, params: &ParamSet) -> Option<Arc<RwLock<Node>>> {
         let shape_type = name.to_string();
+        if shape_type != "curve" {
+            self.finalize_curve_batch();
+        }
         match shape_type.as_str() {
-            "plymesh" => {
+            "plymesh" => { 
                 let title = ShapeComponent::get_name_from_type(name);
                 if let Some(filename) = params.find_one_string("filename")
                     && let Some(fullpath) = self.find_file_path(filename.as_str())
@@ -389,18 +417,28 @@ impl SceneTarget {
                 return Some(node);
             }
             "curve" => {
-                let curve_edition = CurvesState::create_curve_edition(params);
-                if curve_edition != self.curves_state.curve_edition {
-                    //todo:
-                    let node = self.create_child_node("Curves");
-                    {
-                        let mut node = node.write().unwrap();
-                        let component = ShapeComponent::new(&shape_type, "Curves", params);
-                        node.add_component(component);
-                    }
-                    self.curve_state.curve_edition = curve_edition;
-                    self.curve_state.curves.clear();
+                let current_material = self
+                    .graphics_states
+                    .last()
+                    .and_then(|state| state.current_material.as_ref().map(|m| m.clone()))
+                    .map(|material| material.clone());
+                let material_id = current_material
+                    .as_ref()
+                    .map(|material| material.read().unwrap().get_id().to_string());
+                let local_matrix = self.get_current_local_matrix();
+                let curve_edition =
+                    CurvesState::create_curve_edition(material_id.as_deref(), &local_matrix);
+                if !self.curves_state.curve_edition.is_empty()
+                    && curve_edition != self.curves_state.curve_edition
+                {
+                    self.finalize_curve_batch();
                 }
+                if self.curves_state.curve_edition.is_empty() {
+                    self.curves_state.curve_edition = curve_edition;
+                    self.curves_state.transform = Some(local_matrix);
+                    self.curves_state.material = current_material;
+                }
+                self.curves_state.push(params);
             }
             _ => {
                 log::warn!("Shape {} not supported", name);
@@ -594,6 +632,7 @@ impl PbrtTarget for SceneTarget {
                 .insert("camera".to_string(), t);
         }
         self.api_state = APIState::WorldBlock;
+        self.finalize_curve_batch();
         self.nodes.clear();
         self.nodes.push(Node::root_node("Scene"));
         self.transforms.clear();
@@ -621,12 +660,14 @@ impl PbrtTarget for SceneTarget {
     }
 
     fn attribute_begin(&mut self) {
+        self.finalize_curve_batch();
         self.transform_begin();
         let new_graphics_state = self.graphics_states.last().unwrap().clone();
         self.graphics_states.push(new_graphics_state);
     }
 
     fn attribute_end(&mut self) {
+        self.finalize_curve_batch();
         if self.graphics_states.len() > 1 {
             self.graphics_states.pop();
         } else {
@@ -915,7 +956,9 @@ impl PbrtTarget for SceneTarget {
         }
     }
 
-    fn world_end(&mut self) {}
+    fn world_end(&mut self) {
+        self.finalize_curve_batch();
+    }
 
     fn parse_file(&mut self, _filename: &str) {
         //

--- a/src/io/pbrt/import/scene/scene_target.rs
+++ b/src/io/pbrt/import/scene/scene_target.rs
@@ -1,3 +1,4 @@
+use super::curves::CurvesState;
 use super::graphics_state::GraphicsState;
 use super::render_options::RenderOptions;
 use super::transform::Transform;
@@ -60,6 +61,7 @@ pub struct SceneTarget {
     materials: HashMap<Uuid, Arc<RwLock<Material>>>,
     resources: HashMap<String, Arc<RwLock<dyn ResourceObject>>>,
     work_dirs: Vec<String>,
+    curves_state: CurvesState,
 }
 
 fn create_default_material() -> Arc<RwLock<Material>> {
@@ -103,6 +105,7 @@ impl Default for SceneTarget {
             materials,
             resources: HashMap::new(),
             work_dirs: Vec::new(),
+            curves_state: CurvesState::default(),
         }
     }
 }
@@ -384,6 +387,20 @@ impl SceneTarget {
                     node.add_component(component);
                 }
                 return Some(node);
+            }
+            "curve" => {
+                let curve_edition = CurvesState::create_curve_edition(params);
+                if curve_edition != self.curves_state.curve_edition {
+                    //todo:
+                    let node = self.create_child_node("Curves");
+                    {
+                        let mut node = node.write().unwrap();
+                        let component = ShapeComponent::new(&shape_type, "Curves", params);
+                        node.add_component(component);
+                    }
+                    self.curve_state.curve_edition = curve_edition;
+                    self.curve_state.curves.clear();
+                }
             }
             _ => {
                 log::warn!("Shape {} not supported", name);

--- a/src/model/scene/properties/shape.rs
+++ b/src/model/scene/properties/shape.rs
@@ -2,7 +2,7 @@ use super::common::*;
 use std::cell::LazyCell;
 use std::collections::HashMap;
 
-const PARAMETERS: [(&str, &str, &str, &str, &str); 38] = [
+const PARAMETERS: [(&str, &str, &str, &str, &str); 40] = [
     ("trianglemesh", "integer", "indices", "", ""),
     ("trianglemesh", "point", "P", "", ""),
     ("trianglemesh", "normal", "N", "", ""),
@@ -41,6 +41,11 @@ const PARAMETERS: [(&str, &str, &str, &str, &str); 38] = [
     ("loopsubdiv", "integer", "indices", "", ""),
     ("loopsubdiv", "point", "P", "", ""),
     ("loopsubdiv", "string", "scheme", "loop", ""),
+    ("curves", "integer", "curve_count", "", ""),
+    ("curves", "integer", "vertex_count", "", ""),
+    //("curves", "point", "P", "", ""),
+    //("curves", "normal", "N", "", ""),
+    //("curves", "float", "width", "", ""),
 ];
 
 #[derive(Debug, Clone)]

--- a/src/panel/inspector/panel.rs
+++ b/src/panel/inspector/panel.rs
@@ -209,6 +209,7 @@ impl InspectorPanel {
         let props = shape.as_property_map_mut();
         let shape_type = props.find_one_string("string type").unwrap();
         let name = props.find_one_string("string name").unwrap();
+        let title = name.clone();
         let mut keys = Vec::new();
         let shape_properties = ShapeProperties::get_instance();
         if let Some(params) = shape_properties.get_entries(&shape_type) {
@@ -227,7 +228,7 @@ impl InspectorPanel {
                 ));
             }
         }
-        if show_component_props(index, &name, ui, props, &keys, resource_selector)
+        if show_component_props(index, &title, ui, props, &keys, resource_selector)
             && ShapeComponent::is_ediable(&shape_type)
         {
             is_changed = true;


### PR DESCRIPTION
This pull request adds initial support for importing and batching "curve" shapes from PBRT scenes. The main focus is on grouping consecutive curve shapes with the same material and transform into a single batch, and ensuring proper emission of these batches at appropriate points in the scene import process. The changes include a new `CurvesState` for managing curve batches, logic in `SceneTarget` to handle curve batching, and updates to the shape parameter registry.

**Curve batching and scene import logic:**

* Added a new `CurvesState` struct in `src/io/pbrt/import/scene/curves.rs` to manage batching of curve shapes, including merging their parameters and tracking associated material and transform.
* Integrated `CurvesState` into `SceneTarget` (`src/io/pbrt/import/scene/scene_target.rs`) to collect, merge, and emit batches of curves as a single node. Batches are finalized whenever a non-curve shape is encountered, or at key scene boundaries such as `attribute_begin`, `attribute_end`, and `world_end`. [[1]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R1) [[2]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R64) [[3]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R108) [[4]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R339-R368) [[5]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R419-R442) [[6]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R635) [[7]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56R663-R670) [[8]](diffhunk://#diff-637da4e20499346ae341da052d5d3045fd29306e3c6846ab695aca731f1d4d56L901-R961) [[9]](diffhunk://#diff-71070d6b1122fd0cf094ed72c4975200e4a8f7aa0d2e69bb7304b2a08381eb97R5)

**Shape parameter registry updates:**

* Added parameter entries for the new "curves" shape type in `src/model/scene/properties/shape.rs`, including `curve_count` and `vertex_count`. [[1]](diffhunk://#diff-217094490fedb663b10ba8e9826d2586ed3760325bd219d2bdb91d5f1073c5aaL5-R5) [[2]](diffhunk://#diff-217094490fedb663b10ba8e9826d2586ed3760325bd219d2bdb91d5f1073c5aaR44-R48)

**Mesh data conversion:**

* Updated `create_mesh_data_core` in `src/conversion/mesh_data/mod.rs` to recognize the "curves" shape type, with a placeholder for future implementation.

**Inspector panel UI:**

* Minor update in `src/panel/inspector/panel.rs` to use the correct title variable for displaying shape properties in the inspector panel. [[1]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bR212) [[2]](diffhunk://#diff-d958cb18a3855fda2eaa13055b3b93212447e7b93e47dc640af920e5035f6b8bL230-R231)