### PR TITLE
Feature/directional shadow prep

### DIFF
--- a/assets/shaders/include/lighting_shadow_functions.wgsl
+++ b/assets/shaders/include/lighting_shadow_functions.wgsl
@@ -1,0 +1,33 @@
+#ifndef LIGHTING_SHADOW_FUNCTIONS_WGSL
+#define LIGHTING_SHADOW_FUNCTIONS_WGSL
+
+fn sample_directional_shadow_factor(shadow_index: i32, world_position: vec3<f32>) -> f32 {
+    if (shadow_index < 0) {
+        return 1.0;
+    }
+
+    let shadow = directional_shadow_infos[u32(shadow_index)];
+    let clip = shadow.light_view_proj * vec4<f32>(world_position, 1.0);
+    if (clip.w <= 0.0) {
+        return 1.0;
+    }
+
+    let ndc = clip.xyz / clip.w;
+    if (ndc.x < -1.0 || ndc.x > 1.0 || ndc.y < -1.0 || ndc.y > 1.0 || ndc.z < 0.0 || ndc.z > 1.0)
+    {
+        return 1.0;
+    }
+
+    let uv = vec2<f32>(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5);
+    let compare = ndc.z - max(shadow.bias, 0.0);
+    let layer = i32(shadow_index);
+    return textureSampleCompare(
+        directional_shadow_maps,
+        directional_shadow_sampler,
+        uv,
+        layer,
+        compare,
+    );
+}
+
+#endif

--- a/assets/shaders/include/lighting_shadow_functions.wgsl
+++ b/assets/shaders/include/lighting_shadow_functions.wgsl
@@ -1,25 +1,52 @@
 #ifndef LIGHTING_SHADOW_FUNCTIONS_WGSL
 #define LIGHTING_SHADOW_FUNCTIONS_WGSL
 
-fn sample_directional_shadow_factor(shadow_index: i32, world_position: vec3<f32>) -> f32 {
+fn project_directional_shadow_uv_depth(
+    shadow_index: i32,
+    world_position: vec3<f32>,
+) -> vec4<f32> {
     if (shadow_index < 0) {
-        return 1.0;
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
     }
 
     let shadow = directional_shadow_infos[u32(shadow_index)];
     let clip = shadow.light_view_proj * vec4<f32>(world_position, 1.0);
     if (clip.w <= 0.0) {
-        return 1.0;
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
     }
 
     let ndc = clip.xyz / clip.w;
     if (ndc.x < -1.0 || ndc.x > 1.0 || ndc.y < -1.0 || ndc.y > 1.0 || ndc.z < 0.0 || ndc.z > 1.0)
     {
-        return 1.0;
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
     }
 
     let uv = vec2<f32>(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5);
-    let compare = ndc.z - max(shadow.bias, 0.0);
+    return vec4<f32>(uv, ndc.z, 1.0);
+}
+
+fn sample_directional_shadow_depth(shadow_index: i32, uv: vec2<f32>) -> f32 {
+    if (shadow_index < 0) {
+        return 1.0;
+    }
+
+    let dims = textureDimensions(directional_shadow_maps);
+    let w = max(i32(dims.x), 1);
+    let h = max(i32(dims.y), 1);
+    let x = clamp(i32(uv.x * f32(w)), 0, w - 1);
+    let y = clamp(i32(uv.y * f32(h)), 0, h - 1);
+    return textureLoad(directional_shadow_maps, vec2<i32>(x, y), shadow_index, 0);
+}
+
+fn sample_directional_shadow_factor(shadow_index: i32, world_position: vec3<f32>) -> f32 {
+    let projected = project_directional_shadow_uv_depth(shadow_index, world_position);
+    if (projected.w <= 0.0) {
+        return 1.0;
+    }
+
+    let shadow = directional_shadow_infos[u32(shadow_index)];
+    let uv = projected.xy;
+    let compare = projected.z - max(shadow.bias, 0.0);
     let layer = i32(shadow_index);
     return textureSampleCompare(
         directional_shadow_maps,

--- a/assets/shaders/include/lighting_shadow_header.wgsl
+++ b/assets/shaders/include/lighting_shadow_header.wgsl
@@ -1,0 +1,22 @@
+#ifndef LIGHTING_SHADOW_HEADER_WGSL
+#define LIGHTING_SHADOW_HEADER_WGSL
+
+struct DirectionalShadowInfo {
+    light_view_proj: mat4x4<f32>,
+    bias: f32,
+    _pad0: vec3<f32>,
+}
+
+@group(5)
+@binding(0)
+var<storage, read> directional_shadow_infos: array<DirectionalShadowInfo>;
+
+@group(5)
+@binding(1)
+var directional_shadow_maps: texture_depth_2d_array;
+
+@group(5)
+@binding(2)
+var directional_shadow_sampler: sampler_comparison;
+
+#endif

--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -45,6 +45,10 @@ var ltc_texture_array: texture_2d_array<f32>;// LTC lookup texture
 @binding(1)
 var ltc_sampler: sampler;
 
+#ifdef ENABLE_DIRECTIONAL_LIGHT_SHADOW
+#include "lighting_shadow_functions.wgsl"
+#endif
+
 //-------------------------------------------------------
 const MAX_FLOAT: f32 = 1e+10;
 const PI: f32 = 3.14159265359;
@@ -542,7 +546,7 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     var color = vec3<f32>(0.0);
     for (var i: u32 = 0; i < light_uniforms.num_directional_lights; i++) {
         let light = directional_lights[i];
-        let intensity = light.intensity.rgb;
+        var intensity = light.intensity.rgb;
         let radius = max(light.radius, 1e-4);
 
         let direction = normalize(light.direction.xyz);
@@ -575,6 +579,11 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
 #endif
         let wi = tbn * -direction;// object to light vector
         let shade_input = ShadeInput(diffuse, specular, in.uv, magnitude, fresnel, wo, wi);
+
+#ifdef ENABLE_DIRECTIONAL_LIGHT_SHADOW
+        let shadow_factor = sample_directional_shadow_factor(light.shadow_index, in.w_position);
+        intensity *= shadow_factor;
+#endif
 
         var k = 1.0;//1.0 / (2.0 * PI * PI);
         color += k * intensity * shade(shade_input);

--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -53,6 +53,8 @@ var ltc_sampler: sampler;
 const MAX_FLOAT: f32 = 1e+10;
 const PI: f32 = 3.14159265359;
 const INV_PI: f32 = 1.0 / 3.14159265359;
+// 0: off, 1: shadow factor, 2: sampled shadow map depth, 3: projected uv/depth
+const DEBUG_DIRECTIONAL_SHADOW_VIEW_MODE: u32 = 0u;
 //-------------------------------------------------------
 // LTC functions and definitions
 const LUT_SIZE: f32 = 64.0; // ltc_texture size
@@ -544,6 +546,10 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
     // Accumulate lighting
     
     var color = vec3<f32>(0.0);
+    var debug_shadow_factor = 1.0;
+    var debug_shadow_depth = 1.0;
+    var debug_shadow_uvz = vec3<f32>(0.0);
+    var debug_has_shadow_proj = false;
     for (var i: u32 = 0; i < light_uniforms.num_directional_lights; i++) {
         let light = directional_lights[i];
         var intensity = light.intensity.rgb;
@@ -581,13 +587,34 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
         let shade_input = ShadeInput(diffuse, specular, in.uv, magnitude, fresnel, wo, wi);
 
 #ifdef ENABLE_DIRECTIONAL_LIGHT_SHADOW
+        let projected = project_directional_shadow_uv_depth(light.shadow_index, in.w_position);
+        if (!debug_has_shadow_proj && projected.w > 0.0) {
+            debug_has_shadow_proj = true;
+            debug_shadow_uvz = vec3<f32>(projected.x, projected.y, projected.z);
+            debug_shadow_depth = sample_directional_shadow_depth(light.shadow_index, projected.xy);
+        }
         let shadow_factor = sample_directional_shadow_factor(light.shadow_index, in.w_position);
         intensity *= shadow_factor;
+        debug_shadow_factor = min(debug_shadow_factor, shadow_factor);
 #endif
 
         var k = 1.0;//1.0 / (2.0 * PI * PI);
         color += k * intensity * shade(shade_input);
+
+#ifdef ENABLE_DIRECTIONAL_LIGHT_SHADOW
+        if (DEBUG_DIRECTIONAL_SHADOW_VIEW_MODE == 1u && light.shadow_index >= 0) {
+            return vec4<f32>(vec3<f32>(debug_shadow_factor), 1.0);
+        }
+        if (DEBUG_DIRECTIONAL_SHADOW_VIEW_MODE == 2u && debug_has_shadow_proj) {
+            return vec4<f32>(vec3<f32>(debug_shadow_depth), 1.0);
+        }
+        if (DEBUG_DIRECTIONAL_SHADOW_VIEW_MODE == 3u && debug_has_shadow_proj) {
+            return vec4<f32>(debug_shadow_uvz, 1.0);
+        }
+#endif
     }
+
+
 
     for (var i: u32 = 0; i < light_uniforms.num_sphere_lights; i++) {
         let light = sphere_lights[i];

--- a/assets/shaders/include/lighting_surface_header.wgsl
+++ b/assets/shaders/include/lighting_surface_header.wgsl
@@ -135,4 +135,8 @@ var<uniform> global_uniforms: GlobalUniforms;
 @group(1) @binding(0)
 var<uniform> local_uniforms: LocalUniforms;
 
+#ifdef ENABLE_DIRECTIONAL_LIGHT_SHADOW
+#include "lighting_shadow_header.wgsl"
+#endif
+
 #endif

--- a/assets/shaders/include/lighting_surface_header.wgsl
+++ b/assets/shaders/include/lighting_surface_header.wgsl
@@ -29,11 +29,14 @@ struct LightUniforms {
 
 struct DirectionalLight {
     direction: vec4<f32>,
-    // Example light direction
+    // Light direction
     intensity: vec4<f32>,
-    // Example light intensity
+    // Light intensity
     radius: f32,
-    _pad1: vec3<f32>,
+    // Radius for shadow calculation
+    shadow_index: i32,
+    // Index for the shadow map -1 if no shadow
+    _pad1: vec2<f32>,
     // Padding for alignment
 }
 

--- a/src/io/pbrt/import/scene/curves.rs
+++ b/src/io/pbrt/import/scene/curves.rs
@@ -1,5 +1,5 @@
-use crate::model::base::ParamSet;
 use crate::model::base::Matrix4x4;
+use crate::model::base::ParamSet;
 use crate::model::base::Property;
 use crate::model::base::PropertyMap;
 use crate::model::scene::Material;
@@ -7,7 +7,9 @@ use crate::model::scene::Material;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-const APPENDABLE_KEYS: [&str; 9] = ["P", "N", "width", "width0", "width1", "normal", "u", "v", "uv"];
+const APPENDABLE_KEYS: [&str; 9] = [
+    "P", "N", "width", "width0", "width1", "normal", "u", "v", "uv",
+];
 
 #[derive(Default)]
 pub struct CurvesState {

--- a/src/io/pbrt/import/scene/mod.rs
+++ b/src/io/pbrt/import/scene/mod.rs
@@ -1,7 +1,7 @@
+mod curves;
 mod graphics_state;
 mod render_options;
 mod scene_target;
 mod transform;
-mod curves;
 
 pub use scene_target::SceneTarget;

--- a/src/io/pbrt/import/scene/scene_target.rs
+++ b/src/io/pbrt/import/scene/scene_target.rs
@@ -367,7 +367,7 @@ impl SceneTarget {
             self.finalize_curve_batch();
         }
         match shape_type.as_str() {
-            "plymesh" => { 
+            "plymesh" => {
                 let title = ShapeComponent::get_name_from_type(name);
                 if let Some(filename) = params.find_one_string("filename")
                     && let Some(fullpath) = self.find_file_path(filename.as_str())

--- a/src/model/scene/light.rs
+++ b/src/model/scene/light.rs
@@ -17,6 +17,8 @@ impl Light {
         if props.get("string id").is_none() {
             props.insert("string id", Property::from(id.to_string()));
         }
+        let edition = Uuid::new_v4();
+        props.insert("string edition", Property::from(edition.to_string()));
         Light { id, props }
     }
 

--- a/src/model/scene/material.rs
+++ b/src/model/scene/material.rs
@@ -25,6 +25,8 @@ impl Material {
         props.insert("string id", Property::from(id.to_string()));
         props.insert("string name_", Property::from(name));
         props.insert("string type", Property::from(t));
+        let edition = Uuid::new_v4();
+        props.insert("string edition", Property::from(edition.to_string()));
         replace_properties(&mut props);
         Material { id, props }
     }

--- a/src/model/scene/properties/light.rs
+++ b/src/model/scene/properties/light.rs
@@ -2,7 +2,7 @@ use super::common::*;
 use std::cell::LazyCell;
 use std::collections::HashMap;
 
-const PARAMETERS: [(&str, &str, &str, &str, &str); 28] = [
+const PARAMETERS: [(&str, &str, &str, &str, &str); 30] = [
     ("point", "color", "I", "1.0 1.0 1.0", ""),
     ("point", "color", "scale", "1.0 1.0 1.0", ""),
     ("point", "point", "from", "0.0 0.0 0.0", ""),
@@ -26,6 +26,8 @@ const PARAMETERS: [(&str, &str, &str, &str, &str); 28] = [
     //("distant", "point", "from", "0.0 0.0 0.0", ""),
     //("distant", "point", "to", "0.0 0.0 1.0", ""),
     ("distant", "float", "sourceangle", "0.5357", "0.0 30.0"), //angular diameter of the light source
+    ("distant", "bool", "castshadow", "true", ""),
+    ("distant", "float", "shadowbias", "0.001", "0.0 0.1"),
     //
     ("infinite", "color", "L", "1.0 1.0 1.0", ""),
     ("infinite", "color", "scale", "1.0 1.0 1.0", ""),

--- a/src/render/wgpu/aabb_renderer.rs
+++ b/src/render/wgpu/aabb_renderer.rs
@@ -122,7 +122,8 @@ impl AabbRenderer {
         self.local_matrices.reserve(num_items);
 
         let local_uniform_alignment = self.local_uniform_alignment;
-        if self.local_uniform_buffer.size() < (num_items as wgpu::BufferAddress * local_uniform_alignment)
+        if self.local_uniform_buffer.size()
+            < (num_items as wgpu::BufferAddress * local_uniform_alignment)
         {
             let new_buffer = create_local_uniform_buffer(device, num_items);
             let new_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -142,7 +143,8 @@ impl AabbRenderer {
         }
 
         for (i, mesh_item) in mesh_items.iter().enumerate() {
-            let local = create_aabb_local_transform(mesh_item.mesh.aabb.min, mesh_item.mesh.aabb.max);
+            let local =
+                create_aabb_local_transform(mesh_item.mesh.aabb.min, mesh_item.mesh.aabb.max);
             let local_to_world = mesh_item.matrix * local;
             self.local_matrices.push(local_to_world);
 
@@ -150,7 +152,11 @@ impl AabbRenderer {
                 local_to_world: local_to_world.to_cols_array_2d(),
             };
             let offset = i as wgpu::BufferAddress * local_uniform_alignment;
-            queue.write_buffer(&self.local_uniform_buffer, offset, bytemuck::bytes_of(&uniform));
+            queue.write_buffer(
+                &self.local_uniform_buffer,
+                offset,
+                bytemuck::bytes_of(&uniform),
+            );
         }
 
         let global_uniforms = GlobalUniforms {
@@ -173,13 +179,18 @@ impl AabbRenderer {
         render_pass.set_bind_group(0, &self.global_bind_group, &[]);
         render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
         for i in 0..self.local_matrices.len() {
-            let local_uniform_offset = i as wgpu::DynamicOffset * local_uniform_alignment as wgpu::DynamicOffset;
+            let local_uniform_offset =
+                i as wgpu::DynamicOffset * local_uniform_alignment as wgpu::DynamicOffset;
             render_pass.set_bind_group(1, &self.local_bind_group, &[local_uniform_offset]);
             render_pass.draw(0..self.vertex_count, 0..1);
         }
     }
 
-    pub fn new(device: &wgpu::Device, _queue: &wgpu::Queue, target_format: wgpu::TextureFormat) -> Self {
+    pub fn new(
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        target_format: wgpu::TextureFormat,
+    ) -> Self {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("AABB Shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("shaders/render_aabb.wgsl").into()),
@@ -287,7 +298,8 @@ impl AabbRenderer {
 
         let local_uniform_size = size_of::<LocalUniforms>() as wgpu::BufferAddress;
         let local_uniform_alignment = {
-            let alignment = device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+            let alignment =
+                device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
             align_to(local_uniform_size, alignment)
         };
 

--- a/src/render/wgpu/aabb_renderer.rs
+++ b/src/render/wgpu/aabb_renderer.rs
@@ -1,0 +1,330 @@
+use super::lines::RenderLinesVertex;
+use super::render_item::RenderItem;
+use std::sync::Arc;
+
+use bytemuck::{Pod, Zeroable};
+use eframe::wgpu;
+use eframe::wgpu::util::DeviceExt;
+use wgpu::util::align_to;
+
+const MIN_LOCAL_BUFFER_NUM: usize = 64;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+struct GlobalUniforms {
+    world_to_camera: [[f32; 4]; 4],
+    camera_to_clip: [[f32; 4]; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+struct LocalUniforms {
+    local_to_world: [[f32; 4]; 4],
+}
+
+#[derive(Debug, Clone)]
+pub struct AabbRenderer {
+    pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    vertex_count: u32,
+    #[allow(dead_code)]
+    global_bind_group_layout: wgpu::BindGroupLayout,
+    global_bind_group: wgpu::BindGroup,
+    global_uniform_buffer: wgpu::Buffer,
+    local_bind_group_layout: wgpu::BindGroupLayout,
+    local_bind_group: wgpu::BindGroup,
+    local_uniform_buffer: wgpu::Buffer,
+    local_uniform_alignment: wgpu::BufferAddress,
+    local_matrices: Vec<glam::Mat4>,
+}
+
+fn create_local_uniform_buffer(device: &wgpu::Device, num_items: usize) -> wgpu::Buffer {
+    let local_uniform_size = std::mem::size_of::<LocalUniforms>() as wgpu::BufferAddress;
+    let uniform_alignment = {
+        let alignment = device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+        align_to(local_uniform_size, alignment)
+    };
+    let required_size = uniform_alignment * num_items as wgpu::BufferAddress;
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("AABB Local Uniform Buffer"),
+        size: required_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+        mapped_at_creation: false,
+    })
+}
+
+fn create_box_line_vertices() -> Vec<RenderLinesVertex> {
+    let p000 = [-1.0, -1.0, -1.0];
+    let p001 = [-1.0, -1.0, 1.0];
+    let p010 = [-1.0, 1.0, -1.0];
+    let p011 = [-1.0, 1.0, 1.0];
+    let p100 = [1.0, -1.0, -1.0];
+    let p101 = [1.0, -1.0, 1.0];
+    let p110 = [1.0, 1.0, -1.0];
+    let p111 = [1.0, 1.0, 1.0];
+
+    let edges = [
+        (p000, p001),
+        (p001, p011),
+        (p011, p010),
+        (p010, p000),
+        (p100, p101),
+        (p101, p111),
+        (p111, p110),
+        (p110, p100),
+        (p000, p100),
+        (p001, p101),
+        (p011, p111),
+        (p010, p110),
+    ];
+
+    let mut vertices = Vec::with_capacity(edges.len() * 2);
+    for (start, end) in edges {
+        vertices.push(RenderLinesVertex { position: start });
+        vertices.push(RenderLinesVertex { position: end });
+    }
+    vertices
+}
+
+fn create_aabb_local_transform(min: [f32; 3], max: [f32; 3]) -> glam::Mat4 {
+    let min = glam::vec3(min[0], min[1], min[2]);
+    let max = glam::vec3(max[0], max[1], max[2]);
+    let center = (min + max) * 0.5;
+    let half_extent = (max - min) * 0.5;
+    let epsilon = 1e-5;
+    let safe_half_extent = glam::vec3(
+        half_extent.x.max(epsilon),
+        half_extent.y.max(epsilon),
+        half_extent.z.max(epsilon),
+    );
+    glam::Mat4::from_scale_rotation_translation(safe_half_extent, glam::Quat::IDENTITY, center)
+}
+
+impl AabbRenderer {
+    pub fn prepare(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        render_items: &[Arc<RenderItem>],
+        world_to_camera: &glam::Mat4,
+        camera_to_clip: &glam::Mat4,
+    ) {
+        let mesh_items = render_items
+            .iter()
+            .filter_map(|item| match item.as_ref() {
+                RenderItem::Mesh(mesh_item) => Some(mesh_item),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        let num_items = mesh_items.len();
+        self.local_matrices.clear();
+        self.local_matrices.reserve(num_items);
+
+        let local_uniform_alignment = self.local_uniform_alignment;
+        if self.local_uniform_buffer.size() < (num_items as wgpu::BufferAddress * local_uniform_alignment)
+        {
+            let new_buffer = create_local_uniform_buffer(device, num_items);
+            let new_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("AABB Local Bind Group"),
+                layout: &self.local_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &new_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(size_of::<LocalUniforms>() as _),
+                    }),
+                }],
+            });
+            self.local_uniform_buffer = new_buffer;
+            self.local_bind_group = new_bind_group;
+        }
+
+        for (i, mesh_item) in mesh_items.iter().enumerate() {
+            let local = create_aabb_local_transform(mesh_item.mesh.aabb.min, mesh_item.mesh.aabb.max);
+            let local_to_world = mesh_item.matrix * local;
+            self.local_matrices.push(local_to_world);
+
+            let uniform = LocalUniforms {
+                local_to_world: local_to_world.to_cols_array_2d(),
+            };
+            let offset = i as wgpu::BufferAddress * local_uniform_alignment;
+            queue.write_buffer(&self.local_uniform_buffer, offset, bytemuck::bytes_of(&uniform));
+        }
+
+        let global_uniforms = GlobalUniforms {
+            world_to_camera: world_to_camera.to_cols_array_2d(),
+            camera_to_clip: camera_to_clip.to_cols_array_2d(),
+        };
+        queue.write_buffer(
+            &self.global_uniform_buffer,
+            0,
+            bytemuck::bytes_of(&global_uniforms),
+        );
+    }
+
+    pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
+        if self.local_matrices.is_empty() {
+            return;
+        }
+        let local_uniform_alignment = self.local_uniform_alignment;
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.global_bind_group, &[]);
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+        for i in 0..self.local_matrices.len() {
+            let local_uniform_offset = i as wgpu::DynamicOffset * local_uniform_alignment as wgpu::DynamicOffset;
+            render_pass.set_bind_group(1, &self.local_bind_group, &[local_uniform_offset]);
+            render_pass.draw(0..self.vertex_count, 0..1);
+        }
+    }
+
+    pub fn new(device: &wgpu::Device, _queue: &wgpu::Queue, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("AABB Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/render_aabb.wgsl").into()),
+        });
+
+        let vertex_buffer_layout = [wgpu::VertexBufferLayout {
+            array_stride: size_of::<RenderLinesVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[wgpu::VertexAttribute {
+                format: wgpu::VertexFormat::Float32x3,
+                offset: 0,
+                shader_location: 0,
+            }],
+        }];
+
+        let global_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("AABB Global Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(size_of::<GlobalUniforms>() as _),
+                    },
+                    count: None,
+                }],
+            });
+
+        let local_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("AABB Local Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(size_of::<LocalUniforms>() as _),
+                    },
+                    count: None,
+                }],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("AABB Pipeline Layout"),
+            bind_group_layouts: &[&global_bind_group_layout, &local_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let primitive = wgpu::PrimitiveState {
+            cull_mode: None,
+            topology: wgpu::PrimitiveTopology::LineList,
+            polygon_mode: wgpu::PolygonMode::Line,
+            ..Default::default()
+        };
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("AABB Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &vertex_buffer_layout,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(target_format.into())],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive,
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: false,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let global_uniforms = GlobalUniforms {
+            world_to_camera: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            camera_to_clip: glam::Mat4::IDENTITY.to_cols_array_2d(),
+        };
+        let global_uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("AABB Global Uniform Buffer"),
+            contents: bytemuck::bytes_of(&global_uniforms),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+        });
+
+        let global_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("AABB Global Bind Group"),
+            layout: &global_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: global_uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        let local_uniform_size = size_of::<LocalUniforms>() as wgpu::BufferAddress;
+        let local_uniform_alignment = {
+            let alignment = device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+            align_to(local_uniform_size, alignment)
+        };
+
+        let local_uniform_buffer = create_local_uniform_buffer(device, MIN_LOCAL_BUFFER_NUM);
+        let local_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("AABB Local Bind Group"),
+            layout: &local_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &local_uniform_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(size_of::<LocalUniforms>() as _),
+                }),
+            }],
+        });
+
+        let vertices = create_box_line_vertices();
+        let vertex_count = vertices.len() as u32;
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("AABB Vertex Buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        Self {
+            pipeline,
+            vertex_buffer,
+            vertex_count,
+            global_bind_group_layout,
+            global_bind_group,
+            global_uniform_buffer,
+            local_bind_group_layout,
+            local_bind_group,
+            local_uniform_buffer,
+            local_uniform_alignment,
+            local_matrices: Vec::new(),
+        }
+    }
+}

