### PR TITLE
Refactor camera input into pluggable CameraController

### DIFF
--- a/src/panel/views/render/camera_controller.rs
+++ b/src/panel/views/render/camera_controller.rs
@@ -1,0 +1,103 @@
+use crate::model::base::Quaternion;
+use crate::model::base::Vector3;
+use crate::model::scene::CameraComponent;
+use crate::model::scene::CoordinateSystemComponent;
+use crate::model::scene::Node;
+use crate::model::scene::TransformComponent;
+
+use std::sync::Arc;
+use std::sync::RwLock;
+
+use eframe::egui;
+
+pub trait CameraController {
+    fn react_response(&mut self, response: &egui::Response, root_node: &Arc<RwLock<Node>>);
+}
+
+pub struct OrbitCameraController;
+
+impl Default for OrbitCameraController {
+    fn default() -> Self {
+        Self
+    }
+}
+
+const ORBIT_SPEED: f32 = 0.01;
+const PAN_SPEED: f32 = 0.0025;
+const DOLLY_DRAG_SPEED: f32 = 0.01;
+const DOLLY_WHEEL_SPEED: f32 = 0.0015;
+
+fn get_camera_axes(
+    root_node: &Arc<RwLock<Node>>,
+    rotation: &Quaternion,
+) -> (Vector3, Vector3, Vector3) {
+    let m = rotation.to_matrix();
+    let mut up = m.transform_vector(&Vector3::new(0.0, 1.0, 0.0)).normalize();
+    let mut right = m.transform_vector(&Vector3::new(1.0, 0.0, 0.0)).normalize();
+    let mut forward = m.transform_vector(&Vector3::new(0.0, 0.0, 1.0)).normalize();
+
+    let root_node = root_node.read().unwrap();
+    if let Some(cs) = root_node.get_component::<CoordinateSystemComponent>() {
+        up = cs.get_up_vector().normalize();
+        forward = Vector3::cross(&right, &up).normalize(); //xy->z
+        right = Vector3::cross(&up, &forward).normalize(); //yz->x
+    }
+    (up, right, forward)
+}
+
+impl CameraController for OrbitCameraController {
+    fn react_response(&mut self, response: &egui::Response, root_node: &Arc<RwLock<Node>>) {
+        if let Some(camera_node) = Node::find_node_by_component::<CameraComponent>(root_node) {
+            let mut camera_node = camera_node.write().unwrap();
+            if let Some(component) = camera_node.get_component_mut::<TransformComponent>() {
+                let mut is_changed = false;
+                let drag = response.drag_motion();
+                let (mut t, mut r, s) = component.get_local_trs();
+                let distance_scale = f32::max(t.length(), 1.0);
+
+                if response.dragged_by(egui::PointerButton::Primary) {
+                    let rotation_y = drag.x * ORBIT_SPEED;
+                    let rotation_x = drag.y * ORBIT_SPEED;
+                    let (up, right, _forward) = get_camera_axes(root_node, &r);
+
+                    let rotation_y = if s.x < 0.0 { -rotation_y } else { rotation_y };
+                    let rotation_x = if s.y < 0.0 { -rotation_x } else { rotation_x };
+
+                    let rot_y = Quaternion::from_angle_axis(rotation_y, &up);
+                    let rot_x = Quaternion::from_angle_axis(rotation_x, &right);
+                    r = (rot_x * rot_y * r).normalize();
+                    is_changed = true;
+                }
+
+                if response.dragged_by(egui::PointerButton::Secondary) {
+                    let (up, right, _forward) = get_camera_axes(root_node, &r);
+                    let tx = -drag.x * PAN_SPEED * distance_scale;
+                    let ty = drag.y * PAN_SPEED * distance_scale;
+                    t += right * tx + up * ty;
+                    is_changed = true;
+                }
+
+                if response.dragged_by(egui::PointerButton::Middle) {
+                    let (_up, _right, forward) = get_camera_axes(root_node, &r);
+                    let tz = drag.y * DOLLY_DRAG_SPEED * distance_scale;
+                    t += forward * tz;
+                    is_changed = true;
+                }
+
+                if response.hovered() {
+                    let scroll = response.ctx.input(|i| i.raw_scroll_delta.y);
+                    if scroll != 0.0 {
+                        let (_up, _right, forward) = get_camera_axes(root_node, &r);
+                        let tz = -scroll * DOLLY_WHEEL_SPEED * distance_scale;
+                        t += forward * tz;
+                        is_changed = true;
+                    }
+                }
+
+                if is_changed {
+                    component.set_local_trs(t, r, s);
+                }
+            }
+        }
+    }
+}

--- a/src/panel/views/render/mod.rs
+++ b/src/panel/views/render/mod.rs
@@ -1,3 +1,4 @@
+pub mod camera_controller;
 pub mod fps_counter;
 pub mod image_data;
 pub mod image_receiver;

--- a/src/panel/views/render/render_panel.rs
+++ b/src/panel/views/render/render_panel.rs
@@ -1,3 +1,4 @@
+use super::camera_controller::OrbitCameraController;
 use super::render_history::RenderHistory;
 use super::render_state::RenderState;
 //
