### PR TITLE
Add slope-scale shadow bias and dynamic shadow map sizing

### DIFF
--- a/assets/shaders/include/lighting_shadow_functions.wgsl
+++ b/assets/shaders/include/lighting_shadow_functions.wgsl
@@ -76,6 +76,8 @@ fn sample_directional_shadow_factor(
     cascade_count: u32,
     view_depth: f32,
     world_position: vec3<f32>,
+    surface_normal: vec3<f32>,
+    light_direction: vec3<f32>,
 ) -> f32 {
     let projected = project_directional_shadow_uv_depth(
         base_shadow_index,
@@ -90,7 +92,12 @@ fn sample_directional_shadow_factor(
     let shadow_index = i32(projected.w);
     let shadow = directional_shadow_infos[u32(shadow_index)];
     let uv = projected.xy;
-    let compare = projected.z - max(shadow.bias, 0.0);
+    let n = normalize(surface_normal);
+    let l = normalize(-light_direction);
+    let ndotl = max(dot(n, l), 0.0);
+    let slope_term = (1.0 - ndotl);
+    let final_bias = max(shadow.bias, 0.0) + max(shadow.slope_bias, 0.0) * slope_term;
+    let compare = projected.z - final_bias;
     return textureSampleCompare(
         directional_shadow_maps,
         directional_shadow_sampler,

--- a/assets/shaders/include/lighting_shadow_header.wgsl
+++ b/assets/shaders/include/lighting_shadow_header.wgsl
@@ -5,8 +5,8 @@ struct DirectionalShadowInfo {
     light_view_proj: mat4x4<f32>,
     split_end: f32,
     bias: f32,
+    slope_bias: f32,
     map_layer: i32,
-    _pad0: i32,
 }
 
 @group(5)

--- a/assets/shaders/include/lighting_surface_footer.wgsl
+++ b/assets/shaders/include/lighting_surface_footer.wgsl
@@ -613,6 +613,8 @@ fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
                 light.cascade_count,
                 view_depth,
                 in.w_position,
+                N,
+                direction,
             );
         intensity *= shadow_factor;
         debug_shadow_factor = min(debug_shadow_factor, shadow_factor);

--- a/src/model/scene/properties/light.rs
+++ b/src/model/scene/properties/light.rs
@@ -2,7 +2,7 @@ use super::common::*;
 use std::cell::LazyCell;
 use std::collections::HashMap;
 
-const PARAMETERS: [(&str, &str, &str, &str, &str); 31] = [
+const PARAMETERS: [(&str, &str, &str, &str, &str); 32] = [
     ("point", "color", "I", "1.0 1.0 1.0", ""),
     ("point", "color", "scale", "1.0 1.0 1.0", ""),
     ("point", "point", "from", "0.0 0.0 0.0", ""),
@@ -29,6 +29,7 @@ const PARAMETERS: [(&str, &str, &str, &str, &str); 31] = [
     ("distant", "bool", "castshadow", "true", ""),
     ("distant", "integer", "cascadecount", "4", "1 4"),
     ("distant", "float", "shadowbias", "0.001", "0.0 0.1"),
+    ("distant", "float", "shadowslopebias", "0.01", "0.0 0.1"),
     //
     ("infinite", "color", "L", "1.0 1.0 1.0", ""),
     ("infinite", "color", "scale", "1.0 1.0 1.0", ""),

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -7,11 +7,12 @@ pub struct DirectionalRenderLight {
     pub id: Uuid,
     pub edition: String,
     pub direction: [f32; 3],
-    pub intensity: [f32; 3], // RGB intensity
-    pub source_angle: f32,   // Angular diameter of the light source in radians
-    pub cast_shadow: bool,   // Whether the light casts shadow
-    pub shadow_bias: f32,    // Shadow depth bias
-    pub cascade_count: u32,  // Number of CSM cascades (1..4)
+    pub intensity: [f32; 3],    // RGB intensity
+    pub source_angle: f32,      // Angular diameter of the light source in radians
+    pub cast_shadow: bool,      // Whether the light casts shadow
+    pub shadow_bias: f32,       // Shadow depth bias
+    pub shadow_slope_bias: f32, // Shadow slope-scale bias
+    pub cascade_count: u32,     // Number of CSM cascades (1..4)
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -5,9 +5,9 @@ use super::mesh::RenderVertex;
 use super::render_item::RenderItem;
 use super::render_resource::RenderResourceManager;
 use super::shader::RenderShader;
-use super::shadow::create_directional_light_shadows;
 use super::shadow::DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT;
 use super::shadow::RenderDirectionalLightShadow;
+use super::shadow::create_directional_light_shadows;
 use super::texture::RenderTexture;
 use crate::render::wgpu::light::RenderLight;
 use std::collections::HashMap;
@@ -38,7 +38,6 @@ const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8
 const DIRECTIONAL_SHADOW_PIPELINE_ID: Uuid =
     Uuid::from_u128(0x77dd5bcc_89c5_4eff_8adf_9b5f8667d9f1);
 const Z_PREPASS_PIPELINE_ID: Uuid = Uuid::from_u128(0x9979b259_39f8_4ce5_8ea5_d8078618620f);
-const DIRECTIONAL_SHADOW_MAP_SIZE: u32 = 2048;
 
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
@@ -134,10 +133,10 @@ struct InfiniteLight {
 #[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
 struct DirectionalShadowInfo {
     light_view_proj: [[f32; 4]; 4], // 4 * 4 * 4 = 64
-    split_end: f32,                // 1 * 4 = 4
-    bias: f32,                     // 1 * 4 = 4
-    map_layer: i32,                // 1 * 4 = 4
-    _pad0: i32,                    // 1 * 4 = 4
+    split_end: f32,                 // 1 * 4 = 4
+    bias: f32,                      // 1 * 4 = 4
+    slope_bias: f32,                // 1 * 4 = 4
+    map_layer: i32,                 // 1 * 4 = 4
 }
 
 #[derive(Debug, Clone)]
@@ -374,14 +373,15 @@ impl LightingMeshRenderer {
                         contents: bytemuck::bytes_of(&global_uniforms),
                         usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
                     });
-                let shadow_global_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-                    label: Some("Shadow Global Bind Group"),
-                    layout: &self.global_bind_group_layout,
-                    entries: &[wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: shadow_global_uniform_buffer.as_entire_binding(),
-                    }],
-                });
+                let shadow_global_bind_group =
+                    device.create_bind_group(&wgpu::BindGroupDescriptor {
+                        label: Some("Shadow Global Bind Group"),
+                        layout: &self.global_bind_group_layout,
+                        entries: &[wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: shadow_global_uniform_buffer.as_entire_binding(),
+                        }],
+                    });
 
                 let shadow_texture = &cascade.texture;
                 {
@@ -404,7 +404,8 @@ impl LightingMeshRenderer {
                         render_pass.set_pipeline(&pipeline_entry.pipeline);
                         render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
                         for item_index in pipeline_entry.mesh_indices.iter().copied() {
-                            if let RenderItem::Mesh(mesh_item) = self.mesh_items[item_index].as_ref()
+                            if let RenderItem::Mesh(mesh_item) =
+                                self.mesh_items[item_index].as_ref()
                             {
                                 let local_uniform_offset = item_index as wgpu::DynamicOffset
                                     * local_uniform_alignment as wgpu::DynamicOffset;
@@ -443,8 +444,14 @@ impl LightingMeshRenderer {
                         aspect: wgpu::TextureAspect::DepthOnly,
                     },
                     wgpu::Extent3d {
-                        width: DIRECTIONAL_SHADOW_MAP_SIZE,
-                        height: DIRECTIONAL_SHADOW_MAP_SIZE,
+                        width: shadow_texture
+                            .texture
+                            .width()
+                            .min(self.directional_shadow_map_array.texture.width()),
+                        height: shadow_texture
+                            .texture
+                            .height()
+                            .min(self.directional_shadow_map_array.texture.height()),
                         depth_or_array_layers: 1,
                     },
                 );
@@ -1002,11 +1009,19 @@ impl LightingMeshRenderer {
                 .map(|s| s.cascades.len())
                 .sum::<usize>();
             let layer_count = total_cascade_count.max(1) as u32;
+            let (shadow_map_width, shadow_map_height) = directional_light_shadows
+                .iter()
+                .find_map(|s| s.cascades.first())
+                .map(|c| (c.texture.texture.width(), c.texture.texture.height()))
+                .unwrap_or((
+                    self.directional_shadow_map_array.width.max(1),
+                    self.directional_shadow_map_array.height.max(1),
+                ));
             self.ensure_directional_shadow_map_array(
                 device,
                 layer_count,
-                DIRECTIONAL_SHADOW_MAP_SIZE,
-                DIRECTIONAL_SHADOW_MAP_SIZE,
+                shadow_map_width,
+                shadow_map_height,
             );
 
             let mut infos = vec![DirectionalShadowInfo::default(); MAX_DIRECTIONAL_SHADOW_NUM];
@@ -1020,8 +1035,8 @@ impl LightingMeshRenderer {
                         light_view_proj: cascade.light_view_proj.to_cols_array_2d(),
                         split_end: cascade.split_end,
                         bias: shadow.shadow_bias,
+                        slope_bias: shadow.shadow_slope_bias,
                         map_layer: info_index as i32,
-                        _pad0: 0,
                     };
                     info_index += 1;
                 }
@@ -1253,7 +1268,9 @@ impl LightingMeshRenderer {
                         -1
                     };
                     let cascade_count = if light.cast_shadow {
-                        light.cascade_count.clamp(1, DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT as u32)
+                        light
+                            .cascade_count
+                            .clamp(1, DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT as u32)
                     } else {
                         0
                     };
@@ -1870,9 +1887,9 @@ impl LightingMeshRenderer {
                 ],
             });
 
-        let directional_shadow_info_buffer_size =
-            (MAX_DIRECTIONAL_SHADOW_NUM * size_of::<DirectionalShadowInfo>())
-                as wgpu::BufferAddress;
+        let directional_shadow_info_buffer_size = (MAX_DIRECTIONAL_SHADOW_NUM
+            * size_of::<DirectionalShadowInfo>())
+            as wgpu::BufferAddress;
         let directional_shadow_bind_group_layout =
             device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                 label: Some("Directional Shadow Bind Group Layout"),
@@ -2043,7 +2060,9 @@ impl LightingMeshRenderer {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&directional_shadow_map_array.view),
+                    resource: wgpu::BindingResource::TextureView(
+                        &directional_shadow_map_array.view,
+                    ),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -127,6 +127,10 @@ fn get_directional_light_item(
         let source_angle = source_angle.to_radians();
         let cascade_count = props.find_one_int("cascadecount").unwrap_or(4).clamp(1, 4) as u32;
         let shadow_bias = props.find_one_float("shadowbias").unwrap_or(0.001).max(0.0);
+        let shadow_slope_bias = props
+            .find_one_float("shadowslopebias")
+            .unwrap_or(0.01)
+            .max(0.0);
 
         // Accept both spellings to be robust against source scene variants.
         let cast_shadow = props
@@ -143,6 +147,7 @@ fn get_directional_light_item(
             source_angle,
             cast_shadow,
             shadow_bias,
+            shadow_slope_bias,
             cascade_count,
             ..Default::default()
         };

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -8,11 +8,14 @@ use std::sync::Arc;
 use eframe::wgpu;
 use uuid::Uuid;
 
-const SHADOW_MAP_SIZE: u32 = 2048;
 const SHADOW_BOUNDS_MARGIN: f32 = 0.1;
+const DIRECTIONAL_SHADOW_MAP_SIZE: u32 = 2048;
 pub const DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT: usize = 4;
-// Higher value biases cascade resolution toward near camera range.
-const CASCADE_SPLIT_LAMBDA: f32 = 0.8;
+// Blend factor between uniform and logarithmic CSM split distributions.
+// split = lerp(uniform_split, log_split, CASCADE_SPLIT_LAMBDA)
+// 0.0 -> fully uniform, 1.0 -> fully logarithmic.
+// Higher values allocate more resolution to near-camera cascades.
+const CASCADE_SPLIT_LAMBDA: f32 = 0.9;
 
 #[derive(Debug, Clone)]
 pub struct RenderDirectionalLightShadowCascade {
@@ -28,6 +31,7 @@ pub struct RenderDirectionalLightShadow {
     pub id: Uuid,
     pub edition: String,
     pub shadow_bias: f32,
+    pub shadow_slope_bias: f32,
     pub cascades: Vec<RenderDirectionalLightShadowCascade>,
 }
 
@@ -257,8 +261,7 @@ pub fn create_directional_light_shadows(
 
             let corners = get_aabb_corners(world_min_c, world_max_c);
             let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
-            let mut light_max =
-                glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+            let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
             for corner in corners {
                 let p = light_view.transform_point3(corner);
                 expand_bounds(&mut light_min, &mut light_max, p);
@@ -282,8 +285,8 @@ pub fn create_directional_light_shadows(
             let height = (light_max.y - light_min.y).abs() + 2.0 * my;
             let mut center_x = 0.5 * (light_min.x + light_max.x);
             let mut center_y = 0.5 * (light_min.y + light_max.y);
-            let units_per_texel_x = (width / SHADOW_MAP_SIZE as f32).max(1e-6);
-            let units_per_texel_y = (height / SHADOW_MAP_SIZE as f32).max(1e-6);
+            let units_per_texel_x = (width / DIRECTIONAL_SHADOW_MAP_SIZE as f32).max(1e-6);
+            let units_per_texel_y = (height / DIRECTIONAL_SHADOW_MAP_SIZE as f32).max(1e-6);
             center_x = (center_x / units_per_texel_x).floor() * units_per_texel_x;
             center_y = (center_y / units_per_texel_y).floor() * units_per_texel_y;
 
@@ -299,8 +302,11 @@ pub fn create_directional_light_shadows(
 
             let tex_id = Uuid::new_v3(
                 &Uuid::NAMESPACE_OID,
-                format!("directional-shadow:{}:cascade:{}", directional_light.id, cascade_index)
-                    .as_bytes(),
+                format!(
+                    "directional-shadow:{}:cascade:{}",
+                    directional_light.id, cascade_index
+                )
+                .as_bytes(),
             );
             let render_texture = if let Some(tex) = render_resource_manager.get_texture(tex_id) {
                 if tex.edition == directional_light.edition {
@@ -309,8 +315,8 @@ pub fn create_directional_light_shadows(
                     let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
                         label: Some("Directional Shadow Map"),
                         size: wgpu::Extent3d {
-                            width: SHADOW_MAP_SIZE,
-                            height: SHADOW_MAP_SIZE,
+                            width: DIRECTIONAL_SHADOW_MAP_SIZE,
+                            height: DIRECTIONAL_SHADOW_MAP_SIZE,
                             depth_or_array_layers: 1,
                         },
                         mip_level_count: 1,
@@ -350,8 +356,8 @@ pub fn create_directional_light_shadows(
                 let shadow_texture = device.create_texture(&wgpu::TextureDescriptor {
                     label: Some("Directional Shadow Map"),
                     size: wgpu::Extent3d {
-                        width: SHADOW_MAP_SIZE,
-                        height: SHADOW_MAP_SIZE,
+                        width: DIRECTIONAL_SHADOW_MAP_SIZE,
+                        height: DIRECTIONAL_SHADOW_MAP_SIZE,
                         depth_or_array_layers: 1,
                     },
                     mip_level_count: 1,
@@ -363,7 +369,8 @@ pub fn create_directional_light_shadows(
                         | wgpu::TextureUsages::COPY_SRC,
                     view_formats: &[wgpu::TextureFormat::Depth32Float],
                 });
-                let shadow_view = shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
+                let shadow_view =
+                    shadow_texture.create_view(&wgpu::TextureViewDescriptor::default());
                 let shadow_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
                     address_mode_u: wgpu::AddressMode::ClampToEdge,
                     address_mode_v: wgpu::AddressMode::ClampToEdge,
@@ -399,6 +406,7 @@ pub fn create_directional_light_shadows(
             id: directional_light.id,
             edition: directional_light.edition.clone(),
             shadow_bias: directional_light.shadow_bias,
+            shadow_slope_bias: directional_light.shadow_slope_bias,
             cascades,
         });
         render_resource_manager.add_directional_light_shadow(&shadow);


### PR DESCRIPTION
This pull request introduces improvements to the handling of directional light shadows, specifically by adding support for a slope-scale bias to reduce shadow artifacts and by refining the configuration and usage of shadow map sizes. The changes span shader code, scene properties, rendering logic, and shadow creation, ensuring that the new slope bias is correctly propagated and used throughout the rendering pipeline.

**Directional shadow bias improvements:**

* Added a new `shadowslopebias` property for distant lights in the `PARAMETERS` array and exposed it in the `DirectionalRenderLight` struct, allowing configuration of slope-scale bias for shadows. [[1]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5R32) [[2]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR14)
* Updated the shadow info structs (`DirectionalShadowInfo`) and their usage in both shader and Rust code to include the new `slope_bias` field. [[1]](diffhunk://#diff-8ef321409053f3bddf9f4dee544a96f4f701dc4b35fd5708fe6d1fa44dbf7340R8-L9) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R138-L140)
* Modified the shadow sampling function in WGSL (`sample_directional_shadow_factor`) to use the slope-scale bias for more accurate bias calculation based on surface angle, reducing shadow acne and artifacts.

**Shadow map configuration and propagation:**

* Replaced hardcoded shadow map sizes with a constant (`DIRECTIONAL_SHADOW_MAP_SIZE`) and ensured consistent usage throughout the shadow creation and rendering code, including proper propagation of actual shadow map dimensions. [[1]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L11-R18) [[2]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L285-R289) [[3]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L312-R319) [[4]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L353-R360) [[5]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716R1012-R1024) [[6]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L446-R454)
* Updated the cascade split lambda to 0.9 for improved allocation of shadow resolution near the camera.

**Pipeline and bind group adjustments:**

* Refactored bind group and render pass setup code for clarity and consistency, including minor formatting improvements. [[1]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L377-R377) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L407-R408) [[3]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L1873-R1891) [[4]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L2046-R2065)

**Property parsing and propagation:**

* Ensured that the new `shadowslopebias` property is parsed from scene properties and propagated to the shadow creation logic, connecting scene configuration to rendering. [[1]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cR130-R133) [[2]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cR150) [[3]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4R409)

**Shader interface updates:**

* Updated shader function signatures and calls to accept and use surface normal and light direction for slope bias computation, ensuring the new bias logic is applied in rendering. [[1]](diffhunk://#diff-adbc59172c6e941ed89f63a73b9a50e854e72fbcc2a823d9bf7a69e919444cf4R79-R80) [[2]](diffhunk://#diff-7e31fa86d15f5210beb67a339d2415e30c9ebb0389422dfaa314a467c3d210faR616-R617)

These changes collectively improve the quality and configurability of directional light shadows, making them less prone to artifacts and more responsive to scene properties.