--- a/src/render/wgpu/camera.rs
+++ b/src/render/wgpu/camera.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Clone)]
+pub struct RenderCamera {
+    pub world_to_camera: glam::Mat4,
+    pub camera_to_world: glam::Mat4,
+    pub camera_to_clip: glam::Mat4,
+    pub position: glam::Vec3,
+    pub forward: glam::Vec3,
+    pub up: glam::Vec3,
+    pub right: glam::Vec3,
+}
+
+impl RenderCamera {
+    pub fn from_matrices(world_to_camera: glam::Mat4, camera_to_clip: glam::Mat4) -> Self {
+        let camera_to_world = world_to_camera.inverse();
+        let position = camera_to_world.transform_point3(glam::Vec3::ZERO);
+        let forward = camera_to_world
+            .transform_vector3(glam::vec3(0.0, 0.0, -1.0))
+            .normalize_or_zero();
+        let up = camera_to_world
+            .transform_vector3(glam::vec3(0.0, 1.0, 0.0))
+            .normalize_or_zero();
+        let right = camera_to_world
+            .transform_vector3(glam::vec3(1.0, 0.0, 0.0))
+            .normalize_or_zero();
+        Self {
+            world_to_camera,
+            camera_to_world,
+            camera_to_clip,
+            position,
+            forward,
+            up,
+            right,
+        }
+    }
+}

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -9,7 +9,7 @@ pub struct DirectionalRenderLight {
     pub direction: [f32; 3],
     pub intensity: [f32; 3], // RGB intensity
     pub source_angle: f32,   // Angular diameter of the light source in radians
-    pub cast_shadow: bool,    // Whether the light casts shadow
+    pub cast_shadow: bool,   // Whether the light casts shadow
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -10,6 +10,7 @@ pub struct DirectionalRenderLight {
     pub intensity: [f32; 3], // RGB intensity
     pub source_angle: f32,   // Angular diameter of the light source in radians
     pub cast_shadow: bool,   // Whether the light casts shadow
+    pub shadow_bias: f32,    // Shadow depth bias
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -9,6 +9,7 @@ pub struct DirectionalRenderLight {
     pub direction: [f32; 3],
     pub intensity: [f32; 3], // RGB intensity
     pub source_angle: f32,   // Angular diameter of the light source in radians
+    pub cast_shadow: bool,    // Whether the light casts shadow
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -63,7 +63,8 @@ struct DirectionalLight {
     direction: [f32; 4], // Direction of the light // 4 * 4 = 16
     intensity: [f32; 4], // Intensity of the light // 4 * 4 = 16
     radius: f32,         // Radius of the light // 1 * 4 = 4
-    _pad1: [f32; 3],     // Padding // 3 * 4 = 12
+    shadow_index: i32,   // Index for the shadow map -1 if no shadow // 1 * 4 = 4
+    _pad1: [f32; 2],     // Padding // 2 * 4 = 8
 }
 
 #[repr(C)]
@@ -885,11 +886,14 @@ impl LightingMeshRenderer {
 
                     let radius = (0.5 * light.source_angle).tan();
 
+                    let shadow_index = -1; //TODO: support shadows for directional lights
+
                     let light = DirectionalLight {
                         direction: [direction[0], direction[1], direction[2], 0.0],
                         intensity: [intensity[0], intensity[1], intensity[2], 1.0],
                         radius,
-                        _pad1: [0.0; 3],
+                        shadow_index,
+                        _pad1: [0.0; 2],
                     };
                     light_buffer.push(light);
                 }

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -9,6 +9,7 @@ use super::shadow::create_directional_light_shadows;
 use super::texture::RenderTexture;
 use crate::render::wgpu::light::RenderLight;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -32,6 +33,7 @@ const MAX_LIGHT_TEXTURE_NUM: usize = 1; // Maximum number of light textures
 const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8_40a5fa168488);
 const DIRECTIONAL_SHADOW_PIPELINE_ID: Uuid =
     Uuid::from_u128(0x77dd5bcc_89c5_4eff_8adf_9b5f8667d9f1);
+const Z_PREPASS_PIPELINE_ID: Uuid = Uuid::from_u128(0x9979b259_39f8_4ce5_8ea5_d8078618620f);
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
@@ -167,9 +169,16 @@ struct MaterialBindGroupEntry {
 }
 
 #[derive(Debug, Clone)]
+enum PipelinePassType {
+    Shading,
+    ZPrepass,
+    ShadowDirectional,
+}
+
+#[derive(Debug, Clone)]
 struct PipelineEntry {
+    pub pass_type: PipelinePassType,
     pub pipeline: wgpu::RenderPipeline,
-    pub z_prepass_pipeline: Option<wgpu::RenderPipeline>,
     pub material_bind_group_layout: wgpu::BindGroupLayout,
     pub material_bind_groups: Vec<Arc<MaterialBindGroupEntry>>,
     pub mesh_indices: Vec<usize>,
@@ -242,6 +251,11 @@ fn get_shader_uses_z_prepass(category: RenderCategory) -> bool {
     category == RenderCategory::Opaque || category == RenderCategory::Emissive
 }
 
+fn get_shader_uses_shadow(category: RenderCategory) -> bool {
+    // Keep shadow-caster selection independent from z-prepass policy.
+    category == RenderCategory::Opaque || category == RenderCategory::Emissive
+}
+
 impl LightingMeshRenderer {
     pub fn prepare(
         &mut self,
@@ -261,7 +275,7 @@ impl LightingMeshRenderer {
                 queue,
                 render_resource_manager,
                 camera,
-                render_items,
+                &mesh_items,
                 &light_items,
             ); //group(3)
         }
@@ -301,55 +315,39 @@ impl LightingMeshRenderer {
             )
         };
 
-        let mut pipelines = vec![];
-        for pipeline_entry in self.pipelines.values() {
-            let mut sort_order = 0;
-            {
-                let pipeline_entry = pipeline_entry.read().unwrap();
-                if pipeline_entry.mesh_indices.is_empty() {
-                    continue;
-                }
-                sort_order = pipeline_entry.sort_order;
-            }
-            pipelines.push((sort_order, pipeline_entry.clone()));
-        }
-
-        //TODO: sort pipelines to minimize pipeline switching
-        pipelines.sort_by(|a, b| a.0.cmp(&b.0));
-
         let mut z_prepass_pipelines = Vec::new();
         let mut shading_pipelines = Vec::new();
-        for (_, pipeline_entry) in pipelines.iter() {
+        for pipeline_entry in self.pipelines.values() {
             let pipeline_entry = pipeline_entry.read().unwrap();
-            if pipeline_entry.z_prepass_pipeline.is_some() {
-                z_prepass_pipelines.push(pipeline_entry.clone());
+            if pipeline_entry.mesh_indices.is_empty() {
+                continue;
             }
-            shading_pipelines.push(pipeline_entry.clone());
+            match pipeline_entry.pass_type {
+                PipelinePassType::ZPrepass => z_prepass_pipelines.push(pipeline_entry.clone()),
+                PipelinePassType::Shading => shading_pipelines.push(pipeline_entry.clone()),
+                PipelinePassType::ShadowDirectional => {}
+            }
         }
+        //TODO: sort pipelines to minimize pipeline switching
+        shading_pipelines.sort_by(|a, b| a.sort_order.cmp(&b.sort_order));
 
         // Depth-only prepass for opaque-like geometry.
         for pipeline_entry in z_prepass_pipelines.iter() {
-            if let Some(z_prepass_pipeline) = &pipeline_entry.z_prepass_pipeline {
-                render_pass.set_pipeline(z_prepass_pipeline);
-                render_pass.set_bind_group(0, &self.global_bind_group, &[]);
-                let length = pipeline_entry.mesh_indices.len();
-                for i in 0..length {
-                    let item_index = pipeline_entry.mesh_indices[i];
-                    if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
-                        let local_uniform_offset = item_index as wgpu::DynamicOffset
-                            * local_uniform_alignment as wgpu::DynamicOffset;
-                        render_pass.set_bind_group(
-                            1,
-                            &self.local_bind_group,
-                            &[local_uniform_offset],
-                        );
-                        render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
-                        render_pass.set_index_buffer(
-                            mesh_item.mesh.index_buffer.slice(..),
-                            wgpu::IndexFormat::Uint32,
-                        );
-                        render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
-                    }
+            render_pass.set_pipeline(&pipeline_entry.pipeline);
+            render_pass.set_bind_group(0, &self.global_bind_group, &[]);
+            let length = pipeline_entry.mesh_indices.len();
+            for i in 0..length {
+                let item_index = pipeline_entry.mesh_indices[i];
+                if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
+                    let local_uniform_offset = item_index as wgpu::DynamicOffset
+                        * local_uniform_alignment as wgpu::DynamicOffset;
+                    render_pass.set_bind_group(1, &self.local_bind_group, &[local_uniform_offset]);
+                    render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
+                    render_pass.set_index_buffer(
+                        mesh_item.mesh.index_buffer.slice(..),
+                        wgpu::IndexFormat::Uint32,
+                    );
+                    render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
                 }
             }
         }
@@ -557,12 +555,15 @@ impl LightingMeshRenderer {
                 let mut entry = entry.write().unwrap();
                 entry.mesh_indices.clear();
                 entry.material_indices.clear();
-                for bind_group in entry.material_bind_groups.iter() {
-                    prev_bind_groups.insert(bind_group.id, bind_group.clone());
+                if matches!(entry.pass_type, PipelinePassType::Shading) {
+                    for bind_group in entry.material_bind_groups.iter() {
+                        prev_bind_groups.insert(bind_group.id, bind_group.clone());
+                    }
                 }
                 entry.material_bind_groups.clear();
             }
             let mut tmp_pipelines: HashMap<Uuid, TmpPipelineEntry> = HashMap::new();
+            let mut z_prepass_mesh_indices: HashSet<usize> = HashSet::new();
             for (mesh_index, item) in mesh_items.iter().enumerate() {
                 if let Some(material) = item.get_material() {
                     for pass in material.passes.iter() {
@@ -582,6 +583,9 @@ impl LightingMeshRenderer {
                             entry
                                 .material_indices_map
                                 .insert(pass_id, (new_material_index, pass.clone()));
+                        }
+                        if get_shader_uses_z_prepass(pass.render_category) {
+                            z_prepass_mesh_indices.insert(mesh_index);
                         }
                     }
                 }
@@ -632,6 +636,23 @@ impl LightingMeshRenderer {
                         entry.material_bind_groups.push(Arc::new(bind_group_entry));
                     }
                 }
+            }
+
+            if !z_prepass_mesh_indices.is_empty() {
+                if !self.pipelines.contains_key(&Z_PREPASS_PIPELINE_ID) {
+                    let entry = self.create_z_prepass_pipeline(device);
+                    self.pipelines
+                        .insert(Z_PREPASS_PIPELINE_ID, Arc::new(RwLock::new(entry)));
+                }
+                if let Some(entry) = self.pipelines.get_mut(&Z_PREPASS_PIPELINE_ID) {
+                    let mut entry = entry.write().unwrap();
+                    let mut indices: Vec<usize> = z_prepass_mesh_indices.into_iter().collect();
+                    indices.sort_unstable();
+                    entry.mesh_indices = indices;
+                    entry.material_indices.clear();
+                }
+            } else {
+                self.pipelines.remove(&Z_PREPASS_PIPELINE_ID);
             }
         }
         self.mesh_items = mesh_items.to_vec();
@@ -693,20 +714,42 @@ impl LightingMeshRenderer {
         queue: &wgpu::Queue,
         render_resource_manager: &mut RenderResourceManager,
         camera: &RenderCamera,
-        all_render_items: &[Arc<RenderItem>],
-        light_render_items: &[Arc<RenderItem>],
+        mesh_items: &[Arc<RenderItem>],
+        light_items: &[Arc<RenderItem>],
     ) {
         let mut light_uniforms = LightUniforms::default();
         let mut light_textures = Vec::new();
+        let shadow_mesh_indices = mesh_items
+            .iter()
+            .enumerate()
+            .filter_map(|(i, item)| {
+                item.get_material().and_then(|material| {
+                    if material
+                        .passes
+                        .iter()
+                        .any(|pass| get_shader_uses_shadow(pass.render_category))
+                    {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
 
         let directional_light_shadows = create_directional_light_shadows(
             device,
             queue,
             camera,
-            all_render_items,
+            mesh_items,
+            light_items,
             render_resource_manager,
         );
-        self.update_directional_shadow_pipeline_entry(device, !directional_light_shadows.is_empty());
+        self.update_directional_shadow_pipeline_entry(
+            device,
+            !directional_light_shadows.is_empty(),
+            &shadow_mesh_indices,
+        );
         let mut directional_shadow_index_map = HashMap::new();
         for (i, shadow) in directional_light_shadows.iter().enumerate() {
             directional_shadow_index_map.insert(shadow.id, i as i32);
@@ -715,7 +758,7 @@ impl LightingMeshRenderer {
         // Point lights
         {
             let mut light_buffer = Vec::new();
-            for item in light_render_items.iter() {
+            for item in light_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderItem::Light(item) = item.as_ref()
                     && let RenderLight::Sphere(light) = item.light.as_ref()
@@ -753,7 +796,7 @@ impl LightingMeshRenderer {
         // Spot lights
         {
             let mut light_buffer = Vec::new();
-            for item in light_render_items.iter() {
+            for item in light_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Disk(light) = light_item.light.as_ref()
                 {
@@ -804,7 +847,7 @@ impl LightingMeshRenderer {
         // Rect lights
         {
             let mut light_buffer = Vec::new();
-            for item in light_render_items.iter() {
+            for item in light_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Rect(rect) = light_item.light.as_ref()
                 {
@@ -854,7 +897,7 @@ impl LightingMeshRenderer {
         // Infinite lights
         {
             let mut light_buffer = Vec::new();
-            for item in light_render_items.iter() {
+            for item in light_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Infinite(light) = light_item.light.as_ref()
                 {
@@ -894,7 +937,7 @@ impl LightingMeshRenderer {
         // Directional lights
         {
             let mut light_buffer = Vec::new();
-            for item in light_render_items.iter() {
+            for item in light_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Directional(light) = light_item.light.as_ref()
                 {
@@ -973,112 +1016,119 @@ impl LightingMeshRenderer {
         &mut self,
         device: &wgpu::Device,
         has_directional_shadows: bool,
+        shadow_mesh_indices: &[usize],
     ) {
         if !has_directional_shadows {
             self.pipelines.remove(&DIRECTIONAL_SHADOW_PIPELINE_ID);
             return;
         }
-        if self.pipelines.contains_key(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
-            return;
-        }
-
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Directional Shadow Pipeline Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/lighting_z_prepass.wgsl").into()),
-        });
-
-        let vertex_buffer_layout = [wgpu::VertexBufferLayout {
-            array_stride: size_of::<RenderVertex>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    offset: std::mem::size_of::<f32>() as u64 * 3,
-                    shader_location: 1,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    offset: std::mem::size_of::<f32>() as u64 * 6,
-                    shader_location: 2,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    offset: std::mem::size_of::<f32>() as u64 * 9,
-                    shader_location: 3,
-                },
-            ],
-        }];
-
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("Directional Shadow Pipeline Layout"),
-            bind_group_layouts: &[&self.global_bind_group_layout, &self.local_bind_group_layout],
-            push_constant_ranges: &[],
-        });
-
-        let primitive = wgpu::PrimitiveState {
-            topology: wgpu::PrimitiveTopology::TriangleList,
-            polygon_mode: wgpu::PolygonMode::Fill,
-            ..Default::default()
-        };
-
-        let depth_texture_format = wgpu::TextureFormat::Depth32Float;
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Directional Shadow Pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                buffers: &vertex_buffer_layout,
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: self.target_format,
-                    blend: None,
-                    write_mask: wgpu::ColorWrites::empty(),
-                })],
-                compilation_options: wgpu::PipelineCompilationOptions::default(),
-            }),
-            primitive,
-            depth_stencil: Some(wgpu::DepthStencilState {
-                format: depth_texture_format,
-                depth_write_enabled: true,
-                depth_compare: wgpu::CompareFunction::LessEqual,
-                stencil: wgpu::StencilState::default(),
-                bias: wgpu::DepthBiasState::default(),
-            }),
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-            cache: None,
-        });
-
-        let material_bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("Directional Shadow Material Bind Group Layout"),
-                entries: &[],
+        if !self.pipelines.contains_key(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("Directional Shadow Pipeline Shader"),
+                source: wgpu::ShaderSource::Wgsl(
+                    include_str!("shaders/lighting_z_prepass.wgsl").into(),
+                ),
             });
 
-        let entry = PipelineEntry {
-            pipeline,
-            z_prepass_pipeline: None,
-            material_bind_group_layout,
-            material_bind_groups: Vec::new(),
-            mesh_indices: Vec::new(),
-            material_indices: Vec::new(),
-            sort_order: 0,
-            enable_lighting: false,
-        };
-        self.pipelines.insert(
-            DIRECTIONAL_SHADOW_PIPELINE_ID,
-            Arc::new(RwLock::new(entry)),
-        );
+            let vertex_buffer_layout = [wgpu::VertexBufferLayout {
+                array_stride: size_of::<RenderVertex>() as wgpu::BufferAddress,
+                step_mode: wgpu::VertexStepMode::Vertex,
+                attributes: &[
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: 0,
+                        shader_location: 0,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: std::mem::size_of::<f32>() as u64 * 3,
+                        shader_location: 1,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: std::mem::size_of::<f32>() as u64 * 6,
+                        shader_location: 2,
+                    },
+                    wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x3,
+                        offset: std::mem::size_of::<f32>() as u64 * 9,
+                        shader_location: 3,
+                    },
+                ],
+            }];
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Directional Shadow Pipeline Layout"),
+                bind_group_layouts: &[&self.global_bind_group_layout, &self.local_bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+            let primitive = wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                ..Default::default()
+            };
+
+            let depth_texture_format = wgpu::TextureFormat::Depth32Float;
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("Directional Shadow Pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &vertex_buffer_layout,
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: self.target_format,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::empty(),
+                    })],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive,
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: depth_texture_format,
+                    depth_write_enabled: true,
+                    depth_compare: wgpu::CompareFunction::LessEqual,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            });
+
+            let material_bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("Directional Shadow Material Bind Group Layout"),
+                    entries: &[],
+                });
+
+            let entry = PipelineEntry {
+                pass_type: PipelinePassType::ShadowDirectional,
+                pipeline,
+                material_bind_group_layout,
+                material_bind_groups: Vec::new(),
+                mesh_indices: shadow_mesh_indices.to_vec(),
+                material_indices: Vec::new(),
+                sort_order: 0,
+                enable_lighting: false,
+            };
+            self.pipelines.insert(
+                DIRECTIONAL_SHADOW_PIPELINE_ID,
+                Arc::new(RwLock::new(entry)),
+            );
+        }
+
+        if let Some(entry) = self.pipelines.get_mut(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
+            let mut entry = entry.write().unwrap();
+            entry.mesh_indices = shadow_mesh_indices.to_vec();
+            entry.material_indices.clear();
+        }
     }
 
     fn create_pipeline(
@@ -1091,7 +1141,6 @@ impl LightingMeshRenderer {
         let render_category = pass.render_category;
         let material_uniform_size = pass.uniform_values.len();
         let has_lighting = get_shader_has_lighting(render_category);
-        let uses_z_prepass = get_shader_uses_z_prepass(render_category);
         let sort_order = render_category as u32;
 
         let vertex_buffer_layout = [wgpu::VertexBufferLayout {
@@ -1210,7 +1259,7 @@ impl LightingMeshRenderer {
         {
             depth_write_enabled = false;
         }
-        if uses_z_prepass {
+        if get_shader_uses_z_prepass(render_category) {
             depth_write_enabled = false;
         }
 
@@ -1250,63 +1299,10 @@ impl LightingMeshRenderer {
             cache: None,
         });
 
-        let z_prepass_pipeline = if uses_z_prepass {
-            let z_prepass_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("Lighting Z Prepass Shader"),
-                source: wgpu::ShaderSource::Wgsl(
-                    include_str!("shaders/lighting_z_prepass.wgsl").into(),
-                ),
-            });
-            let z_prepass_pipeline_layout =
-                device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                    label: Some("Lighting Z Prepass Pipeline Layout"),
-                    bind_group_layouts: &[
-                        &self.global_bind_group_layout,
-                        &self.local_bind_group_layout,
-                    ],
-                    push_constant_ranges: &[],
-                });
-            Some(
-                device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                    label: Some("Lighting Z Prepass Pipeline"),
-                    layout: Some(&z_prepass_pipeline_layout),
-                    vertex: wgpu::VertexState {
-                        module: &z_prepass_shader,
-                        entry_point: Some("vs_main"),
-                        buffers: &vertex_buffer_layout,
-                        compilation_options: wgpu::PipelineCompilationOptions::default(),
-                    },
-                    fragment: Some(wgpu::FragmentState {
-                        module: &z_prepass_shader,
-                        entry_point: Some("fs_main"),
-                        targets: &[Some(wgpu::ColorTargetState {
-                            format: color_texture_format,
-                            blend: None,
-                            write_mask: wgpu::ColorWrites::empty(),
-                        })],
-                        compilation_options: wgpu::PipelineCompilationOptions::default(),
-                    }),
-                    primitive,
-                    depth_stencil: Some(wgpu::DepthStencilState {
-                        format: depth_texture_format,
-                        depth_write_enabled: true,
-                        depth_compare: wgpu::CompareFunction::LessEqual,
-                        stencil: wgpu::StencilState::default(),
-                        bias: wgpu::DepthBiasState::default(),
-                    }),
-                    multisample: wgpu::MultisampleState::default(),
-                    multiview: None,
-                    cache: None,
-                }),
-            )
-        } else {
-            None
-        };
-
         // Create a uniform buffer for material properties
         let entry = PipelineEntry {
+            pass_type: PipelinePassType::Shading,
             pipeline,
-            z_prepass_pipeline,
             material_bind_group_layout,
             material_bind_groups: Vec::new(),
             mesh_indices: Vec::new(),
@@ -1315,6 +1311,101 @@ impl LightingMeshRenderer {
             enable_lighting: has_lighting,
         };
         return entry;
+    }
+
+    fn create_z_prepass_pipeline(&self, device: &wgpu::Device) -> PipelineEntry {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Lighting Z Prepass Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/lighting_z_prepass.wgsl").into()),
+        });
+
+        let vertex_buffer_layout = [wgpu::VertexBufferLayout {
+            array_stride: size_of::<RenderVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: 0,
+                    shader_location: 0,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: std::mem::size_of::<f32>() as u64 * 3,
+                    shader_location: 1,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: std::mem::size_of::<f32>() as u64 * 6,
+                    shader_location: 2,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: std::mem::size_of::<f32>() as u64 * 9,
+                    shader_location: 3,
+                },
+            ],
+        }];
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Lighting Z Prepass Pipeline Layout"),
+            bind_group_layouts: &[&self.global_bind_group_layout, &self.local_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let primitive = wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            ..Default::default()
+        };
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Lighting Z Prepass Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &vertex_buffer_layout,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: self.target_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::empty(),
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive,
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let material_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Lighting Z Prepass Material Bind Group Layout"),
+                entries: &[],
+            });
+
+        PipelineEntry {
+            pass_type: PipelinePassType::ZPrepass,
+            pipeline,
+            material_bind_group_layout,
+            material_bind_groups: Vec::new(),
+            mesh_indices: Vec::new(),
+            material_indices: Vec::new(),
+            sort_order: 0,
+            enable_lighting: false,
+        }
     }
 }
 

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -172,7 +172,7 @@ struct MaterialBindGroupEntry {
 enum PipelinePassType {
     Shading,
     ZPrepass,
-    ShadowDirectional,
+    Shadow,
 }
 
 #[derive(Debug, Clone)]
@@ -315,6 +315,7 @@ impl LightingMeshRenderer {
             )
         };
 