@@ -51,7 +52,8 @@ impl RenderPanel {
         let config = controller.read().unwrap().get_config();
         let history = create_history("1", &config);
         let render_view = RenderView::new(cc);
-        let scene_view = SceneView::new(cc);
+        let mut scene_view = SceneView::new(cc);
+        scene_view.set_camera_controller(Box::new(OrbitCameraController));
         Self {
             app_controller: controller.clone(),
             histories: vec![history],

--- a/src/panel/views/render/scene_view.rs
+++ b/src/panel/views/render/scene_view.rs
@@ -1,10 +1,9 @@
+use super::camera_controller::CameraController;
+use super::camera_controller::OrbitCameraController;
 use super::fps_counter::FpsCounter;
 use crate::model::base::Matrix4x4;
 use crate::model::base::Property;
-use crate::model::base::Quaternion;
-use crate::model::base::Vector3;
 use crate::model::scene::CameraComponent;
-use crate::model::scene::CoordinateSystemComponent;
 use crate::model::scene::FilmComponent;
 use crate::model::scene::Node;
 use crate::model::scene::TransformComponent;
@@ -19,48 +18,12 @@ use std::sync::RwLock;
 use eframe::egui;
 use egui::Vec2;
 
-pub fn react_response(response: &egui::Response, root_node: &Arc<RwLock<Node>>) {
-    if response.dragged_by(egui::PointerButton::Primary)
-        && let Some(camera_node) = Node::find_node_by_component::<CameraComponent>(root_node)
-    {
-        let mut camera_node = camera_node.write().unwrap();
-        if let Some(component) = camera_node.get_component_mut::<TransformComponent>() {
-            let rotation_y = response.drag_motion().x * 0.01;
-            let rotation_x = response.drag_motion().y * 0.01;
-            {
-                let (t, r, s) = component.get_local_trs();
-                let m = r.to_matrix();
-                let mut upper = m.transform_vector(&Vector3::new(0.0, 1.0, 0.0)).normalize();
-                let mut right = m.transform_vector(&Vector3::new(1.0, 0.0, 0.0)).normalize();
-
-                {
-                    let root_node = root_node.read().unwrap();
-                    if let Some(cs) = root_node.get_component::<CoordinateSystemComponent>() {
-                        upper = cs.get_up_vector();
-                        let forward = Vector3::cross(&right, &upper).normalize(); //xy->z
-                        right = Vector3::cross(&upper, &forward).normalize(); //yz->x
-                    }
-                }
-                //let upper = Vector3::new(0.0, 1.0, 0.0);
-                //let right = Vector3::new(1.0, 0.0, 0.0);
-
-                let rotation_y = if s.x < 0.0 { -rotation_y } else { rotation_y };
-                let rotation_x = if s.y < 0.0 { -rotation_x } else { rotation_x };
-
-                let rot_y = Quaternion::from_angle_axis(rotation_y, &upper);
-                let rot_x = Quaternion::from_angle_axis(rotation_x, &right);
-                let new_rotation = rot_x * rot_y * r;
-                component.set_local_trs(t, new_rotation, s);
-            }
-        }
-    }
-}
-
 pub struct SceneView {
     wireframe: Option<WireRenderer>,
     solid: Option<SolidRenderer>,
     shaded: Option<LightingRenderer>,
     fps_counter: FpsCounter,
+    camera_controller: Box<dyn CameraController>,
 }
 
 impl SceneView {
@@ -73,7 +36,12 @@ impl SceneView {
             solid,
             shaded,
             fps_counter: FpsCounter::new(),
+            camera_controller: Box::new(OrbitCameraController),
         }
+    }
+
+    pub fn set_camera_controller(&mut self, controller: Box<dyn CameraController>) {
+        self.camera_controller = controller;
     }
 
     pub fn show(
@@ -158,7 +126,7 @@ impl SceneView {
 
         let (rect, response) = ui.allocate_exact_size(available_size, egui::Sense::drag());
         if is_playing {
-            react_response(&response, node);
+            self.camera_controller.react_response(&response, node);
         }
 
         let aspect = rect.width() / rect.height();
@@ -206,5 +174,13 @@ impl SceneView {
                 egui::Color32::GREEN,
             );
         }
+
+        ui.painter().text(
+            rect.left_bottom() + egui::vec2(8.0, -8.0),
+            egui::Align2::LEFT_BOTTOM,
+            "LMB Orbit | RMB Pan | MMB/Wheel Dolly",
+            egui::FontId::monospace(12.0),
+            egui::Color32::LIGHT_GRAY,
+        );
     }
 }


### PR DESCRIPTION
This pull request introduces a modular camera controller system for the scene view, replacing the previous hardcoded camera manipulation logic with a flexible, trait-based design. The new `OrbitCameraController` is now the default and can be swapped out as needed. The changes improve code maintainability, extensibility, and user experience by clarifying camera controls.

**Camera Controller System Refactor:**

* Introduced a new `CameraController` trait and implemented an `OrbitCameraController` struct in `camera_controller.rs`, encapsulating all camera manipulation logic and supporting orbit, pan, and dolly operations.
* Removed the old, monolithic `react_response` camera logic from `scene_view.rs` and replaced it with a `camera_controller` field in `SceneView`, delegating camera input handling to the controller. [[1]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029L22-R26) [[2]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029R39-R46) [[3]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029L161-R129)
* Added a method to `SceneView` to allow swapping the camera controller at runtime, increasing flexibility for future controller types.

**Integration and Initialization:**

* Updated `RenderPanel` to initialize `SceneView` with an `OrbitCameraController` by default and expose the ability to set the camera controller. [[1]](diffhunk://#diff-e6d339e4045af2f1d34213858d1f82c3c3bf05de8cc49525c4496aa4fe87c845R1) [[2]](diffhunk://#diff-e6d339e4045af2f1d34213858d1f82c3c3bf05de8cc49525c4496aa4fe87c845L54-R56) [[3]](diffhunk://#diff-42d20cfb10ea7e0115c99758000bc36b24bbd7123afcf2f7e6a6def4770bc029R1-L7)

**User Experience:**

* Added an on-screen hint in the scene view to inform users of the camera controls: "LMB Orbit | RMB Pan | MMB/Wheel Dolly".