+        let mut shadow_pipelies = Vec::new();
         let mut z_prepass_pipelines = Vec::new();
         let mut shading_pipelines = Vec::new();
         for pipeline_entry in self.pipelines.values() {
@@ -325,7 +326,7 @@ impl LightingMeshRenderer {
             match pipeline_entry.pass_type {
                 PipelinePassType::ZPrepass => z_prepass_pipelines.push(pipeline_entry.clone()),
                 PipelinePassType::Shading => shading_pipelines.push(pipeline_entry.clone()),
-                PipelinePassType::ShadowDirectional => {}
+                PipelinePassType::Shadow => shadow_pipelies.push(pipeline_entry.clone()),
             }
         }
         //TODO: sort pipelines to minimize pipeline switching
@@ -395,12 +396,7 @@ impl LightingMeshRenderer {
         }
     }
 
-    fn prepare_global(
-        &self,
-        _device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        camera: &RenderCamera,
-    ) {
+    fn prepare_global(&self, _device: &wgpu::Device, queue: &wgpu::Queue, camera: &RenderCamera) {
         let global_uniforms = GlobalUniforms {
             world_to_camera: camera.world_to_camera.to_cols_array_2d(),
             camera_to_clip: camera.camera_to_clip.to_cols_array_2d(),
@@ -1059,7 +1055,10 @@ impl LightingMeshRenderer {
 
             let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("Directional Shadow Pipeline Layout"),
-                bind_group_layouts: &[&self.global_bind_group_layout, &self.local_bind_group_layout],
+                bind_group_layouts: &[
+                    &self.global_bind_group_layout,
+                    &self.local_bind_group_layout,
+                ],
                 push_constant_ranges: &[],
             });
 
@@ -1109,7 +1108,7 @@ impl LightingMeshRenderer {
                 });
 
             let entry = PipelineEntry {
-                pass_type: PipelinePassType::ShadowDirectional,
+                pass_type: PipelinePassType::Shadow,
                 pipeline,
                 material_bind_group_layout,
                 material_bind_groups: Vec::new(),
@@ -1118,10 +1117,8 @@ impl LightingMeshRenderer {
                 sort_order: 0,
                 enable_lighting: false,
             };
-            self.pipelines.insert(
-                DIRECTIONAL_SHADOW_PIPELINE_ID,
-                Arc::new(RwLock::new(entry)),
-            );
+            self.pipelines
+                .insert(DIRECTIONAL_SHADOW_PIPELINE_ID, Arc::new(RwLock::new(entry)));
         }
 
         if let Some(entry) = self.pipelines.get_mut(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
@@ -1316,7 +1313,9 @@ impl LightingMeshRenderer {
     fn create_z_prepass_pipeline(&self, device: &wgpu::Device) -> PipelineEntry {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Lighting Z Prepass Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/lighting_z_prepass.wgsl").into()),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("shaders/lighting_z_prepass.wgsl").into(),
+            ),
         });
 
         let vertex_buffer_layout = [wgpu::VertexBufferLayout {
@@ -1348,7 +1347,10 @@ impl LightingMeshRenderer {
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Lighting Z Prepass Pipeline Layout"),
-            bind_group_layouts: &[&self.global_bind_group_layout, &self.local_bind_group_layout],
+            bind_group_layouts: &[
+                &self.global_bind_group_layout,
+                &self.local_bind_group_layout,
+            ],
             push_constant_ranges: &[],
         });
 

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -1,8 +1,11 @@
+use super::camera::RenderCamera;
 use super::material::RenderCategory;
 use super::material::RenderPass;
 use super::mesh::RenderVertex;
 use super::render_item::RenderItem;
+use super::render_resource::RenderResourceManager;
 use super::shader::RenderShader;
+use super::shadow::create_directional_light_shadows;
 use super::texture::RenderTexture;
 use crate::render::wgpu::light::RenderLight;
 use std::collections::HashMap;
@@ -27,6 +30,8 @@ const MAX_INFINITE_LIGHT_NUM: usize = 1; // Maximum number of infinite lights
 const MAX_LIGHT_TEXTURE_NUM: usize = 1; // Maximum number of light textures
 
 const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8_40a5fa168488);
+const DIRECTIONAL_SHADOW_PIPELINE_ID: Uuid =
+    Uuid::from_u128(0x77dd5bcc_89c5_4eff_8adf_9b5f8667d9f1);
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
@@ -200,6 +205,8 @@ pub struct LightingMeshRenderer {
     #[allow(dead_code)]
     ltc_bind_group_layout: wgpu::BindGroupLayout,
 
+    shadow_resource_manager: RenderResourceManager,
+
     // Mesh items to render
     mesh_items: Vec<Arc<RenderItem>>,
     // Textures used in the materials
@@ -243,15 +250,14 @@ impl LightingMeshRenderer {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         render_items: &[Arc<RenderItem>],
-        world_to_camera: &glam::Mat4,
-        camera_to_clip: &glam::Mat4,
+        camera: &RenderCamera,
     ) {
-        self.prepare_global(device, queue, world_to_camera, camera_to_clip); //group(0)
+        self.prepare_global(device, queue, camera); //group(0)
         {
             let (mesh_items, light_items) = Self::split_items(render_items);
             self.prepare_locals(device, queue, &mesh_items); //group(1)
             self.prepare_materials(device, queue, &mesh_items); //group(2)
-            self.prepare_lights(device, queue, &light_items); //group(3)
+            self.prepare_lights(device, queue, camera, render_items, &light_items); //group(3)
         }
     }
 
@@ -389,16 +395,13 @@ impl LightingMeshRenderer {
         &self,
         _device: &wgpu::Device,
         queue: &wgpu::Queue,
-        world_to_camera: &glam::Mat4,
-        camera_to_clip: &glam::Mat4,
+        camera: &RenderCamera,
     ) {
-        let camera_to_world = world_to_camera.inverse();
-        let camera_position = camera_to_world.transform_point3(glam::vec3(0.0, 0.0, 0.0));
         let global_uniforms = GlobalUniforms {
-            world_to_camera: world_to_camera.to_cols_array_2d(), // Identity matrix for now
-            camera_to_clip: camera_to_clip.to_cols_array_2d(),   // Identity matrix for now
-            camera_to_world: camera_to_world.to_cols_array_2d(), // Identity matrix for now
-            camera_position: [camera_position.x, camera_position.y, camera_position.z, 1.0],
+            world_to_camera: camera.world_to_camera.to_cols_array_2d(),
+            camera_to_clip: camera.camera_to_clip.to_cols_array_2d(),
+            camera_to_world: camera.camera_to_world.to_cols_array_2d(),
+            camera_position: [camera.position.x, camera.position.y, camera.position.z, 1.0],
         };
         let global_unifrom_buffer = &self.global_uniform_buffer;
         queue.write_buffer(
@@ -682,14 +685,30 @@ impl LightingMeshRenderer {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-        render_items: &[Arc<RenderItem>],
+        camera: &RenderCamera,
+        all_render_items: &[Arc<RenderItem>],
+        light_render_items: &[Arc<RenderItem>],
     ) {
         let mut light_uniforms = LightUniforms::default();
         let mut light_textures = Vec::new();
+
+        let directional_light_shadows = create_directional_light_shadows(
+            device,
+            queue,
+            camera,
+            all_render_items,
+            &mut self.shadow_resource_manager,
+        );
+        self.update_directional_shadow_pipeline_entry(device, !directional_light_shadows.is_empty());
+        let mut directional_shadow_index_map = HashMap::new();
+        for (i, shadow) in directional_light_shadows.iter().enumerate() {
+            directional_shadow_index_map.insert(shadow.id, i as i32);
+        }
+
         // Point lights
         {
             let mut light_buffer = Vec::new();
-            for item in render_items.iter() {
+            for item in light_render_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderItem::Light(item) = item.as_ref()
                     && let RenderLight::Sphere(light) = item.light.as_ref()
@@ -727,7 +746,7 @@ impl LightingMeshRenderer {
         // Spot lights
         {
             let mut light_buffer = Vec::new();
-            for item in render_items.iter() {
+            for item in light_render_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Disk(light) = light_item.light.as_ref()
                 {
@@ -778,7 +797,7 @@ impl LightingMeshRenderer {
         // Rect lights
         {
             let mut light_buffer = Vec::new();
-            for item in render_items.iter() {
+            for item in light_render_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Rect(rect) = light_item.light.as_ref()
                 {
@@ -828,7 +847,7 @@ impl LightingMeshRenderer {
         // Infinite lights
         {
             let mut light_buffer = Vec::new();
-            for item in render_items.iter() {
+            for item in light_render_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Infinite(light) = light_item.light.as_ref()
                 {
@@ -868,7 +887,7 @@ impl LightingMeshRenderer {
         // Directional lights
         {
             let mut light_buffer = Vec::new();
-            for item in render_items.iter() {
+            for item in light_render_items.iter() {
                 if let RenderItem::Light(light_item) = item.as_ref()
                     && let RenderLight::Directional(light) = light_item.light.as_ref()
                 {
@@ -886,7 +905,11 @@ impl LightingMeshRenderer {
 
                     let radius = (0.5 * light.source_angle).tan();
 
-                    let shadow_index = -1; //TODO: support shadows for directional lights
+                    let shadow_index = if light.cast_shadow {
+                        *directional_shadow_index_map.get(&light.id).unwrap_or(&-1)
+                    } else {
+                        -1
+                    };
 
                     let light = DirectionalLight {
                         direction: [direction[0], direction[1], direction[2], 0.0],
@@ -936,6 +959,118 @@ impl LightingMeshRenderer {
             &self.light_uniform_buffer,
             0,
             bytemuck::bytes_of(&light_uniforms),
+        );
+    }
+
+    fn update_directional_shadow_pipeline_entry(
+        &mut self,
+        device: &wgpu::Device,
+        has_directional_shadows: bool,
+    ) {
+        if !has_directional_shadows {
+            self.pipelines.remove(&DIRECTIONAL_SHADOW_PIPELINE_ID);
+            return;
+        }
+        if self.pipelines.contains_key(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
+            return;
+        }
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Directional Shadow Pipeline Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/lighting_z_prepass.wgsl").into()),
+        });
+
+        let vertex_buffer_layout = [wgpu::VertexBufferLayout {
+            array_stride: size_of::<RenderVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: 0,
+                    shader_location: 0,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: std::mem::size_of::<f32>() as u64 * 3,
+                    shader_location: 1,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: std::mem::size_of::<f32>() as u64 * 6,
+                    shader_location: 2,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: std::mem::size_of::<f32>() as u64 * 9,
+                    shader_location: 3,
+                },
+            ],
+        }];
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Directional Shadow Pipeline Layout"),
+            bind_group_layouts: &[&self.global_bind_group_layout, &self.local_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let primitive = wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            ..Default::default()
+        };
+
+        let depth_texture_format = wgpu::TextureFormat::Depth32Float;
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Directional Shadow Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &vertex_buffer_layout,
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: self.target_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::empty(),
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive,
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: depth_texture_format,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let material_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Directional Shadow Material Bind Group Layout"),
+                entries: &[],
+            });
+
+        let entry = PipelineEntry {
+            pipeline,
+            z_prepass_pipeline: None,
+            material_bind_group_layout,
+            material_bind_groups: Vec::new(),
+            mesh_indices: Vec::new(),
+            material_indices: Vec::new(),
+            sort_order: 0,
+            enable_lighting: false,
+        };
+        self.pipelines.insert(
+            DIRECTIONAL_SHADOW_PIPELINE_ID,
+            Arc::new(RwLock::new(entry)),
         );
     }
 
@@ -1511,6 +1646,7 @@ impl LightingMeshRenderer {
             mesh_items,
             textures,
             pipelines: materials,
+            shadow_resource_manager: RenderResourceManager::new(),
         };
         pass.init(device, queue);
         return pass;

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -6,6 +6,7 @@ use super::render_item::RenderItem;
 use super::render_resource::RenderResourceManager;
 use super::shader::RenderShader;
 use super::shadow::create_directional_light_shadows;
+use super::shadow::RenderDirectionalLightShadow;
 use super::texture::RenderTexture;
 use crate::render::wgpu::light::RenderLight;
 use std::collections::HashMap;
@@ -24,6 +25,7 @@ use bytemuck::{Pod, Zeroable};
 
 const MIN_LOCAL_BUFFER_NUM: usize = 64;
 const MAX_DIRECTIONAL_LIGHT_NUM: usize = 4; // Maximum number of directional lights
+const MAX_DIRECTIONAL_SHADOW_NUM: usize = MAX_DIRECTIONAL_LIGHT_NUM;
 const MAX_SPHERE_LIGHT_NUM: usize = 256; // Maximum number of point lights
 const MAX_DISK_LIGHT_NUM: usize = 32; // Maximum number of spot lights
 const MAX_RECT_LIGHT_NUM: usize = 32; // Maximum number of rectangle lights
@@ -34,6 +36,7 @@ const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8
 const DIRECTIONAL_SHADOW_PIPELINE_ID: Uuid =
     Uuid::from_u128(0x77dd5bcc_89c5_4eff_8adf_9b5f8667d9f1);
 const Z_PREPASS_PIPELINE_ID: Uuid = Uuid::from_u128(0x9979b259_39f8_4ce5_8ea5_d8078618620f);
+const DIRECTIONAL_SHADOW_MAP_SIZE: u32 = 2048;
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
@@ -122,6 +125,24 @@ struct InfiniteLight {
     intensity: [f32; 4],       // Intensity of the light // 4 * 4 = 16
     indices: [i32; 4],         // Indices for the light texture
     inv_matrix: [[f32; 4]; 4], // Inverse matrix for the light texture
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
+struct DirectionalShadowInfo {
+    light_view_proj: [[f32; 4]; 4], // 4 * 4 * 4 = 64
+    bias: f32,                      // 1 * 4 = 4
+    _pad0: [f32; 3],               // 3 * 4 = 12
+}
+
+#[derive(Debug, Clone)]
+struct DirectionalShadowMapArray {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    sampler: wgpu::Sampler,
+    layer_count: u32,
+    width: u32,
+    height: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -213,6 +234,12 @@ pub struct LightingMeshRenderer {
 
     #[allow(dead_code)]
     ltc_bind_group_layout: wgpu::BindGroupLayout,
+    #[allow(dead_code)]
+    directional_shadow_bind_group_layout: wgpu::BindGroupLayout,
+    directional_shadow_bind_group: wgpu::BindGroup,
+    directional_shadow_info_buffer: wgpu::Buffer,
+    directional_shadow_map_array: DirectionalShadowMapArray,
+    directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
 
     // Mesh items to render
     mesh_items: Vec<Arc<RenderItem>>,
@@ -287,6 +314,136 @@ impl LightingMeshRenderer {
         }
     }
 
+    pub fn render_directional_shadow_maps(
+        &self,
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        _main_camera: &RenderCamera,
+    ) {
+        if self.directional_light_shadows.is_empty() {
+            return;
+        }
+
+        let local_uniform_alignment = {
+            let alignment = self.min_uniform_buffer_offset_alignment;
+            align_to(
+                std::mem::size_of::<LocalUniforms>() as wgpu::BufferAddress,
+                alignment,
+            )
+        };
+
+        let mut shadow_pipelines = Vec::new();
+        for pipeline_entry in self.pipelines.values() {
+            let pipeline_entry = pipeline_entry.read().unwrap();
+            if pipeline_entry.mesh_indices.is_empty() {
+                continue;
+            }
+            if matches!(pipeline_entry.pass_type, PipelinePassType::Shadow) {
+                shadow_pipelines.push(pipeline_entry.clone());
+            }
+        }
+        if shadow_pipelines.is_empty() {
+            return;
+        }
+
+        for (layer, shadow) in self.directional_light_shadows.iter().enumerate() {
+            let shadow_camera = RenderCamera::from_matrices(shadow.light_view, shadow.light_proj);
+            let global_uniforms = GlobalUniforms {
+                world_to_camera: shadow_camera.world_to_camera.to_cols_array_2d(),
+                camera_to_clip: shadow_camera.camera_to_clip.to_cols_array_2d(),
+                camera_to_world: shadow_camera.camera_to_world.to_cols_array_2d(),
+                camera_position: [
+                    shadow_camera.position.x,
+                    shadow_camera.position.y,
+                    shadow_camera.position.z,
+                    1.0,
+                ],
+            };
+            let shadow_global_uniform_buffer =
+                device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("Shadow Global Uniform Buffer"),
+                    contents: bytemuck::bytes_of(&global_uniforms),
+                    usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                });
+            let shadow_global_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("Shadow Global Bind Group"),
+                layout: &self.global_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: shadow_global_uniform_buffer.as_entire_binding(),
+                }],
+            });
+
+            if let Some(shadow_texture) = shadow.textures.first() {
+                {
+                    let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("Directional Shadow Render Pass"),
+                        color_attachments: &[],
+                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                            view: &shadow_texture.view,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(1.0),
+                                store: wgpu::StoreOp::Store,
+                            }),
+                            stencil_ops: None,
+                        }),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+
+                    for pipeline_entry in shadow_pipelines.iter() {
+                        render_pass.set_pipeline(&pipeline_entry.pipeline);
+                        render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
+                        for item_index in pipeline_entry.mesh_indices.iter().copied() {
+                            if let RenderItem::Mesh(mesh_item) = self.mesh_items[item_index].as_ref()
+                            {
+                                let local_uniform_offset = item_index as wgpu::DynamicOffset
+                                    * local_uniform_alignment as wgpu::DynamicOffset;
+                                render_pass.set_bind_group(
+                                    1,
+                                    &self.local_bind_group,
+                                    &[local_uniform_offset],
+                                );
+                                render_pass
+                                    .set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
+                                render_pass.set_index_buffer(
+                                    mesh_item.mesh.index_buffer.slice(..),
+                                    wgpu::IndexFormat::Uint32,
+                                );
+                                render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
+                            }
+                        }
+                    }
+                }
+
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &shadow_texture.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::DepthOnly,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &self.directional_shadow_map_array.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x: 0,
+                            y: 0,
+                            z: layer as u32,
+                        },
+                        aspect: wgpu::TextureAspect::DepthOnly,
+                    },
+                    wgpu::Extent3d {
+                        width: DIRECTIONAL_SHADOW_MAP_SIZE,
+                        height: DIRECTIONAL_SHADOW_MAP_SIZE,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            }
+        }
+    }
+
     // -------------------------------------------------------
 
     fn split_items(
@@ -315,7 +472,6 @@ impl LightingMeshRenderer {
             )
         };
 
-        let mut shadow_pipelies = Vec::new();
         let mut z_prepass_pipelines = Vec::new();
         let mut shading_pipelines = Vec::new();
         for pipeline_entry in self.pipelines.values() {
@@ -326,9 +482,10 @@ impl LightingMeshRenderer {
             match pipeline_entry.pass_type {
                 PipelinePassType::ZPrepass => z_prepass_pipelines.push(pipeline_entry.clone()),
                 PipelinePassType::Shading => shading_pipelines.push(pipeline_entry.clone()),
-                PipelinePassType::Shadow => shadow_pipelies.push(pipeline_entry.clone()),
+                PipelinePassType::Shadow => {}
             }
         }
+
         //TODO: sort pipelines to minimize pipeline switching
         shading_pipelines.sort_by(|a, b| a.sort_order.cmp(&b.sort_order));
 
@@ -360,6 +517,7 @@ impl LightingMeshRenderer {
             render_pass.set_bind_group(0, &self.global_bind_group, &[]);
             if pipeline_entry.enable_lighting {
                 render_pass.set_bind_group(3, &self.light_bind_group, &[]);
+                render_pass.set_bind_group(5, &self.directional_shadow_bind_group, &[]);
             }
             debug_assert!(
                 pipeline_entry.mesh_indices.len() == pipeline_entry.material_indices.len()
@@ -704,6 +862,89 @@ impl LightingMeshRenderer {
         return light_bind_group;
     }
 
+    fn create_directional_shadow_bind_group(
+        &self,
+        device: &wgpu::Device,
+        directional_shadow_map_view: &wgpu::TextureView,
+        directional_shadow_sampler: &wgpu::Sampler,
+    ) -> wgpu::BindGroup {
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Lighting Directional Shadow Bind Group"),
+            layout: &self.directional_shadow_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: self.directional_shadow_info_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(directional_shadow_map_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(directional_shadow_sampler),
+                },
+            ],
+        })
+    }
+
+    fn ensure_directional_shadow_map_array(
+        &mut self,
+        device: &wgpu::Device,
+        layer_count: u32,
+        width: u32,
+        height: u32,
+    ) {
+        let array = &self.directional_shadow_map_array;
+        if array.layer_count == layer_count && array.width == width && array.height == height {
+            return;
+        }
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Directional Shadow Map Array"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: layer_count,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[wgpu::TextureFormat::Depth32Float],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor {
+            label: Some("Directional Shadow Map Array View"),
+            format: Some(wgpu::TextureFormat::Depth32Float),
+            dimension: Some(wgpu::TextureViewDimension::D2Array),
+            usage: Some(wgpu::TextureUsages::TEXTURE_BINDING),
+            aspect: wgpu::TextureAspect::All,
+            base_mip_level: 0,
+            mip_level_count: Some(1),
+            base_array_layer: 0,
+            array_layer_count: Some(layer_count),
+        });
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            compare: Some(wgpu::CompareFunction::LessEqual),
+            ..Default::default()
+        });
+        self.directional_shadow_map_array = DirectionalShadowMapArray {
+            texture,
+            view,
+            sampler,
+            layer_count,
+            width,
+            height,
+        };
+    }
+
     fn prepare_lights(
         &mut self,
         device: &wgpu::Device,
@@ -746,6 +987,40 @@ impl LightingMeshRenderer {
             !directional_light_shadows.is_empty(),
             &shadow_mesh_indices,
         );
+        {
+            let layer_count = directional_light_shadows.len().max(1) as u32;
+            self.ensure_directional_shadow_map_array(
+                device,
+                layer_count,
+                DIRECTIONAL_SHADOW_MAP_SIZE,
+                DIRECTIONAL_SHADOW_MAP_SIZE,
+            );
+
+            let mut infos = vec![DirectionalShadowInfo::default(); MAX_DIRECTIONAL_SHADOW_NUM];
+            for (i, shadow) in directional_light_shadows
+                .iter()
+                .take(MAX_DIRECTIONAL_SHADOW_NUM)
+                .enumerate()
+            {
+                infos[i] = DirectionalShadowInfo {
+                    light_view_proj: shadow.light_view_proj.to_cols_array_2d(),
+                    bias: shadow.shadow_bias,
+                    _pad0: [0.0; 3],
+                };
+            }
+            queue.write_buffer(
+                &self.directional_shadow_info_buffer,
+                0,
+                bytemuck::cast_slice(&infos),
+            );
+
+            self.directional_shadow_bind_group = self.create_directional_shadow_bind_group(
+                device,
+                &self.directional_shadow_map_array.view,
+                &self.directional_shadow_map_array.sampler,
+            );
+        }
+        self.directional_light_shadows = directional_light_shadows.clone();
         let mut directional_shadow_index_map = HashMap::new();
         for (i, shadow) in directional_light_shadows.iter().enumerate() {
             directional_shadow_index_map.insert(shadow.id, i as i32);
@@ -952,6 +1227,7 @@ impl LightingMeshRenderer {
                     let radius = (0.5 * light.source_angle).tan();
 
                     let shadow_index = if light.cast_shadow {
+                        //log::info!("Directional light {:?} casts shadow", light_item.light.get_id());
                         *directional_shadow_index_map.get(&light.id).unwrap_or(&-1)
                     } else {
                         -1
@@ -1078,16 +1354,7 @@ impl LightingMeshRenderer {
                     buffers: &vertex_buffer_layout,
                     compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format: self.target_format,
-                        blend: None,
-                        write_mask: wgpu::ColorWrites::empty(),
-                    })],
-                    compilation_options: wgpu::PipelineCompilationOptions::default(),
-                }),
+                fragment: None,
                 primitive,
                 depth_stencil: Some(wgpu::DepthStencilState {
                     format: depth_texture_format,
@@ -1215,6 +1482,7 @@ impl LightingMeshRenderer {
         if has_lighting {
             bind_group_layouts.push(&self.light_bind_group_layout); //group(3)
             bind_group_layouts.push(&self.ltc_bind_group_layout); //group(4)
+            bind_group_layouts.push(&self.directional_shadow_bind_group_layout); //group(5)
         }
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -1576,6 +1844,44 @@ impl LightingMeshRenderer {
                 ],
             });
 
+        let directional_shadow_info_buffer_size =
+            (MAX_DIRECTIONAL_SHADOW_NUM * size_of::<DirectionalShadowInfo>())
+                as wgpu::BufferAddress;
+        let directional_shadow_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Directional Shadow Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: wgpu::BufferSize::new(
+                                directional_shadow_info_buffer_size,
+                            ),
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Depth,
+                            view_dimension: wgpu::TextureViewDimension::D2Array,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Comparison),
+                        count: None,
+                    },
+                ],
+            });
+
         let global_unifroms = GlobalUniforms {
             world_to_camera: glam::Mat4::IDENTITY.to_cols_array_2d(), // Identity matrix for now
             camera_to_clip: glam::Mat4::IDENTITY.to_cols_array_2d(),  // Identity matrix for now
@@ -1648,6 +1954,76 @@ impl LightingMeshRenderer {
             size: infinite_light_buffer_size,
             mapped_at_creation: false,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+        });
+        let directional_shadow_info_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Buffer for Directional Shadow Infos"),
+            size: directional_shadow_info_buffer_size,
+            mapped_at_creation: false,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+        });
+
+        let directional_shadow_array_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Directional Shadow Map Array"),
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[wgpu::TextureFormat::Depth32Float],
+        });
+        let directional_shadow_array_view =
+            directional_shadow_array_texture.create_view(&wgpu::TextureViewDescriptor {
+                label: Some("Directional Shadow Map Array View"),
+                format: Some(wgpu::TextureFormat::Depth32Float),
+                dimension: Some(wgpu::TextureViewDimension::D2Array),
+                usage: Some(wgpu::TextureUsages::TEXTURE_BINDING),
+                aspect: wgpu::TextureAspect::All,
+                base_mip_level: 0,
+                mip_level_count: Some(1),
+                base_array_layer: 0,
+                array_layer_count: Some(1),
+            });
+        let directional_shadow_array_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            compare: Some(wgpu::CompareFunction::LessEqual),
+            ..Default::default()
+        });
+        let directional_shadow_map_array = DirectionalShadowMapArray {
+            texture: directional_shadow_array_texture,
+            view: directional_shadow_array_view,
+            sampler: directional_shadow_array_sampler,
+            layer_count: 1,
+            width: 1,
+            height: 1,
+        };
+
+        let directional_shadow_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Lighting Directional Shadow Bind Group"),
+            layout: &directional_shadow_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: directional_shadow_info_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&directional_shadow_map_array.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&directional_shadow_map_array.sampler),
+                },
+            ],
         });
 
         let default_light_texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -1743,6 +2119,11 @@ impl LightingMeshRenderer {
             rect_light_buffer,
             infinite_light_buffer,
             ltc_bind_group_layout,
+            directional_shadow_bind_group_layout,
+            directional_shadow_bind_group,
+            directional_shadow_info_buffer,
+            directional_shadow_map_array,
+            directional_light_shadows: Vec::new(),
             mesh_items,
             textures,
             pipelines: materials,

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -205,8 +205,6 @@ pub struct LightingMeshRenderer {
     #[allow(dead_code)]
     ltc_bind_group_layout: wgpu::BindGroupLayout,
 
-    shadow_resource_manager: RenderResourceManager,
-
     // Mesh items to render
     mesh_items: Vec<Arc<RenderItem>>,
     // Textures used in the materials
@@ -249,6 +247,7 @@ impl LightingMeshRenderer {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        render_resource_manager: &mut RenderResourceManager,
         render_items: &[Arc<RenderItem>],
         camera: &RenderCamera,
     ) {
@@ -257,7 +256,14 @@ impl LightingMeshRenderer {
             let (mesh_items, light_items) = Self::split_items(render_items);
             self.prepare_locals(device, queue, &mesh_items); //group(1)
             self.prepare_materials(device, queue, &mesh_items); //group(2)
-            self.prepare_lights(device, queue, camera, render_items, &light_items); //group(3)
+            self.prepare_lights(
+                device,
+                queue,
+                render_resource_manager,
+                camera,
+                render_items,
+                &light_items,
+            ); //group(3)
         }
     }
 
@@ -685,6 +691,7 @@ impl LightingMeshRenderer {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        render_resource_manager: &mut RenderResourceManager,
         camera: &RenderCamera,
         all_render_items: &[Arc<RenderItem>],
         light_render_items: &[Arc<RenderItem>],
@@ -697,7 +704,7 @@ impl LightingMeshRenderer {
             queue,
             camera,
             all_render_items,
-            &mut self.shadow_resource_manager,
+            render_resource_manager,
         );
         self.update_directional_shadow_pipeline_entry(device, !directional_light_shadows.is_empty());
         let mut directional_shadow_index_map = HashMap::new();
@@ -1646,7 +1653,6 @@ impl LightingMeshRenderer {
             mesh_items,
             textures,
             pipelines: materials,
-            shadow_resource_manager: RenderResourceManager::new(),
         };
         pass.init(device, queue);
         return pass;

--- a/src/render/wgpu/lighting_renderer.rs
+++ b/src/render/wgpu/lighting_renderer.rs
@@ -3,6 +3,8 @@ use super::lighting_mesh_renderer::LightingMeshRenderer;
 use super::linear_to_srgb_renderer::LinearToSrgbRenderer;
 use super::lines_renderer::LinesRenderer;
 use super::render_item::get_render_items;
+use super::render_resource::RenderResourceComponent;
+use super::render_resource::RenderResourceManager;
 use crate::model::base::Matrix4x4;
 use crate::model::scene::Node;
 use crate::render::render_mode::RenderMode;
@@ -45,6 +47,17 @@ struct PerFrameCallback {
 
 unsafe impl Send for PerFrameCallback {}
 unsafe impl Sync for PerFrameCallback {}
+
+fn get_render_resource_manager(node: &Arc<RwLock<Node>>) -> Arc<RwLock<RenderResourceManager>> {
+    let mut node = node.write().unwrap();
+    if node.get_component::<RenderResourceComponent>().is_none() {
+        node.add_component::<RenderResourceComponent>(RenderResourceComponent::new());
+    }
+    let component = node
+        .get_component::<RenderResourceComponent>()
+        .expect("RenderResourceComponent should exist on root node");
+    component.get_resource_manager()
+}
 
 impl PerFrameCallback {
     pub fn prepare_frame_buffers(
@@ -126,9 +139,12 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                 {
                     // Prepare the mesh renderer with the render items
                     let mut renderer = self.mesh_renderer.write().unwrap();
+                    let render_resource_manager = get_render_resource_manager(&self.node);
+                    let mut render_resource_manager = render_resource_manager.write().unwrap();
                     renderer.prepare(
                         device,
                         queue,
+                        &mut render_resource_manager,
                         &render_items,
                         &self.render_camera,
                     );

--- a/src/render/wgpu/lighting_renderer.rs
+++ b/src/render/wgpu/lighting_renderer.rs
@@ -150,6 +150,16 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                     );
                 }
                 {
+                    // Render shadow pipelines before the main lighting pass.
+                    let renderer = self.mesh_renderer.read().unwrap();
+                    renderer.render_directional_shadow_maps(
+                        device,
+                        queue,
+                        encoder,
+                        &self.render_camera,
+                    );
+                }
+                {
                     let mut renderer = self.lines_renderer.write().unwrap();
                     renderer.prepare(
                         device,

--- a/src/render/wgpu/lighting_renderer.rs
+++ b/src/render/wgpu/lighting_renderer.rs
@@ -1,3 +1,4 @@
+use super::camera::RenderCamera;
 use super::lighting_mesh_renderer::LightingMeshRenderer;
 use super::linear_to_srgb_renderer::LinearToSrgbRenderer;
 use super::lines_renderer::LinesRenderer;
@@ -39,8 +40,7 @@ struct PerFrameCallback {
     copy_texture_renderer: Arc<RwLock<LinearToSrgbRenderer>>,
     frame_buffers: Arc<RwLock<FrameBufferMap>>,
     node: Arc<RwLock<Node>>,
-    world_to_camera: glam::Mat4,
-    camera_to_clip: glam::Mat4,
+    render_camera: RenderCamera,
 }
 
 unsafe impl Send for PerFrameCallback {}
@@ -130,8 +130,7 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                         device,
                         queue,
                         &render_items,
-                        &self.world_to_camera,
-                        &self.camera_to_clip,
+                        &self.render_camera,
                     );
                 }
                 {
@@ -140,8 +139,8 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                         device,
                         queue,
                         &render_items,
-                        &self.world_to_camera,
-                        &self.camera_to_clip,
+                        &self.render_camera.world_to_camera,
+                        &self.render_camera.camera_to_clip,
                     );
                 }
                 {
@@ -230,6 +229,7 @@ impl LightingRenderer {
     ) {
         let c2c = *c2c;
         let c2c = Matrix4x4::OPENGL_TO_WGPU_CLIP * c2c; // Convert to WGPU clip space
+        let render_camera = RenderCamera::from_matrices(glam::Mat4::from(w2c), glam::Mat4::from(c2c));
         ui.painter().add(egui_wgpu::Callback::new_paint_callback(
             rect,
             PerFrameCallback {
@@ -239,8 +239,7 @@ impl LightingRenderer {
                 copy_texture_renderer: self.copy_texture_renderer.clone(),
                 frame_buffers: self.frame_buffers.clone(),
                 node: node.clone(),
-                world_to_camera: glam::Mat4::from(w2c),
-                camera_to_clip: glam::Mat4::from(c2c),
+                render_camera,
             },
         ));
     }

--- a/src/render/wgpu/lighting_renderer.rs
+++ b/src/render/wgpu/lighting_renderer.rs
@@ -245,7 +245,8 @@ impl LightingRenderer {
     ) {
         let c2c = *c2c;
         let c2c = Matrix4x4::OPENGL_TO_WGPU_CLIP * c2c; // Convert to WGPU clip space
-        let render_camera = RenderCamera::from_matrices(glam::Mat4::from(w2c), glam::Mat4::from(c2c));
+        let render_camera =
+            RenderCamera::from_matrices(glam::Mat4::from(w2c), glam::Mat4::from(c2c));
         ui.painter().add(egui_wgpu::Callback::new_paint_callback(
             rect,
             PerFrameCallback {

--- a/src/render/wgpu/mesh.rs
+++ b/src/render/wgpu/mesh.rs
@@ -14,6 +14,40 @@ pub struct RenderMesh {
     pub index_buffer: wgpu::Buffer,
     pub vertex_count: u32,
     pub index_count: u32,
+    pub aabb: Aabb,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Aabb {
+    pub min: [f32; 3],
+    pub max: [f32; 3],
+}
+
+impl Aabb {
+    pub fn from_positions(positions: &[f32]) -> Self {
+        let mut chunks = positions.chunks_exact(3);
+        let Some(first) = chunks.next() else {
+            return Self::default();
+        };
+
+        let mut min = [first[0], first[1], first[2]];
+        let mut max = min;
+
+        for chunk in chunks {
+            let x = chunk[0];
+            let y = chunk[1];
+            let z = chunk[2];
+
+            min[0] = min[0].min(x);
+            min[1] = min[1].min(y);
+            min[2] = min[2].min(z);
+            max[0] = max[0].max(x);
+            max[1] = max[1].max(y);
+            max[2] = max[2].max(z);
+        }
+
+        Self { min, max }
+    }
 }
 
 #[repr(C)]
@@ -68,6 +102,7 @@ impl RenderMesh {
         let mesh_id = shape.get_id();
         let edition = shape.get_edition();
         if let Some(mut mesh_data) = create_mesh_data(shape) {
+            let aabb = Aabb::from_positions(&mesh_data.positions);
             let num_vertices = mesh_data.positions.len() / 3;
             if mesh_data.normals.len() < num_vertices * 3 {
                 // If positions are not provided, create a default position
@@ -99,6 +134,7 @@ impl RenderMesh {
                 index_buffer,
                 vertex_count: vertex_count as u32,
                 index_count: index_count as u32,
+                aabb,
             };
             return Some(mesh);
         }

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -1,4 +1,5 @@
 pub mod aabb_renderer;
+pub mod camera;
 pub mod light;
 pub mod lighting_mesh_renderer;
 pub mod lighting_renderer;

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -1,3 +1,4 @@
+pub mod aabb_renderer;
 pub mod light;
 pub mod lighting_mesh_renderer;
 pub mod lighting_renderer;
@@ -15,6 +16,7 @@ pub mod render_mesh_item;
 pub mod render_object_instance_item;
 pub mod render_resource;
 pub mod shader;
+pub mod shadow;
 pub mod solid_mesh_renderer;
 pub mod solid_renderer;
 pub mod texture;

--- a/src/render/wgpu/render_item.rs
+++ b/src/render/wgpu/render_item.rs
@@ -227,6 +227,7 @@ pub fn get_texture(
 pub fn get_shader_type(
     shader_type: &str,
     uniform_values: &[(String, RenderUniformValue)],
+    render_category: RenderCategory,
 ) -> String {
     let mut s = "".to_string();
     for (key, val) in uniform_values.iter() {
@@ -251,7 +252,14 @@ pub fn get_shader_type(
             }
         }
     }
+    if uses_directional_light_shadow(render_category) {
+        s.push_str("_ENABLE_DIRECTIONAL_LIGHT_SHADOW@D");
+    }
     return format!("{}{}", shader_type, s);
+}
+
+fn uses_directional_light_shadow(render_category: RenderCategory) -> bool {
+    render_category != RenderCategory::Emissive
 }
 
 fn create_uniform_value_bytes(
@@ -349,7 +357,10 @@ fn get_fallback_shader_source() -> String {
     return code;
 }
 
-fn create_defines(uniform_values: &[(String, RenderUniformValue)]) -> Vec<(String, String)> {
+fn create_defines(
+    uniform_values: &[(String, RenderUniformValue)],
+    render_category: RenderCategory,
+) -> Vec<(String, String)> {
     let mut defines = Vec::new();
     for (name, value) in uniform_values.iter() {
         if let RenderUniformValue::Texture(_) = value {
@@ -360,14 +371,21 @@ fn create_defines(uniform_values: &[(String, RenderUniformValue)]) -> Vec<(Strin
             ));
         }
     }
+    if uses_directional_light_shadow(render_category) {
+        defines.push((
+            "ENABLE_DIRECTIONAL_LIGHT_SHADOW".to_string(),
+            "1".to_string(),
+        ));
+    }
     return defines;
 }
 
 fn generate_shader_source(
     shader_type: &str,
     uniform_values: &[(String, RenderUniformValue)],
+    render_category: RenderCategory,
 ) -> Option<String> {
-    let modified_shader_type = get_shader_type(shader_type, uniform_values);
+    let modified_shader_type = get_shader_type(shader_type, uniform_values, render_category);
     let cache_dir = dirs::cache_dir()
         .unwrap()
         .join("pbrt_ui")
@@ -375,7 +393,7 @@ fn generate_shader_source(
         .join("shaders");
     let prebuilt_shader_path = cache_dir.join(format!("{}.wgsl", shader_type));
 
-    let defines = create_defines(uniform_values);
+    let defines = create_defines(uniform_values, render_category);
     if prebuilt_shader_path.exists() {
         let base_path = dirs::cache_dir()
             .unwrap()
@@ -407,7 +425,11 @@ fn generate_shader_source(
     return None;
 }
 
-fn get_shader_source(shader_type: &str, uniform_values: &[(String, RenderUniformValue)]) -> String {
+fn get_shader_source(
+    shader_type: &str,
+    uniform_values: &[(String, RenderUniformValue)],
+    render_category: RenderCategory,
+) -> String {
     let cache_dir = dirs::cache_dir().unwrap().join("pbrt_ui").join("shaders");
     let shader_path = cache_dir.join(format!("{}.wgsl", shader_type));
     if shader_path.exists()
@@ -416,7 +438,9 @@ fn get_shader_source(shader_type: &str, uniform_values: &[(String, RenderUniform
         return code;
     }
 
-    if let Some(generated_source) = generate_shader_source(shader_type, uniform_values) {
+    if let Some(generated_source) =
+        generate_shader_source(shader_type, uniform_values, render_category)
+    {
         return generated_source;
     }
 
@@ -428,8 +452,9 @@ fn get_shader_module(
     device: &wgpu::Device,
     shader_type: &str,
     uniform_values: &[(String, RenderUniformValue)],
+    render_category: RenderCategory,
 ) -> wgpu::ShaderModule {
-    let source = get_shader_source(shader_type, uniform_values);
+    let source = get_shader_source(shader_type, uniform_values, render_category);
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some(format!("Shader : {}", shader_type).as_str()),
         source: wgpu::ShaderSource::Wgsl(source.into()),
@@ -442,15 +467,16 @@ pub fn create_render_shader(
     _queue: &wgpu::Queue,
     shader_type: &str,
     uniform_values: &[(String, RenderUniformValue)],
+    render_category: RenderCategory,
     render_resource_manager: &mut RenderResourceManager,
 ) -> Arc<RenderShader> {
     //let org_shader_type = shader_type.to_string();
-    let modified_shader_type = get_shader_type(shader_type, uniform_values);
+    let modified_shader_type = get_shader_type(shader_type, uniform_values, render_category);
     let shader_id = get_shader_id_from_type(&modified_shader_type);
     if let Some(shader) = render_resource_manager.get_shader(shader_id) {
         return shader.clone();
     }
-    let shader_module = get_shader_module(device, shader_type, uniform_values);
+    let shader_module = get_shader_module(device, shader_type, uniform_values, render_category);
     let render_shader = RenderShader {
         id: shader_id,
         name: modified_shader_type.clone(),
@@ -475,6 +501,7 @@ pub fn create_render_pass(
         queue,
         shader_type,
         uniform_values,
+        render_category,
         render_resource_manager,
     );
     let (_uniform_values_types, uniform_values_bytes) = create_uniform_value_bytes(uniform_values);

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -126,6 +126,9 @@ fn get_directional_light_item(
         let source_angle = source_angle.max(0.2); // Prevent too small angles
         let source_angle = source_angle.to_radians();
 
+        let cast_shadow = props.find_one_bool("castshadow").unwrap_or(false);
+        //
+
         let intensity = [l[0] * scale[0], l[1] * scale[1], l[2] * scale[2]];
         let render_light = DirectionalRenderLight {
             id,
@@ -133,6 +136,7 @@ fn get_directional_light_item(
             direction,
             intensity,
             source_angle,
+            cast_shadow,
             ..Default::default()
         };
         let render_light = Arc::new(RenderLight::Directional(render_light));

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -125,9 +125,13 @@ fn get_directional_light_item(
         let source_angle = props.find_one_float("sourceangle").unwrap_or(0.5357);
         let source_angle = source_angle.max(0.2); // Prevent too small angles
         let source_angle = source_angle.to_radians();
+        let shadow_bias = props.find_one_float("shadowbias").unwrap_or(0.001).max(0.0);
 
-        let cast_shadow = props.find_one_bool("castshadow").unwrap_or(false);
-        //
+        // Accept both spellings to be robust against source scene variants.
+        let cast_shadow = props
+            .find_one_bool("castshadow")
+            .or_else(|| props.find_one_bool("castshadows"))
+            .unwrap_or(true);
 
         let intensity = [l[0] * scale[0], l[1] * scale[1], l[2] * scale[2]];
         let render_light = DirectionalRenderLight {
@@ -137,6 +141,7 @@ fn get_directional_light_item(
             intensity,
             source_angle,
             cast_shadow,
+            shadow_bias,
             ..Default::default()
         };
         let render_light = Arc::new(RenderLight::Directional(render_light));

--- a/src/render/wgpu/render_resource.rs
+++ b/src/render/wgpu/render_resource.rs
@@ -3,6 +3,7 @@ use super::lines::RenderLines;
 use super::material::RenderMaterial;
 use super::mesh::RenderMesh;
 use super::shader::RenderShader;
+use super::shadow::RenderDirectionalLightShadow;
 use super::texture::RenderTexture;
 use crate::model::scene::Component;
 
@@ -20,6 +21,7 @@ pub struct RenderResourceManager {
     pub shaders: HashMap<Uuid, Arc<RenderShader>>,
     pub materials: HashMap<Uuid, Arc<RenderMaterial>>,
     pub textures: HashMap<Uuid, Arc<RenderTexture>>,
+    pub directional_light_shadows: HashMap<Uuid, Arc<RenderDirectionalLightShadow>>,
 }
 
 impl RenderResourceManager {
@@ -31,6 +33,7 @@ impl RenderResourceManager {
             shaders: HashMap::new(),
             materials: HashMap::new(),
             textures: HashMap::new(),
+            directional_light_shadows: HashMap::new(),
         }
     }
     pub fn add_mesh(&mut self, mesh: &Arc<RenderMesh>) {
@@ -109,6 +112,21 @@ impl RenderResourceManager {
 
     pub fn remove_texture(&mut self, id: Uuid) {
         self.textures.remove(&id);
+    }
+
+    pub fn add_directional_light_shadow(&mut self, shadow: &Arc<RenderDirectionalLightShadow>) {
+        self.directional_light_shadows.insert(shadow.id, shadow.clone());
+    }
+
+    pub fn get_directional_light_shadow(
+        &self,
+        id: Uuid,
+    ) -> Option<&Arc<RenderDirectionalLightShadow>> {
+        self.directional_light_shadows.get(&id)
+    }
+
+    pub fn clear_directional_light_shadows(&mut self) {
+        self.directional_light_shadows.clear();
     }
 }
 

--- a/src/render/wgpu/render_resource.rs
+++ b/src/render/wgpu/render_resource.rs
@@ -115,7 +115,8 @@ impl RenderResourceManager {
     }
 
     pub fn add_directional_light_shadow(&mut self, shadow: &Arc<RenderDirectionalLightShadow>) {
-        self.directional_light_shadows.insert(shadow.id, shadow.clone());
+        self.directional_light_shadows
+            .insert(shadow.id, shadow.clone());
     }
 
     pub fn get_directional_light_shadow(

--- a/src/render/wgpu/shaders/render_aabb.wgsl
+++ b/src/render/wgpu/shaders/render_aabb.wgsl
@@ -1,0 +1,31 @@
+struct GlobalUniforms {
+    world_to_camera: mat4x4<f32>,
+    camera_to_clip: mat4x4<f32>,
+}
+
+struct LocalUniforms {
+    local_to_world: mat4x4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> global_uniforms: GlobalUniforms;
+
+@group(1) @binding(0)
+var<uniform> local_uniforms: LocalUniforms;
+
+struct VertexOut {
+    @builtin(position) position: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@location(0) position: vec3<f32>) -> VertexOut {
+    var out: VertexOut;
+    let transform = global_uniforms.camera_to_clip * global_uniforms.world_to_camera * local_uniforms.local_to_world;
+    out.position = transform * vec4<f32>(position, 1.0);
+    return out;
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.95, 0.85, 0.1, 1.0);
+}

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -18,6 +18,7 @@ pub struct RenderDirectionalLightShadow {
     pub light_view: glam::Mat4,
     pub light_proj: glam::Mat4,
     pub light_view_proj: glam::Mat4,
+    pub shadow_bias: f32,
     pub textures: Vec<Arc<RenderTexture>>,
 }
 
@@ -109,6 +110,9 @@ pub fn create_directional_light_shadows(
             },
             _ => continue,
         };
+        if !directional_light.cast_shadow {
+            continue;
+        }
 
         let mut light_dir = glam::vec3(
             directional_light.direction[0],
@@ -178,7 +182,8 @@ pub fn create_directional_light_shadows(
                     dimension: wgpu::TextureDimension::D2,
                     format: wgpu::TextureFormat::Depth32Float,
                     usage: wgpu::TextureUsages::TEXTURE_BINDING
-                        | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                        | wgpu::TextureUsages::RENDER_ATTACHMENT
+                        | wgpu::TextureUsages::COPY_SRC,
                     view_formats: &[wgpu::TextureFormat::Depth32Float],
                 });
                 let shadow_view =
@@ -218,7 +223,8 @@ pub fn create_directional_light_shadows(
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Depth32Float,
                 usage: wgpu::TextureUsages::TEXTURE_BINDING
-                    | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    | wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::COPY_SRC,
                 view_formats: &[wgpu::TextureFormat::Depth32Float],
             });
             let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
@@ -250,6 +256,7 @@ pub fn create_directional_light_shadows(
             light_view,
             light_proj,
             light_view_proj,
+            shadow_bias: directional_light.shadow_bias,
             textures: vec![render_texture],
         });
         render_resource_manager.add_directional_light_shadow(&shadow);

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -1,0 +1,200 @@
+use super::light::RenderLight;
+use super::render_item::RenderItem;
+use super::render_resource::RenderResourceManager;
+use super::texture::RenderTexture;
+use std::sync::Arc;
+
+use eframe::wgpu;
+use uuid::Uuid;
+
+const SHADOW_MAP_SIZE: u32 = 2048;
+const SHADOW_BOUNDS_MARGIN: f32 = 0.1;
+
+#[derive(Debug, Clone)]
+pub struct RenderDirectionalLightShadow {
+    pub id: Uuid,
+    pub edition: String,
+    pub light_view: glam::Mat4,
+    pub light_proj: glam::Mat4,
+    pub light_view_proj: glam::Mat4,
+    pub textures: Vec<Arc<RenderTexture>>,
+}
+
+fn get_aabb_corners(min: glam::Vec3, max: glam::Vec3) -> [glam::Vec3; 8] {
+    [
+        glam::vec3(min.x, min.y, min.z),
+        glam::vec3(min.x, min.y, max.z),
+        glam::vec3(min.x, max.y, min.z),
+        glam::vec3(min.x, max.y, max.z),
+        glam::vec3(max.x, min.y, min.z),
+        glam::vec3(max.x, min.y, max.z),
+        glam::vec3(max.x, max.y, min.z),
+        glam::vec3(max.x, max.y, max.z),
+    ]
+}
+
+fn expand_bounds(min: &mut glam::Vec3, max: &mut glam::Vec3, p: glam::Vec3) {
+    *min = min.min(p);
+    *max = max.max(p);
+}
+
+pub fn create_directional_light_shadows(
+    device: &wgpu::Device,
+    _queue: &wgpu::Queue,
+    render_items: &[Arc<RenderItem>],
+    render_resource_manager: &mut RenderResourceManager,
+) -> Vec<Arc<RenderDirectionalLightShadow>> {
+    let mut shadows = Vec::new();
+
+    //
+    let mut need_compute_shadows = false;
+    for item in render_items {
+        if let RenderItem::Light(light_item) = item.as_ref() {
+            if let RenderLight::Directional(light) = light_item.light.as_ref() {
+                if light.cast_shadow {
+                    need_compute_shadows = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if !need_compute_shadows {
+        return shadows;
+    }
+
+    let mut world_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut world_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    let mut has_mesh = false;
+
+    for item in render_items {
+        if let RenderItem::Mesh(mesh_item) = item.as_ref() {
+            has_mesh = true;
+            let aabb_min = glam::vec3(
+                mesh_item.mesh.aabb.min[0],
+                mesh_item.mesh.aabb.min[1],
+                mesh_item.mesh.aabb.min[2],
+            );
+            let aabb_max = glam::vec3(
+                mesh_item.mesh.aabb.max[0],
+                mesh_item.mesh.aabb.max[1],
+                mesh_item.mesh.aabb.max[2],
+            );
+            let corners = get_aabb_corners(aabb_min, aabb_max);
+            for corner in corners {
+                let world = mesh_item.matrix.transform_point3(corner);
+                expand_bounds(&mut world_min, &mut world_max, world);
+            }
+        }
+    }
+
+    if !has_mesh {
+        return shadows;
+    }
+
+    let world_center = 0.5 * (world_min + world_max);
+    let world_extent = world_max - world_min;
+    let world_radius = world_extent.length() * 0.5;
+    let light_distance = world_radius.max(1.0) * 2.0;
+
+    for item in render_items {
+        let (light_item, directional_light) = match item.as_ref() {
+            RenderItem::Light(light_item) => match light_item.light.as_ref() {
+                RenderLight::Directional(light) => (light_item, light),
+                _ => continue,
+            },
+            _ => continue,
+        };
+
+        let mut light_dir = glam::vec3(
+            directional_light.direction[0],
+            directional_light.direction[1],
+            directional_light.direction[2],
+        );
+        light_dir = light_item.matrix.transform_vector3(light_dir).normalize_or_zero();
+        if light_dir.length_squared() < 1e-8 {
+            continue;
+        }
+
+        let up = if light_dir.abs().dot(glam::vec3(0.0, 1.0, 0.0)) < 0.99 {
+            glam::vec3(0.0, 1.0, 0.0)
+        } else {
+            glam::vec3(1.0, 0.0, 0.0)
+        };
+        let eye = world_center - light_dir * light_distance;
+        let light_view = glam::Mat4::look_at_rh(eye, world_center, up);
+
+        let corners = get_aabb_corners(world_min, world_max);
+        let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+        let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+        for corner in corners {
+            let p = light_view.transform_point3(corner);
+            expand_bounds(&mut light_min, &mut light_max, p);
+        }
+
+        let margin = SHADOW_BOUNDS_MARGIN;
+        let span = light_max - light_min;
+        let mx = span.x.abs().max(1e-3) * margin;
+        let my = span.y.abs().max(1e-3) * margin;
+        let mz = span.z.abs().max(1e-3) * margin;
+
+        let left = light_min.x - mx;
+        let right = light_max.x + mx;
+        let bottom = light_min.y - my;
+        let top = light_max.y + my;
+
+        let near = (-light_max.z - mz).max(0.01);
+        let far = (-light_min.z + mz).max(near + 0.01);
+        let light_proj = glam::Mat4::orthographic_rh(left, right, bottom, top, near, far);
+        let light_view_proj = light_proj * light_view;
+
+        let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Directional Shadow Map"),
+            size: wgpu::Extent3d {
+                width: SHADOW_MAP_SIZE,
+                height: SHADOW_MAP_SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[wgpu::TextureFormat::Depth32Float],
+        });
+        let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            compare: Some(wgpu::CompareFunction::LessEqual),
+            ..Default::default()
+        });
+
+        let tex_id = Uuid::new_v4();
+        let render_texture = Arc::new(RenderTexture {
+            id: tex_id,
+            edition: directional_light.edition.clone(),
+            texture: shadow_texture,
+            view: shadow_view,
+            sampler: shadow_sampler,
+            scale: [1.0, 1.0],
+            delta: [0.0, 0.0],
+        });
+        render_resource_manager.add_texture(&render_texture);
+
+        shadows.push(Arc::new(RenderDirectionalLightShadow {
+            id: directional_light.id,
+            edition: directional_light.edition.clone(),
+            light_view,
+            light_proj,
+            light_view_proj,
+            textures: vec![render_texture],
+        }));
+    }
+
+    shadows
+}

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -115,7 +115,10 @@ pub fn create_directional_light_shadows(
             directional_light.direction[1],
             directional_light.direction[2],
         );
-        light_dir = light_item.matrix.transform_vector3(light_dir).normalize_or_zero();
+        light_dir = light_item
+            .matrix
+            .transform_vector3(light_dir)
+            .normalize_or_zero();
         if light_dir.length_squared() < 1e-8 {
             continue;
         }
@@ -178,7 +181,8 @@ pub fn create_directional_light_shadows(
                         | wgpu::TextureUsages::RENDER_ATTACHMENT,
                     view_formats: &[wgpu::TextureFormat::Depth32Float],
                 });
-                let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
+                let shadow_view =
+                    shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
                 let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
                     address_mode_u: wgpu::AddressMode::ClampToEdge,
                     address_mode_v: wgpu::AddressMode::ClampToEdge,
@@ -213,7 +217,8 @@ pub fn create_directional_light_shadows(
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: wgpu::TextureFormat::Depth32Float,
-                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::RENDER_ATTACHMENT,
                 view_formats: &[wgpu::TextureFormat::Depth32Float],
             });
             let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -1,3 +1,4 @@
+use super::camera::RenderCamera;
 use super::light::RenderLight;
 use super::render_item::RenderItem;
 use super::render_resource::RenderResourceManager;
@@ -41,10 +42,12 @@ fn expand_bounds(min: &mut glam::Vec3, max: &mut glam::Vec3, p: glam::Vec3) {
 pub fn create_directional_light_shadows(
     device: &wgpu::Device,
     _queue: &wgpu::Queue,
+    render_camera: &RenderCamera,
     render_items: &[Arc<RenderItem>],
     render_resource_manager: &mut RenderResourceManager,
 ) -> Vec<Arc<RenderDirectionalLightShadow>> {
     let mut shadows = Vec::new();
+    render_resource_manager.clear_directional_light_shadows();
 
     //
     let mut need_compute_shadows = false;
@@ -116,7 +119,10 @@ pub fn create_directional_light_shadows(
             continue;
         }
 
-        let up = if light_dir.abs().dot(glam::vec3(0.0, 1.0, 0.0)) < 0.99 {
+        let camera_up = render_camera.up.normalize_or_zero();
+        let up = if camera_up.length_squared() > 1e-8 && light_dir.abs().dot(camera_up) < 0.99 {
+            camera_up
+        } else if light_dir.abs().dot(glam::vec3(0.0, 1.0, 0.0)) < 0.99 {
             glam::vec3(0.0, 1.0, 0.0)
         } else {
             glam::vec3(1.0, 0.0, 0.0)
@@ -148,52 +154,100 @@ pub fn create_directional_light_shadows(
         let light_proj = glam::Mat4::orthographic_rh(left, right, bottom, top, near, far);
         let light_view_proj = light_proj * light_view;
 
-        let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Directional Shadow Map"),
-            size: wgpu::Extent3d {
-                width: SHADOW_MAP_SIZE,
-                height: SHADOW_MAP_SIZE,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[wgpu::TextureFormat::Depth32Float],
-        });
-        let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
-        let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            compare: Some(wgpu::CompareFunction::LessEqual),
-            ..Default::default()
-        });
-
-        let tex_id = Uuid::new_v4();
-        let render_texture = Arc::new(RenderTexture {
-            id: tex_id,
-            edition: directional_light.edition.clone(),
-            texture: shadow_texture,
-            view: shadow_view,
-            sampler: shadow_sampler,
-            scale: [1.0, 1.0],
-            delta: [0.0, 0.0],
-        });
-        render_resource_manager.add_texture(&render_texture);
-
-        shadows.push(Arc::new(RenderDirectionalLightShadow {
+        let tex_id = Uuid::new_v3(
+            &Uuid::NAMESPACE_OID,
+            format!("directional-shadow:{}", directional_light.id).as_bytes(),
+        );
+        let render_texture = if let Some(tex) = render_resource_manager.get_texture(tex_id) {
+            if tex.edition == directional_light.edition {
+                tex.clone()
+            } else {
+                let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
+                    label: Some("Directional Shadow Map"),
+                    size: wgpu::Extent3d {
+                        width: SHADOW_MAP_SIZE,
+                        height: SHADOW_MAP_SIZE,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: wgpu::TextureDimension::D2,
+                    format: wgpu::TextureFormat::Depth32Float,
+                    usage: wgpu::TextureUsages::TEXTURE_BINDING
+                        | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    view_formats: &[wgpu::TextureFormat::Depth32Float],
+                });
+                let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
+                let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                    address_mode_u: wgpu::AddressMode::ClampToEdge,
+                    address_mode_v: wgpu::AddressMode::ClampToEdge,
+                    address_mode_w: wgpu::AddressMode::ClampToEdge,
+                    mag_filter: wgpu::FilterMode::Linear,
+                    min_filter: wgpu::FilterMode::Linear,
+                    mipmap_filter: wgpu::FilterMode::Nearest,
+                    compare: Some(wgpu::CompareFunction::LessEqual),
+                    ..Default::default()
+                });
+                let tex = Arc::new(RenderTexture {
+                    id: tex_id,
+                    edition: directional_light.edition.clone(),
+                    texture: shadow_texture,
+                    view: shadow_view,
+                    sampler: shadow_sampler,
+                    scale: [1.0, 1.0],
+                    delta: [0.0, 0.0],
+                });
+                render_resource_manager.add_texture(&tex);
+                tex
+            }
+        } else {
+            let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("Directional Shadow Map"),
+                size: wgpu::Extent3d {
+                    width: SHADOW_MAP_SIZE,
+                    height: SHADOW_MAP_SIZE,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Depth32Float,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+                view_formats: &[wgpu::TextureFormat::Depth32Float],
+            });
+            let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
+            let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                address_mode_w: wgpu::AddressMode::ClampToEdge,
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
+                mipmap_filter: wgpu::FilterMode::Nearest,
+                compare: Some(wgpu::CompareFunction::LessEqual),
+                ..Default::default()
+            });
+            let tex = Arc::new(RenderTexture {
+                id: tex_id,
+                edition: directional_light.edition.clone(),
+                texture: shadow_texture,
+                view: shadow_view,
+                sampler: shadow_sampler,
+                scale: [1.0, 1.0],
+                delta: [0.0, 0.0],
+            });
+            render_resource_manager.add_texture(&tex);
+            tex
+        };
+        let shadow = Arc::new(RenderDirectionalLightShadow {
             id: directional_light.id,
             edition: directional_light.edition.clone(),
             light_view,
             light_proj,
             light_view_proj,
             textures: vec![render_texture],
-        }));
+        });
+        render_resource_manager.add_directional_light_shadow(&shadow);
+        shadows.push(shadow);
     }
 
     shadows

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -43,7 +43,8 @@ pub fn create_directional_light_shadows(
     device: &wgpu::Device,
     _queue: &wgpu::Queue,
     render_camera: &RenderCamera,
-    render_items: &[Arc<RenderItem>],
+    mesh_items: &[Arc<RenderItem>],
+    light_items: &[Arc<RenderItem>],
     render_resource_manager: &mut RenderResourceManager,
 ) -> Vec<Arc<RenderDirectionalLightShadow>> {
     let mut shadows = Vec::new();
@@ -51,7 +52,7 @@ pub fn create_directional_light_shadows(
 
     //
     let mut need_compute_shadows = false;
-    for item in render_items {
+    for item in light_items {
         if let RenderItem::Light(light_item) = item.as_ref() {
             if let RenderLight::Directional(light) = light_item.light.as_ref() {
                 if light.cast_shadow {
@@ -70,7 +71,7 @@ pub fn create_directional_light_shadows(
     let mut world_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
     let mut has_mesh = false;
 
-    for item in render_items {
+    for item in mesh_items {
         if let RenderItem::Mesh(mesh_item) = item.as_ref() {
             has_mesh = true;
             let aabb_min = glam::vec3(
@@ -100,7 +101,7 @@ pub fn create_directional_light_shadows(
     let world_radius = world_extent.length() * 0.5;
     let light_distance = world_radius.max(1.0) * 2.0;
 
-    for item in render_items {
+    for item in light_items {
         let (light_item, directional_light) = match item.as_ref() {
             RenderItem::Light(light_item) => match light_item.light.as_ref() {
                 RenderLight::Directional(light) => (light_item, light),

--- a/src/render/wgpu/solid_renderer.rs
+++ b/src/render/wgpu/solid_renderer.rs
@@ -1,3 +1,4 @@
+use super::aabb_renderer::AabbRenderer;
 use super::lines_renderer::LinesRenderer;
 use super::render_item::get_render_items;
 use super::solid_mesh_renderer::SolidMeshRenderer;
@@ -14,12 +15,14 @@ use eframe::wgpu;
 
 pub struct SolidRenderer {
     mesh_renderer: Arc<RwLock<SolidMeshRenderer>>,
+    aabb_renderer: Arc<RwLock<AabbRenderer>>,
     lines_renderer: Arc<RwLock<LinesRenderer>>,
 }
 
 #[derive(Debug, Clone)]
 struct PerFrameCallback {
     mesh_renderer: Arc<RwLock<SolidMeshRenderer>>,
+    aabb_renderer: Arc<RwLock<AabbRenderer>>,
     lines_renderer: Arc<RwLock<LinesRenderer>>,
     node: Arc<RwLock<Node>>,
     world_to_camera: glam::Mat4,
@@ -70,6 +73,21 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
             );
             command_buffers.extend(cmds);
         }
+        {
+            let render_items = render_items
+                .iter()
+                .filter(|item| matches!(item.as_ref(), RenderItem::Mesh(_)))
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut renderer = self.aabb_renderer.write().unwrap();
+            renderer.prepare(
+                device,
+                queue,
+                &render_items,
+                &self.world_to_camera,
+                &self.camera_to_clip,
+            );
+        }
         if true {
             let render_items = render_items
                 .iter()
@@ -106,6 +124,10 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
             let renderer = self.mesh_renderer.read().unwrap();
             renderer.paint(&info, render_pass, resources);
         }
+        {
+            let renderer = self.aabb_renderer.read().unwrap();
+            renderer.paint(render_pass);
+        }
         if true {
             let renderer = self.lines_renderer.read().unwrap();
             renderer.paint(render_pass);
@@ -119,9 +141,11 @@ impl SolidRenderer {
         let device = &render_state.device;
         let queue = &render_state.queue;
         let mesh_renderer = SolidMeshRenderer::new(device, queue, render_state.target_format);
+        let aabb_renderer = AabbRenderer::new(device, queue, render_state.target_format);
         let lines_renderer = LinesRenderer::new(device, queue, render_state.target_format);
         return Some(SolidRenderer {
             mesh_renderer: Arc::new(RwLock::new(mesh_renderer)),
+            aabb_renderer: Arc::new(RwLock::new(aabb_renderer)),
             lines_renderer: Arc::new(RwLock::new(lines_renderer)),
         });
     }
@@ -140,6 +164,7 @@ impl SolidRenderer {
             rect,
             PerFrameCallback {
                 mesh_renderer: self.mesh_renderer.clone(),
+                aabb_renderer: self.aabb_renderer.clone(),
                 lines_renderer: self.lines_renderer.clone(),
                 node: node.clone(),
                 world_to_camera: glam::Mat4::from(w2c),


### PR DESCRIPTION
This pull request introduces support for directional light shadows in the rendering pipeline, adds a new `AabbRenderer` for visualizing bounding boxes, and makes several improvements to scene data handling and shader organization. The most significant changes are grouped below.

### Directional Light Shadow Support

* Added new WGSL shader modules (`lighting_shadow_header.wgsl` and `lighting_shadow_functions.wgsl`) that define data structures, bindings, and functions for projecting, sampling, and applying directional shadow maps. [[1]](diffhunk://#diff-8ef321409053f3bddf9f4dee544a96f4f701dc4b35fd5708fe6d1fa44dbf7340R1-R22) [[2]](diffhunk://#diff-adbc59172c6e941ed89f63a73b9a50e854e72fbcc2a823d9bf7a69e919444cf4R1-R60)
* Updated existing lighting shaders to integrate shadow support, including new uniforms, shadow sampling logic, and debug visualization modes. This includes modifications to the directional light struct to include a `shadow_index`, and conditional compilation for shadow code. [[1]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL32-R39) [[2]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aR138-R141) [[3]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR48-R57) [[4]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR549-R555) [[5]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR589-R617)

### Scene Data and Property Improvements

* Extended the `DirectionalLight` struct to include a `shadow_index` for associating lights with shadow maps, and updated related scene property definitions to include new parameters for shadow casting and bias. [[1]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL32-R39) [[2]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5L5-R5) [[3]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5R29-R30)
* Modified the creation of `Light` and `Material` objects to include a unique `edition` UUID string property, improving change tracking and identification. [[1]](diffhunk://#diff-c8e9d295c0b3c931a3756c9cf5acee99f4d552dc2b78f8cc8a8bca14cd8d797bR20-R21) [[2]](diffhunk://#diff-f86e52d7583535595a29fccc683f1cac05a49df5a0565ba2b8362883ac337a16R28-R29)

### Renderer Features

* Added a new `AabbRenderer` implementation (`aabb_renderer.rs`) for drawing axis-aligned bounding boxes (AABBs) of mesh objects, including buffer management, pipeline setup, and per-instance transforms.

### Shader and Module Organization

* Refactored shader includes for better modularity, including conditional inclusion of shadow headers and functions based on feature flags. [[1]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aR138-R141) [[2]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR48-R57)
* Moved the `curves` module to the top of the imports in the scene loader for improved clarity and organization. [[1]](diffhunk://#diff-71070d6b1122fd0cf094ed72c4975200e4a8f7aa0d2e69bb7304b2a08381eb97R1-L5) [[2]](diffhunk://#diff-7a93d6a1dc322126242fc2d63924db9fa37bb2d1c65bdf8de31e388781e03123L1-R12)

---

**References:**  
[[1]](diffhunk://#diff-8ef321409053f3bddf9f4dee544a96f4f701dc4b35fd5708fe6d1fa44dbf7340R1-R22) [[2]](diffhunk://#diff-adbc59172c6e941ed89f63a73b9a50e854e72fbcc2a823d9bf7a69e919444cf4R1-R60) [[3]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aL32-R39) [[4]](diffhunk://#diff-aa32e4e35d9d6dedb7cf28a9c532abcc6ff167eafd29b26845cacc0a788b864aR138-R141) [[5]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR48-R57) [[6]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR549-R555) [[7]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR589-R617) [[8]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5L5-R5) [[9]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5R29-R30) [[10]](diffhunk://#diff-c8e9d295c0b3c931a3756c9cf5acee99f4d552dc2b78f8cc8a8bca14cd8d797bR20-R21) [[11]](diffhunk://#diff-f86e52d7583535595a29fccc683f1cac05a49df5a0565ba2b8362883ac337a16R28-R29) [[12]](diffhunk://#diff-f67f75c526bb716a7279a80b27f32ffab784759dc6a0237e56fbd7bea4e3822eR1-R342) [[13]](diffhunk://#diff-71070d6b1122fd0cf094ed72c4975200e4a8f7aa0d2e69bb7304b2a08381eb97R1-L5) [[14]](diffhunk://#diff-7a93d6a1dc322126242fc2d63924db9fa37bb2d1c65bdf8de31e388781e03123L1-R12)