### PR TITLE
Feature/lspsm2

### DIFF
--- a/src/model/scene/properties/light.rs
+++ b/src/model/scene/properties/light.rs
@@ -2,7 +2,7 @@ use super::common::*;
 use std::cell::LazyCell;
 use std::collections::HashMap;
 
-const PARAMETERS: [(&str, &str, &str, &str, &str); 32] = [
+const PARAMETERS: [(&str, &str, &str, &str, &str); 33] = [
     ("point", "color", "I", "1.0 1.0 1.0", ""),
     ("point", "color", "scale", "1.0 1.0 1.0", ""),
     ("point", "point", "from", "0.0 0.0 0.0", ""),
@@ -28,6 +28,7 @@ const PARAMETERS: [(&str, &str, &str, &str, &str); 32] = [
     ("distant", "float", "sourceangle", "0.5357", "0.0 30.0"), //angular diameter of the light source
     ("distant", "bool", "castshadow", "true", ""),
     ("distant", "integer", "cascadecount", "4", "1 4"),
+    ("distant", "string", "shadowprojection", "csm", ""), // csm | lspsm
     ("distant", "float", "shadowbias", "0.001", "0.0 0.1"),
     ("distant", "float", "shadowslopebias", "0.01", "0.0 0.1"),
     //

--- a/src/panel/inspector/common.rs
+++ b/src/panel/inspector/common.rs
@@ -325,6 +325,23 @@ fn show_strings(
                         }
                     }
                 });
+        } else if key_name == "shadowprojection" {
+            let types = ["csm", "lspsm"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>();
+            egui::ComboBox::from_id_salt("shadowprojection")
+                .selected_text(value[0].clone())
+                .show_ui(ui, |ui| {
+                    for name in types.iter() {
+                        if ui
+                            .selectable_value(&mut value[0], name.clone(), name.clone())
+                            .changed()
+                        {
+                            is_changed = true;
+                        }
+                    }
+                });
         } else if key_name == "bumpmap" {
             let mut items = vec![(Uuid::default(), "".to_string(), "none".to_string())];
             items.extend(resource_selector.get_texture_items());

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -2,6 +2,13 @@ use super::texture::RenderTexture;
 use std::sync::Arc;
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DirectionalShadowProjection {
+    #[default]
+    Csm,
+    Lspsm,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct DirectionalRenderLight {
     pub id: Uuid,
@@ -13,6 +20,7 @@ pub struct DirectionalRenderLight {
     pub shadow_bias: f32,       // Shadow depth bias
     pub shadow_slope_bias: f32, // Shadow slope-scale bias
     pub cascade_count: u32,     // Number of CSM cascades (1..4)
+    pub shadow_projection: DirectionalShadowProjection,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -292,6 +292,7 @@ impl LightingMeshRenderer {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
         render_resource_manager: &mut RenderResourceManager,
         render_items: &[Arc<RenderItem>],
         camera: &RenderCamera,
@@ -310,6 +311,8 @@ impl LightingMeshRenderer {
                 &light_items,
             ); //group(3)
         }
+        // Render shadow maps immediately after light preparation.
+        self.render_directional_shadow_maps(device, queue, encoder, camera);
     }
 
     pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
@@ -318,7 +321,7 @@ impl LightingMeshRenderer {
         }
     }
 
-    pub fn render_directional_shadow_maps(
+    fn render_directional_shadow_maps(
         &self,
         device: &wgpu::Device,
         _queue: &wgpu::Queue,

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -682,42 +682,29 @@ impl LightingMeshRenderer {
     }
 
     fn prepare_z_prepass(&mut self, device: &wgpu::Device, mesh_items: &[Arc<RenderItem>]) {
-        let mut z_prepass_mesh_indices: HashSet<usize> = HashSet::new();
-        for entry in self.pipelines.values_mut() {
+        if !self.pipelines.contains_key(&Z_PREPASS_PIPELINE_ID) {
+            let entry = self.create_z_prepass_pipeline(device);
+            self.pipelines
+                .insert(Z_PREPASS_PIPELINE_ID, Arc::new(RwLock::new(entry)));
+        }
+        //todo: check z-prepass should be one pipeline for all meshes or multiple pipelines for different shaders.
+        
+        if let Some(entry) = self.pipelines.get_mut(&Z_PREPASS_PIPELINE_ID) {
             let mut entry = entry.write().unwrap();
-            match &mut *entry {
-                PipelineEntry::ZPrepass(p) => {
-                    p.mesh_indices.clear();
+            if let PipelineEntry::ZPrepass(p) = &mut *entry {
+                let mut indices: Vec<usize> = Vec::with_capacity(mesh_items.len());
+                for (mesh_index, item) in mesh_items.iter().enumerate() {
+                    if let Some(material) = item.get_material()
+                        && material
+                            .passes
+                            .iter()
+                            .any(|pass| get_shader_uses_z_prepass(pass.render_category))
+                    {
+                        indices.push(mesh_index);
+                    }
                 }
-                _ => {}
+                p.mesh_indices = indices;
             }
-        }
-        for (mesh_index, item) in mesh_items.iter().enumerate() {
-            if let Some(material) = item.get_material()
-                && material
-                    .passes
-                    .iter()
-                    .any(|pass| get_shader_uses_z_prepass(pass.render_category))
-            {
-                z_prepass_mesh_indices.insert(mesh_index);
-            }
-        }
-        if !z_prepass_mesh_indices.is_empty() {
-            if !self.pipelines.contains_key(&Z_PREPASS_PIPELINE_ID) {
-                let entry = self.create_z_prepass_pipeline(device);
-                self.pipelines
-                    .insert(Z_PREPASS_PIPELINE_ID, Arc::new(RwLock::new(entry)));
-            }
-            if let Some(entry) = self.pipelines.get_mut(&Z_PREPASS_PIPELINE_ID) {
-                let mut entry = entry.write().unwrap();
-                let mut indices: Vec<usize> = z_prepass_mesh_indices.into_iter().collect();
-                indices.sort_unstable();
-                if let PipelineEntry::ZPrepass(p) = &mut *entry {
-                    p.mesh_indices = indices;
-                }
-            }
-        } else {
-            self.pipelines.remove(&Z_PREPASS_PIPELINE_ID);
         }
     }
 

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -35,8 +35,6 @@ const MAX_INFINITE_LIGHT_NUM: usize = 1; // Maximum number of infinite lights
 const MAX_LIGHT_TEXTURE_NUM: usize = 1; // Maximum number of light textures
 
 const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8_40a5fa168488);
-const DIRECTIONAL_SHADOW_PIPELINE_ID: Uuid =
-    Uuid::from_u128(0x77dd5bcc_89c5_4eff_8adf_9b5f8667d9f1);
 const Z_PREPASS_PIPELINE_ID: Uuid = Uuid::from_u128(0x9979b259_39f8_4ce5_8ea5_d8078618620f);
 
 #[repr(C)]
@@ -244,6 +242,7 @@ pub struct LightingMeshRenderer {
     directional_shadow_info_buffer: wgpu::Buffer,
     directional_shadow_map_array: DirectionalShadowMapArray,
     directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
+    directional_shadow_pipeline: Option<PipelineEntry>,
 
     // Mesh items to render
     mesh_items: Vec<Arc<RenderItem>>,
@@ -302,17 +301,25 @@ impl LightingMeshRenderer {
             let (mesh_items, light_items) = Self::split_items(render_items);
             self.prepare_locals(device, queue, &mesh_items); //group(1)
             self.prepare_materials(device, queue, &mesh_items); //group(2)
-            self.prepare_lights(
-                device,
-                queue,
-                render_resource_manager,
-                camera,
-                &mesh_items,
-                &light_items,
-            ); //group(3)
+            {
+                let shadow_pipelines = self.prepare_lights(
+                    device,
+                    queue,
+                    render_resource_manager,
+                    camera,
+                    &mesh_items,
+                    &light_items,
+                );
+                // Render shadow maps immediately after light preparation.
+                self.render_directional_shadow_maps(
+                    device,
+                    queue,
+                    encoder,
+                    camera,
+                    &shadow_pipelines,
+                );
+            } //group(3)
         }
-        // Render shadow maps immediately after light preparation.
-        self.render_directional_shadow_maps(device, queue, encoder, camera);
     }
 
     pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
@@ -327,6 +334,7 @@ impl LightingMeshRenderer {
         _queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         _main_camera: &RenderCamera,
+        shadow_pipelines: &[Arc<PipelineEntry>],
     ) {
         if self.directional_light_shadows.is_empty() {
             return;
@@ -340,16 +348,6 @@ impl LightingMeshRenderer {
             )
         };
 
-        let mut shadow_pipelines = Vec::new();
-        for pipeline_entry in self.pipelines.values() {
-            let pipeline_entry = pipeline_entry.read().unwrap();
-            if pipeline_entry.mesh_indices.is_empty() {
-                continue;
-            }
-            if matches!(pipeline_entry.pass_type, PipelinePassType::Shadow) {
-                shadow_pipelines.push(pipeline_entry.clone());
-            }
-        }
         if shadow_pipelines.is_empty() {
             return;
         }
@@ -403,7 +401,7 @@ impl LightingMeshRenderer {
                         occlusion_query_set: None,
                     });
 
-                    for pipeline_entry in shadow_pipelines.iter() {
+                    for pipeline_entry in shadow_pipelines {
                         render_pass.set_pipeline(&pipeline_entry.pipeline);
                         render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
                         for item_index in pipeline_entry.mesh_indices.iter().copied() {
@@ -972,7 +970,8 @@ impl LightingMeshRenderer {
         camera: &RenderCamera,
         mesh_items: &[Arc<RenderItem>],
         light_items: &[Arc<RenderItem>],
-    ) {
+    ) -> Vec<Arc<PipelineEntry>> {
+        let mut shadow_pipelines = Vec::new();
         let mut light_uniforms = LightUniforms::default();
         let mut light_textures = Vec::new();
         let shadow_mesh_indices = mesh_items
@@ -1001,11 +1000,13 @@ impl LightingMeshRenderer {
             light_items,
             render_resource_manager,
         );
-        self.update_directional_shadow_pipeline_entry(
-            device,
-            !directional_light_shadows.is_empty(),
-            &shadow_mesh_indices,
-        );
+        if !directional_light_shadows.is_empty()
+            && !shadow_mesh_indices.is_empty()
+            && let Some(pipeline) =
+                self.build_directional_shadow_pipeline_entry(device, &shadow_mesh_indices)
+        {
+            shadow_pipelines.push(Arc::new(pipeline));
+        }
         {
             let total_cascade_count = directional_light_shadows
                 .iter()
@@ -1328,19 +1329,18 @@ impl LightingMeshRenderer {
             0,
             bytemuck::bytes_of(&light_uniforms),
         );
+        shadow_pipelines
     }
 
-    fn update_directional_shadow_pipeline_entry(
+    fn build_directional_shadow_pipeline_entry(
         &mut self,
         device: &wgpu::Device,
-        has_directional_shadows: bool,
         shadow_mesh_indices: &[usize],
-    ) {
-        if !has_directional_shadows {
-            self.pipelines.remove(&DIRECTIONAL_SHADOW_PIPELINE_ID);
-            return;
+    ) -> Option<PipelineEntry> {
+        if shadow_mesh_indices.is_empty() {
+            return None;
         }
-        if !self.pipelines.contains_key(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
+        if self.directional_shadow_pipeline.is_none() {
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("Directional Shadow Pipeline Shader"),
                 source: wgpu::ShaderSource::Wgsl(
@@ -1420,25 +1420,21 @@ impl LightingMeshRenderer {
                     entries: &[],
                 });
 
-            let entry = PipelineEntry {
+            self.directional_shadow_pipeline = Some(PipelineEntry {
                 pass_type: PipelinePassType::Shadow,
                 pipeline,
                 material_bind_group_layout,
                 material_bind_groups: Vec::new(),
-                mesh_indices: shadow_mesh_indices.to_vec(),
+                mesh_indices: Vec::new(),
                 material_indices: Vec::new(),
                 sort_order: 0,
                 enable_lighting: false,
-            };
-            self.pipelines
-                .insert(DIRECTIONAL_SHADOW_PIPELINE_ID, Arc::new(RwLock::new(entry)));
+            });
         }
-
-        if let Some(entry) = self.pipelines.get_mut(&DIRECTIONAL_SHADOW_PIPELINE_ID) {
-            let mut entry = entry.write().unwrap();
-            entry.mesh_indices = shadow_mesh_indices.to_vec();
-            entry.material_indices.clear();
-        }
+        let mut entry = self.directional_shadow_pipeline.clone()?;
+        entry.mesh_indices = shadow_mesh_indices.to_vec();
+        entry.material_indices.clear();
+        Some(entry)
     }
 
     fn create_pipeline(
@@ -2172,6 +2168,7 @@ impl LightingMeshRenderer {
             directional_shadow_info_buffer,
             directional_shadow_map_array,
             directional_light_shadows: Vec::new(),
+            directional_shadow_pipeline: None,
             mesh_items,
             textures,
             pipelines: materials,

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -202,14 +202,10 @@ enum PipelineEntry {
     DirectionalShadow {
         pipeline: wgpu::RenderPipeline,
         mesh_indices: Vec<usize>,
+        directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
         directional_shadow_info_buffer: wgpu::Buffer,
         shadow_map_array: RenderTexture,
     },
-}
-
-struct PreparedShadowPass {
-    directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
-    shadow_pipeline: Arc<RwLock<PipelineEntry>>,
 }
 
 #[derive(Debug, Clone)]
@@ -882,18 +878,17 @@ impl LightingMeshRenderer {
         })
     }
 
-    fn compute_directional_shadow_map_extent(
-        pipeline: &PipelineEntry,
-        directional_light_shadows: &[Arc<RenderDirectionalLightShadow>],
-    ) -> (u32, u32, u32) {
-        let current_size = if let PipelineEntry::DirectionalShadow {
-            shadow_map_array, ..
+    fn compute_directional_shadow_map_extent(pipeline: &PipelineEntry) -> (u32, u32, u32) {
+        let (directional_light_shadows, current_size) = if let PipelineEntry::DirectionalShadow {
+            directional_light_shadows,
+            shadow_map_array,
+            ..
         } = pipeline
         {
             let size = shadow_map_array.texture.size();
-            (size.width, size.height)
+            (directional_light_shadows, (size.width, size.height))
         } else {
-            (1, 1)
+            return (1, 1, 1);
         };
         let total_cascade_count = directional_light_shadows
             .iter()
@@ -967,11 +962,15 @@ impl LightingMeshRenderer {
         if let Some(pipeline_arc) = self.get_directional_shadow_pipeline_entry() {
             {
                 let mut pipeline = pipeline_arc.write().unwrap();
+                if let PipelineEntry::DirectionalShadow {
+                    directional_light_shadows: pipeline_shadows,
+                    ..
+                } = &mut *pipeline
+                {
+                    *pipeline_shadows = directional_light_shadows.to_vec();
+                }
                 let (layer_count, shadow_map_width, shadow_map_height) =
-                    Self::compute_directional_shadow_map_extent(
-                        &pipeline,
-                        directional_light_shadows,
-                    );
+                    Self::compute_directional_shadow_map_extent(&pipeline);
                 let _ = Self::ensure_directional_shadow_map_array(
                     device,
                     &mut pipeline,
@@ -1012,7 +1011,7 @@ impl LightingMeshRenderer {
         camera: &RenderCamera,
         mesh_items: &[Arc<RenderItem>],
         light_items: &[Arc<RenderItem>],
-    ) -> Vec<PreparedShadowPass> {
+    ) -> Vec<Arc<RwLock<PipelineEntry>>> {
         let mut light_uniforms = LightUniforms::default();
         let mut light_textures = Vec::new();
         let shadow_mesh_indices = mesh_items
@@ -1032,7 +1031,7 @@ impl LightingMeshRenderer {
                 })
             })
             .collect::<Vec<_>>();
-        let mut shadow_passes = Vec::new();
+        let mut shadow_pipelines = Vec::new();
         let directional_light_shadows = create_directional_light_shadows(
             device,
             queue,
@@ -1054,10 +1053,7 @@ impl LightingMeshRenderer {
             base_shadow_index += shadow.cascades.len() as i32;
         }
         if let Some(shadow_pipeline_ref) = &shadow_pipeline {
-            shadow_passes.push(PreparedShadowPass {
-                shadow_pipeline: shadow_pipeline_ref.clone(),
-                directional_light_shadows,
-            });
+            shadow_pipelines.push(shadow_pipeline_ref.clone());
         }
         // Point lights
         {
@@ -1324,7 +1320,7 @@ impl LightingMeshRenderer {
             bytemuck::bytes_of(&light_uniforms),
         );
 
-        return shadow_passes;
+        return shadow_pipelines;
     }
 
     fn render_shadow_maps(
@@ -1333,10 +1329,16 @@ impl LightingMeshRenderer {
         queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         main_camera: &RenderCamera,
-        shadow_passes: &[PreparedShadowPass],
+        shadow_pipelines: &[Arc<RwLock<PipelineEntry>>],
     ) {
-        for pass in shadow_passes {
-            self.render_directional_shadow_maps(device, queue, encoder, main_camera, pass);
+        for shadow_pipeline in shadow_pipelines {
+            self.render_directional_shadow_maps(
+                device,
+                queue,
+                encoder,
+                main_camera,
+                shadow_pipeline,
+            );
         }
     }
 
@@ -1346,12 +1348,8 @@ impl LightingMeshRenderer {
         _queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         _main_camera: &RenderCamera,
-        shadow_pass: &PreparedShadowPass,
+        shadow_pipeline: &Arc<RwLock<PipelineEntry>>,
     ) {
-        if shadow_pass.directional_light_shadows.is_empty() {
-            return;
-        }
-
         let local_uniform_alignment = {
             let alignment = self.min_uniform_buffer_offset_alignment;
             align_to(
@@ -1360,11 +1358,24 @@ impl LightingMeshRenderer {
             )
         };
 
-        let directional_light_shadows = &shadow_pass.directional_light_shadows;
-        let shadow_pipeline = &shadow_pass.shadow_pipeline;
+        let directional_light_shadows = {
+            let pipeline_entry = shadow_pipeline.read().unwrap();
+            if let PipelineEntry::DirectionalShadow {
+                directional_light_shadows,
+                ..
+            } = &*pipeline_entry
+            {
+                directional_light_shadows.clone()
+            } else {
+                return;
+            }
+        };
+        if directional_light_shadows.is_empty() {
+            return;
+        }
 
         let mut layer: u32 = 0;
-        for shadow in directional_light_shadows {
+        for shadow in directional_light_shadows.iter() {
             for cascade in shadow.cascades.iter() {
                 let shadow_camera =
                     RenderCamera::from_matrices(cascade.light_view, cascade.light_proj);
@@ -1588,6 +1599,7 @@ impl LightingMeshRenderer {
                 Arc::new(RwLock::new(PipelineEntry::DirectionalShadow {
                     pipeline,
                     mesh_indices: Vec::new(),
+                    directional_light_shadows: Vec::new(),
                     directional_shadow_info_buffer: Self::create_directional_shadow_info_buffer(
                         device,
                     ),

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -184,28 +184,36 @@ struct MaterialBindGroupEntry {
 }
 
 #[derive(Debug, Clone)]
+struct ShadingPipelineEntry {
+    pub pipeline: wgpu::RenderPipeline,
+    pub material_bind_group_layout: wgpu::BindGroupLayout,
+    pub material_bind_groups: Vec<Arc<MaterialBindGroupEntry>>,
+    pub mesh_indices: Vec<usize>,
+    pub material_indices: Vec<usize>,
+    pub sort_order: u32,
+    pub enable_lighting: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ZPrepassPipelineEntry {
+    pub pipeline: wgpu::RenderPipeline,
+    pub mesh_indices: Vec<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct DirectionalShadowPipelineEntry {
+    pub pipeline: wgpu::RenderPipeline,
+    pub mesh_indices: Vec<usize>,
+    pub directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
+    pub directional_shadow_info_buffer: wgpu::Buffer,
+    pub shadow_map_array: RenderTexture,
+}
+
+#[derive(Debug, Clone)]
 enum PipelineEntry {
-    Shading {
-        pipeline: wgpu::RenderPipeline,
-        material_bind_group_layout: wgpu::BindGroupLayout,
-        material_bind_groups: Vec<Arc<MaterialBindGroupEntry>>,
-        mesh_indices: Vec<usize>,
-        material_indices: Vec<usize>,
-        sort_order: u32,
-        enable_lighting: bool,
-    },
-    ZPrepass {
-        pipeline: wgpu::RenderPipeline,
-        mesh_indices: Vec<usize>,
-        material_indices: Vec<usize>,
-    },
-    DirectionalShadow {
-        pipeline: wgpu::RenderPipeline,
-        mesh_indices: Vec<usize>,
-        directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
-        directional_shadow_info_buffer: wgpu::Buffer,
-        shadow_map_array: RenderTexture,
-    },
+    Shading(ShadingPipelineEntry),
+    ZPrepass(ZPrepassPipelineEntry),
+    DirectionalShadow(DirectionalShadowPipelineEntry),
 }
 
 #[derive(Debug, Clone)]
@@ -294,6 +302,7 @@ impl LightingMeshRenderer {
         {
             let (mesh_items, light_items) = Self::split_items(render_items);
             self.prepare_locals(device, queue, &mesh_items); //group(1)
+            self.prepare_z_prepass(device, &mesh_items); //group(2)
             self.prepare_materials(device, queue, &mesh_items); //group(2)
             {
                 let shadow_passes = self.prepare_lights(
@@ -349,15 +358,11 @@ impl LightingMeshRenderer {
         for pipeline_entry in self.pipelines.values() {
             let pipeline_entry = pipeline_entry.read().unwrap();
             match &*pipeline_entry {
-                PipelineEntry::ZPrepass { mesh_indices, .. } if !mesh_indices.is_empty() => {
+                PipelineEntry::ZPrepass(p) if !p.mesh_indices.is_empty() => {
                     z_prepass_pipelines.push(pipeline_entry.clone())
                 }
-                PipelineEntry::Shading {
-                    mesh_indices,
-                    sort_order,
-                    ..
-                } if !mesh_indices.is_empty() => {
-                    shading_pipelines.push((*sort_order, pipeline_entry.clone()))
+                PipelineEntry::Shading(p) if !p.mesh_indices.is_empty() => {
+                    shading_pipelines.push((p.sort_order, pipeline_entry.clone()))
                 }
                 _ => {}
             }
@@ -368,15 +373,10 @@ impl LightingMeshRenderer {
 
         // Depth-only prepass for opaque-like geometry.
         for pipeline_entry in z_prepass_pipelines.iter() {
-            if let PipelineEntry::ZPrepass {
-                pipeline,
-                mesh_indices,
-                ..
-            } = pipeline_entry
-            {
-                render_pass.set_pipeline(pipeline);
+            if let PipelineEntry::ZPrepass(p) = pipeline_entry {
+                render_pass.set_pipeline(&p.pipeline);
                 render_pass.set_bind_group(0, &self.global_bind_group, &[]);
-                for item_index in mesh_indices.iter().copied() {
+                for item_index in p.mesh_indices.iter().copied() {
                     if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
                         let local_uniform_offset = item_index as wgpu::DynamicOffset
                             * local_uniform_alignment as wgpu::DynamicOffset;
@@ -397,27 +397,19 @@ impl LightingMeshRenderer {
         }
 
         for (_, pipeline_entry) in shading_pipelines.iter() {
-            if let PipelineEntry::Shading {
-                pipeline,
-                material_bind_groups,
-                mesh_indices,
-                material_indices,
-                enable_lighting,
-                ..
-            } = pipeline_entry
-            {
-                debug_assert!(!mesh_indices.is_empty());
-                render_pass.set_pipeline(pipeline);
+            if let PipelineEntry::Shading(p) = pipeline_entry {
+                debug_assert!(!p.mesh_indices.is_empty());
+                render_pass.set_pipeline(&p.pipeline);
                 render_pass.set_bind_group(0, &self.global_bind_group, &[]);
-                if *enable_lighting {
+                if p.enable_lighting {
                     render_pass.set_bind_group(3, &self.light_bind_group, &[]);
                     render_pass.set_bind_group(5, &self.directional_shadow_bind_group, &[]);
                 }
-                debug_assert!(mesh_indices.len() == material_indices.len());
-                let length = mesh_indices.len();
+                debug_assert!(p.mesh_indices.len() == p.material_indices.len());
+                let length = p.mesh_indices.len();
                 for i in 0..length {
-                    let item_index = mesh_indices[i];
-                    let material_index = material_indices[i];
+                    let item_index = p.mesh_indices[i];
+                    let material_index = p.material_indices[i];
                     if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
                         let local_uniform_offset = item_index as wgpu::DynamicOffset
                             * local_uniform_alignment as wgpu::DynamicOffset;
@@ -428,11 +420,11 @@ impl LightingMeshRenderer {
                         );
                         render_pass.set_bind_group(
                             2,
-                            &material_bind_groups[material_index].material_bind_group,
+                            &p.material_bind_groups[material_index].material_bind_group,
                             &[],
                         );
                         if let Some(ltc_bind_group) =
-                            &material_bind_groups[material_index].ltc_bind_group
+                            &p.material_bind_groups[material_index].ltc_bind_group
                         {
                             render_pass.set_bind_group(4, ltc_bind_group, &[]);
                         }
@@ -602,32 +594,18 @@ impl LightingMeshRenderer {
             for entry in self.pipelines.values_mut() {
                 let mut entry = entry.write().unwrap();
                 match &mut *entry {
-                    PipelineEntry::Shading {
-                        mesh_indices,
-                        material_indices,
-                        material_bind_groups,
-                        ..
-                    } => {
-                        mesh_indices.clear();
-                        material_indices.clear();
-                        for bind_group in material_bind_groups.iter() {
+                    PipelineEntry::Shading(p) => {
+                        p.mesh_indices.clear();
+                        p.material_indices.clear();
+                        for bind_group in p.material_bind_groups.iter() {
                             prev_bind_groups.insert(bind_group.id, bind_group.clone());
                         }
-                        material_bind_groups.clear();
+                        p.material_bind_groups.clear();
                     }
-                    PipelineEntry::ZPrepass {
-                        mesh_indices,
-                        material_indices,
-                        ..
-                    } => {
-                        mesh_indices.clear();
-                        material_indices.clear();
-                    }
-                    PipelineEntry::DirectionalShadow { .. } => {}
+                    _ => {}
                 }
             }
             let mut tmp_pipelines: HashMap<Uuid, TmpPipelineEntry> = HashMap::new();
-            let mut z_prepass_mesh_indices: HashSet<usize> = HashSet::new();
             for (mesh_index, item) in mesh_items.iter().enumerate() {
                 if let Some(material) = item.get_material() {
                     for pass in material.passes.iter() {
@@ -647,9 +625,6 @@ impl LightingMeshRenderer {
                             entry
                                 .material_indices_map
                                 .insert(pass_id, (new_material_index, pass.clone()));
-                        }
-                        if get_shader_uses_z_prepass(pass.render_category) {
-                            z_prepass_mesh_indices.insert(mesh_index);
                         }
                     }
                 }
@@ -676,17 +651,10 @@ impl LightingMeshRenderer {
                     .get_mut(shader_id)
                     .expect("Pipeline for basic material not found");
                 let mut entry = entry.write().unwrap();
-                if let PipelineEntry::Shading {
-                    material_bind_group_layout,
-                    material_bind_groups,
-                    mesh_indices: entry_mesh_indices,
-                    material_indices: entry_material_indices,
-                    ..
-                } = &mut *entry
-                {
-                    *entry_mesh_indices = mesh_indices.clone();
-                    *entry_material_indices = material_indices.clone();
-                    assert!(entry_mesh_indices.len() == entry_material_indices.len());
+                if let PipelineEntry::Shading(p) = &mut *entry {
+                    p.mesh_indices = mesh_indices.clone();
+                    p.material_indices = material_indices.clone();
+                    assert!(p.mesh_indices.len() == p.material_indices.len());
                     let mut passes = Vec::with_capacity(num_materials);
                     for (_, (index, pass)) in tmp_entry.material_indices_map.iter() {
                         passes.push((index, pass));
@@ -695,46 +663,62 @@ impl LightingMeshRenderer {
                     for (_, pass) in passes.iter() {
                         let id = pass.id;
                         if let Some(bind_group_entry) = prev_bind_groups.get(&id) {
-                            material_bind_groups.push(bind_group_entry.clone());
+                            p.material_bind_groups.push(bind_group_entry.clone());
                         } else {
                             let bind_group_entry = Self::create_material_bind_group(
                                 device,
                                 queue,
-                                &*material_bind_group_layout,
+                                &p.material_bind_group_layout,
                                 &self.ltc_bind_group_layout,
                                 pass,
                             );
-                            material_bind_groups.push(Arc::new(bind_group_entry));
+                            p.material_bind_groups.push(Arc::new(bind_group_entry));
                         }
                     }
                 }
             }
-
-            if !z_prepass_mesh_indices.is_empty() {
-                if !self.pipelines.contains_key(&Z_PREPASS_PIPELINE_ID) {
-                    let entry = self.create_z_prepass_pipeline(device);
-                    self.pipelines
-                        .insert(Z_PREPASS_PIPELINE_ID, Arc::new(RwLock::new(entry)));
-                }
-                if let Some(entry) = self.pipelines.get_mut(&Z_PREPASS_PIPELINE_ID) {
-                    let mut entry = entry.write().unwrap();
-                    let mut indices: Vec<usize> = z_prepass_mesh_indices.into_iter().collect();
-                    indices.sort_unstable();
-                    if let PipelineEntry::ZPrepass {
-                        mesh_indices,
-                        material_indices,
-                        ..
-                    } = &mut *entry
-                    {
-                        *mesh_indices = indices;
-                        material_indices.clear();
-                    }
-                }
-            } else {
-                self.pipelines.remove(&Z_PREPASS_PIPELINE_ID);
-            }
         }
         self.mesh_items = mesh_items.to_vec();
+    }
+
+    fn prepare_z_prepass(&mut self, device: &wgpu::Device, mesh_items: &[Arc<RenderItem>]) {
+        let mut z_prepass_mesh_indices: HashSet<usize> = HashSet::new();
+        for entry in self.pipelines.values_mut() {
+            let mut entry = entry.write().unwrap();
+            match &mut *entry {
+                PipelineEntry::ZPrepass(p) => {
+                    p.mesh_indices.clear();
+                }
+                _ => {}
+            }
+        }
+        for (mesh_index, item) in mesh_items.iter().enumerate() {
+            if let Some(material) = item.get_material()
+                && material
+                    .passes
+                    .iter()
+                    .any(|pass| get_shader_uses_z_prepass(pass.render_category))
+            {
+                z_prepass_mesh_indices.insert(mesh_index);
+            }
+        }
+        if !z_prepass_mesh_indices.is_empty() {
+            if !self.pipelines.contains_key(&Z_PREPASS_PIPELINE_ID) {
+                let entry = self.create_z_prepass_pipeline(device);
+                self.pipelines
+                    .insert(Z_PREPASS_PIPELINE_ID, Arc::new(RwLock::new(entry)));
+            }
+            if let Some(entry) = self.pipelines.get_mut(&Z_PREPASS_PIPELINE_ID) {
+                let mut entry = entry.write().unwrap();
+                let mut indices: Vec<usize> = z_prepass_mesh_indices.into_iter().collect();
+                indices.sort_unstable();
+                if let PipelineEntry::ZPrepass(p) = &mut *entry {
+                    p.mesh_indices = indices;
+                }
+            }
+        } else {
+            self.pipelines.remove(&Z_PREPASS_PIPELINE_ID);
+        }
     }
 
     fn create_light_bind_group(
@@ -879,17 +863,13 @@ impl LightingMeshRenderer {
     }
 
     fn compute_directional_shadow_map_extent(pipeline: &PipelineEntry) -> (u32, u32, u32) {
-        let (directional_light_shadows, current_size) = if let PipelineEntry::DirectionalShadow {
-            directional_light_shadows,
-            shadow_map_array,
-            ..
-        } = pipeline
-        {
-            let size = shadow_map_array.texture.size();
-            (directional_light_shadows, (size.width, size.height))
-        } else {
-            return (1, 1, 1);
-        };
+        let (directional_light_shadows, current_size) =
+            if let PipelineEntry::DirectionalShadow(p) = pipeline {
+                let size = p.shadow_map_array.texture.size();
+                (&p.directional_light_shadows, (size.width, size.height))
+            } else {
+                return (1, 1, 1);
+            };
         let total_cascade_count = directional_light_shadows
             .iter()
             .map(|s| s.cascades.len())
@@ -914,19 +894,16 @@ impl LightingMeshRenderer {
         width: u32,
         height: u32,
     ) -> Option<RenderTexture> {
-        if let PipelineEntry::DirectionalShadow {
-            shadow_map_array, ..
-        } = pipeline
-        {
-            let size = shadow_map_array.texture.size();
+        if let PipelineEntry::DirectionalShadow(p) = pipeline {
+            let size = p.shadow_map_array.texture.size();
             if size.depth_or_array_layers != layer_count
                 || size.width != width
                 || size.height != height
             {
-                *shadow_map_array =
+                p.shadow_map_array =
                     Self::create_directional_shadow_map_array(device, layer_count, width, height);
             }
-            return Some(shadow_map_array.clone());
+            return Some(p.shadow_map_array.clone());
         }
         None
     }
@@ -962,12 +939,8 @@ impl LightingMeshRenderer {
         if let Some(pipeline_arc) = self.get_directional_shadow_pipeline_entry() {
             {
                 let mut pipeline = pipeline_arc.write().unwrap();
-                if let PipelineEntry::DirectionalShadow {
-                    directional_light_shadows: pipeline_shadows,
-                    ..
-                } = &mut *pipeline
-                {
-                    *pipeline_shadows = directional_light_shadows.to_vec();
+                if let PipelineEntry::DirectionalShadow(p) = &mut *pipeline {
+                    p.directional_light_shadows = directional_light_shadows.to_vec();
                 }
                 let (layer_count, shadow_map_width, shadow_map_height) =
                     Self::compute_directional_shadow_map_extent(&pipeline);
@@ -979,22 +952,17 @@ impl LightingMeshRenderer {
                     shadow_map_height,
                 );
 
-                if let PipelineEntry::DirectionalShadow {
-                    directional_shadow_info_buffer,
-                    shadow_map_array,
-                    ..
-                } = &*pipeline
-                {
+                if let PipelineEntry::DirectionalShadow(p) = &*pipeline {
                     queue.write_buffer(
-                        directional_shadow_info_buffer,
+                        &p.directional_shadow_info_buffer,
                         0,
                         bytemuck::cast_slice(&infos),
                     );
                     self.directional_shadow_bind_group = self.create_directional_shadow_bind_group(
                         device,
-                        directional_shadow_info_buffer,
-                        &shadow_map_array.view,
-                        &shadow_map_array.sampler,
+                        &p.directional_shadow_info_buffer,
+                        &p.shadow_map_array.view,
+                        &p.shadow_map_array.sampler,
                     );
                 }
             }
@@ -1360,12 +1328,8 @@ impl LightingMeshRenderer {
 
         let directional_light_shadows = {
             let pipeline_entry = shadow_pipeline.read().unwrap();
-            if let PipelineEntry::DirectionalShadow {
-                directional_light_shadows,
-                ..
-            } = &*pipeline_entry
-            {
-                directional_light_shadows.clone()
+            if let PipelineEntry::DirectionalShadow(p) = &*pipeline_entry {
+                p.directional_light_shadows.clone()
             } else {
                 return;
             }
@@ -1425,15 +1389,10 @@ impl LightingMeshRenderer {
 
                     {
                         let pipeline_entry = shadow_pipeline.read().unwrap();
-                        if let PipelineEntry::DirectionalShadow {
-                            pipeline,
-                            mesh_indices,
-                            ..
-                        } = &*pipeline_entry
-                        {
-                            render_pass.set_pipeline(pipeline);
+                        if let PipelineEntry::DirectionalShadow(p) = &*pipeline_entry {
+                            render_pass.set_pipeline(&p.pipeline);
                             render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
-                            for item_index in mesh_indices.iter().copied() {
+                            for item_index in p.mesh_indices.iter().copied() {
                                 if let RenderItem::Mesh(mesh_item) =
                                     self.mesh_items[item_index].as_ref()
                                 {
@@ -1465,11 +1424,7 @@ impl LightingMeshRenderer {
 
                 {
                     let pipeline_entry = shadow_pipeline.read().unwrap();
-                    if let PipelineEntry::DirectionalShadow {
-                        shadow_map_array,
-                        ..
-                    } = &*pipeline_entry
-                    {
+                    if let PipelineEntry::DirectionalShadow(p) = &*pipeline_entry {
                         encoder.copy_texture_to_texture(
                             wgpu::TexelCopyTextureInfo {
                                 texture: &shadow_texture.texture,
@@ -1478,7 +1433,7 @@ impl LightingMeshRenderer {
                                 aspect: wgpu::TextureAspect::DepthOnly,
                             },
                             wgpu::TexelCopyTextureInfo {
-                                texture: &shadow_map_array.texture,
+                                texture: &p.shadow_map_array.texture,
                                 mip_level: 0,
                                 origin: wgpu::Origin3d {
                                     x: 0,
@@ -1491,11 +1446,11 @@ impl LightingMeshRenderer {
                                 width: shadow_texture
                                     .texture
                                     .width()
-                                    .min(shadow_map_array.texture.width()),
+                                    .min(p.shadow_map_array.texture.width()),
                                 height: shadow_texture
                                     .texture
                                     .height()
-                                    .min(shadow_map_array.texture.height()),
+                                    .min(p.shadow_map_array.texture.height()),
                                 depth_or_array_layers: 1,
                             },
                         );
@@ -1596,24 +1551,27 @@ impl LightingMeshRenderer {
             let _ = material_bind_group_layout;
             self.pipelines.insert(
                 DIRECTIONAL_SHADOW_PIPELINE_ID,
-                Arc::new(RwLock::new(PipelineEntry::DirectionalShadow {
-                    pipeline,
-                    mesh_indices: Vec::new(),
-                    directional_light_shadows: Vec::new(),
-                    directional_shadow_info_buffer: Self::create_directional_shadow_info_buffer(
-                        device,
-                    ),
-                    shadow_map_array: Self::create_directional_shadow_map_array(device, 1, 1, 1),
-                })),
+                Arc::new(RwLock::new(PipelineEntry::DirectionalShadow(
+                    DirectionalShadowPipelineEntry {
+                        pipeline,
+                        mesh_indices: Vec::new(),
+                        directional_light_shadows: Vec::new(),
+                        directional_shadow_info_buffer: Self::create_directional_shadow_info_buffer(
+                            device,
+                        ),
+                        shadow_map_array: Self::create_directional_shadow_map_array(
+                            device, 1, 1, 1,
+                        ),
+                    },
+                ))),
             );
         }
         let entry = self.get_directional_shadow_pipeline_entry()?;
         {
             let mut entry_mut = entry.write().unwrap();
-            if let PipelineEntry::DirectionalShadow { mesh_indices, .. } = &mut *entry_mut {
-                *mesh_indices = shadow_mesh_indices.to_vec();
+            if let PipelineEntry::DirectionalShadow(p) = &mut *entry_mut {
+                p.mesh_indices = shadow_mesh_indices.to_vec();
             }
-            //
         }
         Some(entry.clone())
     }
@@ -1788,7 +1746,7 @@ impl LightingMeshRenderer {
         });
 
         // Create a uniform buffer for material properties
-        PipelineEntry::Shading {
+        PipelineEntry::Shading(ShadingPipelineEntry {
             pipeline,
             material_bind_group_layout,
             material_bind_groups: Vec::new(),
@@ -1796,7 +1754,7 @@ impl LightingMeshRenderer {
             material_indices: Vec::new(),
             sort_order,
             enable_lighting: has_lighting,
-        }
+        })
     }
 
     fn create_z_prepass_pipeline(&self, device: &wgpu::Device) -> PipelineEntry {
@@ -1881,11 +1839,10 @@ impl LightingMeshRenderer {
             cache: None,
         });
 
-        PipelineEntry::ZPrepass {
+        PipelineEntry::ZPrepass(ZPrepassPipelineEntry {
             pipeline,
             mesh_indices: Vec::new(),
-            material_indices: Vec::new(),
-        }
+        })
     }
 }
 

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -35,6 +35,8 @@ const MAX_INFINITE_LIGHT_NUM: usize = 1; // Maximum number of infinite lights
 const MAX_LIGHT_TEXTURE_NUM: usize = 1; // Maximum number of light textures
 
 const DEFAULT_LIGHT_TEXTURE_ID: Uuid = Uuid::from_u128(0xb7814152_c24b_4af1_89a8_40a5fa168488);
+const DIRECTIONAL_SHADOW_PIPELINE_ID: Uuid =
+    Uuid::from_u128(0x77dd5bcc_89c5_4eff_8adf_9b5f8667d9f1);
 const Z_PREPASS_PIPELINE_ID: Uuid = Uuid::from_u128(0x9979b259_39f8_4ce5_8ea5_d8078618620f);
 
 #[repr(C)]
@@ -138,16 +140,6 @@ struct DirectionalShadowInfo {
 }
 
 #[derive(Debug, Clone)]
-struct DirectionalShadowMapArray {
-    texture: wgpu::Texture,
-    view: wgpu::TextureView,
-    sampler: wgpu::Sampler,
-    layer_count: u32,
-    width: u32,
-    height: u32,
-}
-
-#[derive(Debug, Clone)]
 struct TmpPipelineEntry {
     pub shader: Arc<RenderShader>,
     pub mesh_indices: Vec<usize>,
@@ -210,12 +202,14 @@ enum PipelineEntry {
     DirectionalShadow {
         pipeline: wgpu::RenderPipeline,
         mesh_indices: Vec<usize>,
+        directional_shadow_info_buffer: wgpu::Buffer,
+        shadow_map_array: RenderTexture,
     },
 }
 
 struct PreparedShadowPass {
     directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
-    shadow_pipelines: Vec<Arc<PipelineEntry>>,
+    shadow_pipelines: Vec<Arc<RwLock<PipelineEntry>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -247,9 +241,6 @@ pub struct LightingMeshRenderer {
     #[allow(dead_code)]
     directional_shadow_bind_group_layout: wgpu::BindGroupLayout,
     directional_shadow_bind_group: wgpu::BindGroup,
-    directional_shadow_info_buffer: wgpu::Buffer,
-    directional_shadow_map_array: DirectionalShadowMapArray,
-    directional_shadow_pipeline: Option<PipelineEntry>,
 
     // Mesh items to render
     mesh_items: Vec<Arc<RenderItem>>,
@@ -803,6 +794,7 @@ impl LightingMeshRenderer {
     fn create_directional_shadow_bind_group(
         &self,
         device: &wgpu::Device,
+        directional_shadow_info_buffer: &wgpu::Buffer,
         directional_shadow_map_view: &wgpu::TextureView,
         directional_shadow_sampler: &wgpu::Sampler,
     ) -> wgpu::BindGroup {
@@ -812,7 +804,7 @@ impl LightingMeshRenderer {
             entries: &[
                 wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: self.directional_shadow_info_buffer.as_entire_binding(),
+                    resource: directional_shadow_info_buffer.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
@@ -826,18 +818,12 @@ impl LightingMeshRenderer {
         })
     }
 
-    fn ensure_directional_shadow_map_array(
-        &mut self,
+    fn create_directional_shadow_map_array(
         device: &wgpu::Device,
         layer_count: u32,
         width: u32,
         height: u32,
-    ) {
-        let array = &self.directional_shadow_map_array;
-        if array.layer_count == layer_count && array.width == width && array.height == height {
-            return;
-        }
-
+    ) -> RenderTexture {
         let texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("Directional Shadow Map Array"),
             size: wgpu::Extent3d {
@@ -873,14 +859,151 @@ impl LightingMeshRenderer {
             compare: Some(wgpu::CompareFunction::LessEqual),
             ..Default::default()
         });
-        self.directional_shadow_map_array = DirectionalShadowMapArray {
+        RenderTexture {
+            id: Uuid::new_v4(),
+            edition: Uuid::new_v4().to_string(),
             texture,
             view,
             sampler,
-            layer_count,
-            width,
-            height,
+            scale: [1.0, 1.0],
+            delta: [0.0, 0.0],
+        }
+    }
+
+    fn create_directional_shadow_info_buffer(device: &wgpu::Device) -> wgpu::Buffer {
+        let directional_shadow_info_buffer_size = (MAX_DIRECTIONAL_SHADOW_NUM
+            * std::mem::size_of::<DirectionalShadowInfo>()) as wgpu::BufferAddress;
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Buffer for Directional Shadow Infos"),
+            size: directional_shadow_info_buffer_size,
+            mapped_at_creation: false,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
+        })
+    }
+
+    fn compute_directional_shadow_map_extent(
+        pipeline: &PipelineEntry,
+        directional_light_shadows: &[Arc<RenderDirectionalLightShadow>],
+    ) -> (u32, u32, u32) {
+        let current_size = if let PipelineEntry::DirectionalShadow {
+            shadow_map_array, ..
+        } = pipeline
+        {
+            let size = shadow_map_array.texture.size();
+            (size.width, size.height)
+        } else {
+            (1, 1)
         };
+        let total_cascade_count = directional_light_shadows
+            .iter()
+            .map(|s| s.cascades.len())
+            .sum::<usize>();
+        let layer_count = total_cascade_count.max(1) as u32;
+        let (width, height) = directional_light_shadows
+            .iter()
+            .find_map(|s| s.cascades.first())
+            .map(|c| (c.texture.texture.width(), c.texture.texture.height()))
+            .unwrap_or(current_size);
+        (layer_count, width, height)
+    }
+
+    fn get_directional_shadow_pipeline_entry(&self) -> Option<Arc<RwLock<PipelineEntry>>> {
+        self.pipelines.get(&DIRECTIONAL_SHADOW_PIPELINE_ID).cloned()
+    }
+
+    fn ensure_directional_shadow_map_array(
+        device: &wgpu::Device,
+        pipeline: &mut PipelineEntry,
+        layer_count: u32,
+        width: u32,
+        height: u32,
+    ) -> Option<RenderTexture> {
+        if let PipelineEntry::DirectionalShadow {
+            shadow_map_array, ..
+        } = pipeline
+        {
+            let size = shadow_map_array.texture.size();
+            if size.depth_or_array_layers != layer_count
+                || size.width != width
+                || size.height != height
+            {
+                *shadow_map_array =
+                    Self::create_directional_shadow_map_array(device, layer_count, width, height);
+            }
+            return Some(shadow_map_array.clone());
+        }
+        None
+    }
+
+    fn update_directional_shadow_pipeline_entry(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        directional_light_shadows: &[Arc<RenderDirectionalLightShadow>],
+        shadow_mesh_indices: &[usize],
+        shadow_pipelines: &mut Vec<Arc<RwLock<PipelineEntry>>>,
+    ) {
+        if !directional_light_shadows.is_empty() && !shadow_mesh_indices.is_empty() {
+            let _ = self.build_directional_shadow_pipeline_entry(device, shadow_mesh_indices);
+        }
+
+        let mut infos = vec![DirectionalShadowInfo::default(); MAX_DIRECTIONAL_SHADOW_NUM];
+        let mut info_index = 0usize;
+        for shadow in directional_light_shadows.iter() {
+            for cascade in shadow.cascades.iter() {
+                if info_index >= MAX_DIRECTIONAL_SHADOW_NUM {
+                    break;
+                }
+                infos[info_index] = DirectionalShadowInfo {
+                    light_view_proj: cascade.light_view_proj.to_cols_array_2d(),
+                    split_end: cascade.split_end,
+                    bias: shadow.shadow_bias,
+                    slope_bias: shadow.shadow_slope_bias,
+                    map_layer: info_index as i32,
+                };
+                info_index += 1;
+            }
+        }
+        if let Some(pipeline_arc) = self.get_directional_shadow_pipeline_entry() {
+            {
+                let mut pipeline = pipeline_arc.write().unwrap();
+                let (layer_count, shadow_map_width, shadow_map_height) =
+                    Self::compute_directional_shadow_map_extent(
+                        &pipeline,
+                        directional_light_shadows,
+                    );
+                let _ = Self::ensure_directional_shadow_map_array(
+                    device,
+                    &mut pipeline,
+                    layer_count,
+                    shadow_map_width,
+                    shadow_map_height,
+                );
+
+                if let PipelineEntry::DirectionalShadow {
+                    directional_shadow_info_buffer,
+                    shadow_map_array,
+                    ..
+                } = &*pipeline
+                {
+                    queue.write_buffer(
+                        directional_shadow_info_buffer,
+                        0,
+                        bytemuck::cast_slice(&infos),
+                    );
+                    self.directional_shadow_bind_group = self.create_directional_shadow_bind_group(
+                        device,
+                        directional_shadow_info_buffer,
+                        &shadow_map_array.view,
+                        &shadow_map_array.sampler,
+                    );
+                }
+            }
+
+            if !directional_light_shadows.is_empty() && !shadow_mesh_indices.is_empty() {
+                shadow_pipelines.push(pipeline_arc);
+            }
+        }
     }
 
     fn prepare_lights(
@@ -921,63 +1044,13 @@ impl LightingMeshRenderer {
             light_items,
             render_resource_manager,
         );
-        if !directional_light_shadows.is_empty()
-            && !shadow_mesh_indices.is_empty()
-            && let Some(pipeline) =
-                self.build_directional_shadow_pipeline_entry(device, &shadow_mesh_indices)
-        {
-            shadow_pipelines.push(Arc::new(pipeline));
-        }
-        {
-            let total_cascade_count = directional_light_shadows
-                .iter()
-                .map(|s| s.cascades.len())
-                .sum::<usize>();
-            let layer_count = total_cascade_count.max(1) as u32;
-            let (shadow_map_width, shadow_map_height) = directional_light_shadows
-                .iter()
-                .find_map(|s| s.cascades.first())
-                .map(|c| (c.texture.texture.width(), c.texture.texture.height()))
-                .unwrap_or((
-                    self.directional_shadow_map_array.width.max(1),
-                    self.directional_shadow_map_array.height.max(1),
-                ));
-            self.ensure_directional_shadow_map_array(
-                device,
-                layer_count,
-                shadow_map_width,
-                shadow_map_height,
-            );
-
-            let mut infos = vec![DirectionalShadowInfo::default(); MAX_DIRECTIONAL_SHADOW_NUM];
-            let mut info_index = 0usize;
-            for shadow in directional_light_shadows.iter() {
-                for cascade in shadow.cascades.iter() {
-                    if info_index >= MAX_DIRECTIONAL_SHADOW_NUM {
-                        break;
-                    }
-                    infos[info_index] = DirectionalShadowInfo {
-                        light_view_proj: cascade.light_view_proj.to_cols_array_2d(),
-                        split_end: cascade.split_end,
-                        bias: shadow.shadow_bias,
-                        slope_bias: shadow.shadow_slope_bias,
-                        map_layer: info_index as i32,
-                    };
-                    info_index += 1;
-                }
-            }
-            queue.write_buffer(
-                &self.directional_shadow_info_buffer,
-                0,
-                bytemuck::cast_slice(&infos),
-            );
-
-            self.directional_shadow_bind_group = self.create_directional_shadow_bind_group(
-                device,
-                &self.directional_shadow_map_array.view,
-                &self.directional_shadow_map_array.sampler,
-            );
-        }
+        self.update_directional_shadow_pipeline_entry(
+            device,
+            queue,
+            &directional_light_shadows,
+            &shadow_mesh_indices,
+            &mut shadow_pipelines,
+        );
         let mut directional_shadow_index_map = HashMap::new();
         let mut base_shadow_index = 0i32;
         for shadow in directional_light_shadows.iter() {
@@ -1296,6 +1369,20 @@ impl LightingMeshRenderer {
 
         let directional_light_shadows = &shadow_pass.directional_light_shadows;
         let shadow_pipelines = &shadow_pass.shadow_pipelines;
+        let shadow_map_array = shadow_pipelines.iter().find_map(|entry| {
+            let entry = entry.read().unwrap();
+            if let PipelineEntry::DirectionalShadow {
+                shadow_map_array, ..
+            } = &*entry
+            {
+                Some(shadow_map_array.clone())
+            } else {
+                None
+            }
+        });
+        let Some(shadow_map_array) = shadow_map_array else {
+            return;
+        };
 
         let mut layer: u32 = 0;
         for shadow in directional_light_shadows {
@@ -1347,10 +1434,12 @@ impl LightingMeshRenderer {
                     });
 
                     for pipeline_entry in shadow_pipelines {
+                        let pipeline_entry = pipeline_entry.read().unwrap();
                         if let PipelineEntry::DirectionalShadow {
                             pipeline,
                             mesh_indices,
-                        } = pipeline_entry.as_ref()
+                            ..
+                        } = &*pipeline_entry
                         {
                             render_pass.set_pipeline(pipeline);
                             render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
@@ -1373,8 +1462,11 @@ impl LightingMeshRenderer {
                                         mesh_item.mesh.index_buffer.slice(..),
                                         wgpu::IndexFormat::Uint32,
                                     );
-                                    render_pass
-                                        .draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
+                                    render_pass.draw_indexed(
+                                        0..mesh_item.mesh.index_count,
+                                        0,
+                                        0..1,
+                                    );
                                 }
                             }
                         }
@@ -1389,7 +1481,7 @@ impl LightingMeshRenderer {
                         aspect: wgpu::TextureAspect::DepthOnly,
                     },
                     wgpu::TexelCopyTextureInfo {
-                        texture: &self.directional_shadow_map_array.texture,
+                        texture: &shadow_map_array.texture,
                         mip_level: 0,
                         origin: wgpu::Origin3d {
                             x: 0,
@@ -1402,11 +1494,11 @@ impl LightingMeshRenderer {
                         width: shadow_texture
                             .texture
                             .width()
-                            .min(self.directional_shadow_map_array.texture.width()),
+                            .min(shadow_map_array.texture.width()),
                         height: shadow_texture
                             .texture
                             .height()
-                            .min(self.directional_shadow_map_array.texture.height()),
+                            .min(shadow_map_array.texture.height()),
                         depth_or_array_layers: 1,
                     },
                 );
@@ -1419,11 +1511,11 @@ impl LightingMeshRenderer {
         &mut self,
         device: &wgpu::Device,
         shadow_mesh_indices: &[usize],
-    ) -> Option<PipelineEntry> {
+    ) -> Option<Arc<RwLock<PipelineEntry>>> {
         if shadow_mesh_indices.is_empty() {
             return None;
         }
-        if self.directional_shadow_pipeline.is_none() {
+        if self.get_directional_shadow_pipeline_entry().is_none() {
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("Directional Shadow Pipeline Shader"),
                 source: wgpu::ShaderSource::Wgsl(
@@ -1503,16 +1595,27 @@ impl LightingMeshRenderer {
                     entries: &[],
                 });
             let _ = material_bind_group_layout;
-            self.directional_shadow_pipeline = Some(PipelineEntry::DirectionalShadow {
-                pipeline,
-                mesh_indices: Vec::new(),
-            });
+            self.pipelines.insert(
+                DIRECTIONAL_SHADOW_PIPELINE_ID,
+                Arc::new(RwLock::new(PipelineEntry::DirectionalShadow {
+                    pipeline,
+                    mesh_indices: Vec::new(),
+                    directional_shadow_info_buffer: Self::create_directional_shadow_info_buffer(
+                        device,
+                    ),
+                    shadow_map_array: Self::create_directional_shadow_map_array(device, 1, 1, 1),
+                })),
+            );
         }
-        let mut entry = self.directional_shadow_pipeline.clone()?;
-        if let PipelineEntry::DirectionalShadow { mesh_indices, .. } = &mut entry {
-            *mesh_indices = shadow_mesh_indices.to_vec();
+        let entry = self.get_directional_shadow_pipeline_entry()?;
+        {
+            let mut entry_mut = entry.write().unwrap();
+            if let PipelineEntry::DirectionalShadow { mesh_indices, .. } = &mut *entry_mut {
+                *mesh_indices = shadow_mesh_indices.to_vec();
+            }
+            //
         }
-        Some(entry)
+        Some(entry.clone())
     }
 
     fn create_pipeline(
@@ -2062,57 +2165,11 @@ impl LightingMeshRenderer {
             mapped_at_creation: false,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
         });
-        let directional_shadow_info_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("Buffer for Directional Shadow Infos"),
-            size: directional_shadow_info_buffer_size,
-            mapped_at_creation: false,
-            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
-        });
+        let directional_shadow_info_buffer =
+            Self::create_directional_shadow_info_buffer(device);
 
-        let directional_shadow_array_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Directional Shadow Map Array"),
-            size: wgpu::Extent3d {
-                width: 1,
-                height: 1,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-            view_formats: &[wgpu::TextureFormat::Depth32Float],
-        });
-        let directional_shadow_array_view =
-            directional_shadow_array_texture.create_view(&wgpu::TextureViewDescriptor {
-                label: Some("Directional Shadow Map Array View"),
-                format: Some(wgpu::TextureFormat::Depth32Float),
-                dimension: Some(wgpu::TextureViewDimension::D2Array),
-                usage: Some(wgpu::TextureUsages::TEXTURE_BINDING),
-                aspect: wgpu::TextureAspect::All,
-                base_mip_level: 0,
-                mip_level_count: Some(1),
-                base_array_layer: 0,
-                array_layer_count: Some(1),
-            });
-        let directional_shadow_array_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            compare: Some(wgpu::CompareFunction::LessEqual),
-            ..Default::default()
-        });
-        let directional_shadow_map_array = DirectionalShadowMapArray {
-            texture: directional_shadow_array_texture,
-            view: directional_shadow_array_view,
-            sampler: directional_shadow_array_sampler,
-            layer_count: 1,
-            width: 1,
-            height: 1,
-        };
+        let directional_shadow_map_array =
+            Self::create_directional_shadow_map_array(device, 1, 1, 1);
 
         let directional_shadow_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("Lighting Directional Shadow Bind Group"),
@@ -2230,9 +2287,6 @@ impl LightingMeshRenderer {
             ltc_bind_group_layout,
             directional_shadow_bind_group_layout,
             directional_shadow_bind_group,
-            directional_shadow_info_buffer,
-            directional_shadow_map_array,
-            directional_shadow_pipeline: None,
             mesh_items,
             textures,
             pipelines: materials,

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -192,22 +192,30 @@ struct MaterialBindGroupEntry {
 }
 
 #[derive(Debug, Clone)]
-enum PipelinePassType {
-    Shading,
-    ZPrepass,
-    Shadow,
+enum PipelineEntry {
+    Shading {
+        pipeline: wgpu::RenderPipeline,
+        material_bind_group_layout: wgpu::BindGroupLayout,
+        material_bind_groups: Vec<Arc<MaterialBindGroupEntry>>,
+        mesh_indices: Vec<usize>,
+        material_indices: Vec<usize>,
+        sort_order: u32,
+        enable_lighting: bool,
+    },
+    ZPrepass {
+        pipeline: wgpu::RenderPipeline,
+        mesh_indices: Vec<usize>,
+        material_indices: Vec<usize>,
+    },
+    DirectionalShadow {
+        pipeline: wgpu::RenderPipeline,
+        mesh_indices: Vec<usize>,
+    },
 }
 
-#[derive(Debug, Clone)]
-struct PipelineEntry {
-    pub pass_type: PipelinePassType,
-    pub pipeline: wgpu::RenderPipeline,
-    pub material_bind_group_layout: wgpu::BindGroupLayout,
-    pub material_bind_groups: Vec<Arc<MaterialBindGroupEntry>>,
-    pub mesh_indices: Vec<usize>,
-    pub material_indices: Vec<usize>,
-    pub sort_order: u32,
-    pub enable_lighting: bool,
+struct PreparedShadowPass {
+    directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
+    shadow_pipelines: Vec<Arc<PipelineEntry>>,
 }
 
 #[derive(Debug, Clone)]
@@ -241,7 +249,6 @@ pub struct LightingMeshRenderer {
     directional_shadow_bind_group: wgpu::BindGroup,
     directional_shadow_info_buffer: wgpu::Buffer,
     directional_shadow_map_array: DirectionalShadowMapArray,
-    directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
     directional_shadow_pipeline: Option<PipelineEntry>,
 
     // Mesh items to render
@@ -302,7 +309,7 @@ impl LightingMeshRenderer {
             self.prepare_locals(device, queue, &mesh_items); //group(1)
             self.prepare_materials(device, queue, &mesh_items); //group(2)
             {
-                let shadow_pipelines = self.prepare_lights(
+                let shadow_passes = self.prepare_lights(
                     device,
                     queue,
                     render_resource_manager,
@@ -311,13 +318,7 @@ impl LightingMeshRenderer {
                     &light_items,
                 );
                 // Render shadow maps immediately after light preparation.
-                self.render_directional_shadow_maps(
-                    device,
-                    queue,
-                    encoder,
-                    camera,
-                    &shadow_pipelines,
-                );
+                self.render_shadow_maps(device, queue, encoder, camera, &shadow_passes);
             } //group(3)
         }
     }
@@ -325,139 +326,6 @@ impl LightingMeshRenderer {
     pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
         if !self.mesh_items.is_empty() {
             self.render(render_pass, &self.mesh_items);
-        }
-    }
-
-    fn render_directional_shadow_maps(
-        &self,
-        device: &wgpu::Device,
-        _queue: &wgpu::Queue,
-        encoder: &mut wgpu::CommandEncoder,
-        _main_camera: &RenderCamera,
-        shadow_pipelines: &[Arc<PipelineEntry>],
-    ) {
-        if self.directional_light_shadows.is_empty() {
-            return;
-        }
-
-        let local_uniform_alignment = {
-            let alignment = self.min_uniform_buffer_offset_alignment;
-            align_to(
-                std::mem::size_of::<LocalUniforms>() as wgpu::BufferAddress,
-                alignment,
-            )
-        };
-
-        if shadow_pipelines.is_empty() {
-            return;
-        }
-
-        let mut layer: u32 = 0;
-        for shadow in self.directional_light_shadows.iter() {
-            for cascade in shadow.cascades.iter() {
-                let shadow_camera =
-                    RenderCamera::from_matrices(cascade.light_view, cascade.light_proj);
-                let global_uniforms = GlobalUniforms {
-                    world_to_camera: shadow_camera.world_to_camera.to_cols_array_2d(),
-                    camera_to_clip: shadow_camera.camera_to_clip.to_cols_array_2d(),
-                    camera_to_world: shadow_camera.camera_to_world.to_cols_array_2d(),
-                    camera_position: [
-                        shadow_camera.position.x,
-                        shadow_camera.position.y,
-                        shadow_camera.position.z,
-                        1.0,
-                    ],
-                };
-                let shadow_global_uniform_buffer =
-                    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                        label: Some("Shadow Global Uniform Buffer"),
-                        contents: bytemuck::bytes_of(&global_uniforms),
-                        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-                    });
-                let shadow_global_bind_group =
-                    device.create_bind_group(&wgpu::BindGroupDescriptor {
-                        label: Some("Shadow Global Bind Group"),
-                        layout: &self.global_bind_group_layout,
-                        entries: &[wgpu::BindGroupEntry {
-                            binding: 0,
-                            resource: shadow_global_uniform_buffer.as_entire_binding(),
-                        }],
-                    });
-
-                let shadow_texture = &cascade.texture;
-                {
-                    let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: Some("Directional Shadow Render Pass"),
-                        color_attachments: &[],
-                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                            view: &shadow_texture.view,
-                            depth_ops: Some(wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(1.0),
-                                store: wgpu::StoreOp::Store,
-                            }),
-                            stencil_ops: None,
-                        }),
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                    });
-
-                    for pipeline_entry in shadow_pipelines {
-                        render_pass.set_pipeline(&pipeline_entry.pipeline);
-                        render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
-                        for item_index in pipeline_entry.mesh_indices.iter().copied() {
-                            if let RenderItem::Mesh(mesh_item) =
-                                self.mesh_items[item_index].as_ref()
-                            {
-                                let local_uniform_offset = item_index as wgpu::DynamicOffset
-                                    * local_uniform_alignment as wgpu::DynamicOffset;
-                                render_pass.set_bind_group(
-                                    1,
-                                    &self.local_bind_group,
-                                    &[local_uniform_offset],
-                                );
-                                render_pass
-                                    .set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
-                                render_pass.set_index_buffer(
-                                    mesh_item.mesh.index_buffer.slice(..),
-                                    wgpu::IndexFormat::Uint32,
-                                );
-                                render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
-                            }
-                        }
-                    }
-                }
-
-                encoder.copy_texture_to_texture(
-                    wgpu::TexelCopyTextureInfo {
-                        texture: &shadow_texture.texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::DepthOnly,
-                    },
-                    wgpu::TexelCopyTextureInfo {
-                        texture: &self.directional_shadow_map_array.texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d {
-                            x: 0,
-                            y: 0,
-                            z: layer as u32,
-                        },
-                        aspect: wgpu::TextureAspect::DepthOnly,
-                    },
-                    wgpu::Extent3d {
-                        width: shadow_texture
-                            .texture
-                            .width()
-                            .min(self.directional_shadow_map_array.texture.width()),
-                        height: shadow_texture
-                            .texture
-                            .height()
-                            .min(self.directional_shadow_map_array.texture.height()),
-                        depth_or_array_layers: 1,
-                    },
-                );
-                layer += 1;
-            }
         }
     }
 
@@ -493,79 +361,101 @@ impl LightingMeshRenderer {
         let mut shading_pipelines = Vec::new();
         for pipeline_entry in self.pipelines.values() {
             let pipeline_entry = pipeline_entry.read().unwrap();
-            if pipeline_entry.mesh_indices.is_empty() {
-                continue;
-            }
-            match pipeline_entry.pass_type {
-                PipelinePassType::ZPrepass => z_prepass_pipelines.push(pipeline_entry.clone()),
-                PipelinePassType::Shading => shading_pipelines.push(pipeline_entry.clone()),
-                PipelinePassType::Shadow => {}
+            match &*pipeline_entry {
+                PipelineEntry::ZPrepass { mesh_indices, .. } if !mesh_indices.is_empty() => {
+                    z_prepass_pipelines.push(pipeline_entry.clone())
+                }
+                PipelineEntry::Shading {
+                    mesh_indices,
+                    sort_order,
+                    ..
+                } if !mesh_indices.is_empty() => {
+                    shading_pipelines.push((*sort_order, pipeline_entry.clone()))
+                }
+                _ => {}
             }
         }
 
         //TODO: sort pipelines to minimize pipeline switching
-        shading_pipelines.sort_by(|a, b| a.sort_order.cmp(&b.sort_order));
+        shading_pipelines.sort_by(|a, b| a.0.cmp(&b.0));
 
         // Depth-only prepass for opaque-like geometry.
         for pipeline_entry in z_prepass_pipelines.iter() {
-            render_pass.set_pipeline(&pipeline_entry.pipeline);
-            render_pass.set_bind_group(0, &self.global_bind_group, &[]);
-            let length = pipeline_entry.mesh_indices.len();
-            for i in 0..length {
-                let item_index = pipeline_entry.mesh_indices[i];
-                if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
-                    let local_uniform_offset = item_index as wgpu::DynamicOffset
-                        * local_uniform_alignment as wgpu::DynamicOffset;
-                    render_pass.set_bind_group(1, &self.local_bind_group, &[local_uniform_offset]);
-                    render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
-                    render_pass.set_index_buffer(
-                        mesh_item.mesh.index_buffer.slice(..),
-                        wgpu::IndexFormat::Uint32,
-                    );
-                    render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
+            if let PipelineEntry::ZPrepass {
+                pipeline,
+                mesh_indices,
+                ..
+            } = pipeline_entry
+            {
+                render_pass.set_pipeline(pipeline);
+                render_pass.set_bind_group(0, &self.global_bind_group, &[]);
+                for item_index in mesh_indices.iter().copied() {
+                    if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
+                        let local_uniform_offset = item_index as wgpu::DynamicOffset
+                            * local_uniform_alignment as wgpu::DynamicOffset;
+                        render_pass.set_bind_group(
+                            1,
+                            &self.local_bind_group,
+                            &[local_uniform_offset],
+                        );
+                        render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
+                        render_pass.set_index_buffer(
+                            mesh_item.mesh.index_buffer.slice(..),
+                            wgpu::IndexFormat::Uint32,
+                        );
+                        render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
+                    }
                 }
             }
         }
 
-        for pipeline_entry in shading_pipelines.iter() {
-            debug_assert!(!pipeline_entry.mesh_indices.is_empty());
-
-            render_pass.set_pipeline(&pipeline_entry.pipeline); //
-            render_pass.set_bind_group(0, &self.global_bind_group, &[]);
-            if pipeline_entry.enable_lighting {
-                render_pass.set_bind_group(3, &self.light_bind_group, &[]);
-                render_pass.set_bind_group(5, &self.directional_shadow_bind_group, &[]);
-            }
-            debug_assert!(
-                pipeline_entry.mesh_indices.len() == pipeline_entry.material_indices.len()
-            );
-            let length = pipeline_entry.mesh_indices.len();
-            for i in 0..length {
-                let item_index = pipeline_entry.mesh_indices[i];
-                let material_index = pipeline_entry.material_indices[i];
-                if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
-                    let local_uniform_offset = item_index as wgpu::DynamicOffset
-                        * local_uniform_alignment as wgpu::DynamicOffset;
-
-                    //local params
-                    render_pass.set_bind_group(1, &self.local_bind_group, &[local_uniform_offset]);
-                    //material params
-                    render_pass.set_bind_group(
-                        2,
-                        &pipeline_entry.material_bind_groups[material_index].material_bind_group,
-                        &[],
-                    );
-                    if let Some(ltc_bind_group) =
-                        &pipeline_entry.material_bind_groups[material_index].ltc_bind_group
-                    {
-                        render_pass.set_bind_group(4, ltc_bind_group, &[]);
+        for (_, pipeline_entry) in shading_pipelines.iter() {
+            if let PipelineEntry::Shading {
+                pipeline,
+                material_bind_groups,
+                mesh_indices,
+                material_indices,
+                enable_lighting,
+                ..
+            } = pipeline_entry
+            {
+                debug_assert!(!mesh_indices.is_empty());
+                render_pass.set_pipeline(pipeline);
+                render_pass.set_bind_group(0, &self.global_bind_group, &[]);
+                if *enable_lighting {
+                    render_pass.set_bind_group(3, &self.light_bind_group, &[]);
+                    render_pass.set_bind_group(5, &self.directional_shadow_bind_group, &[]);
+                }
+                debug_assert!(mesh_indices.len() == material_indices.len());
+                let length = mesh_indices.len();
+                for i in 0..length {
+                    let item_index = mesh_indices[i];
+                    let material_index = material_indices[i];
+                    if let RenderItem::Mesh(mesh_item) = render_items[item_index].as_ref() {
+                        let local_uniform_offset = item_index as wgpu::DynamicOffset
+                            * local_uniform_alignment as wgpu::DynamicOffset;
+                        render_pass.set_bind_group(
+                            1,
+                            &self.local_bind_group,
+                            &[local_uniform_offset],
+                        );
+                        render_pass.set_bind_group(
+                            2,
+                            &material_bind_groups[material_index].material_bind_group,
+                            &[],
+                        );
+                        if let Some(ltc_bind_group) =
+                            &material_bind_groups[material_index].ltc_bind_group
+                        {
+                            render_pass.set_bind_group(4, ltc_bind_group, &[]);
+                        }
+                        render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
+                        render_pass.set_index_buffer(
+                            mesh_item.mesh.index_buffer.slice(..),
+                            wgpu::IndexFormat::Uint32,
+                        );
+                        render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
                     }
-                    render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
-                    render_pass.set_index_buffer(
-                        mesh_item.mesh.index_buffer.slice(..),
-                        wgpu::IndexFormat::Uint32,
-                    );
-                    render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
                 }
             }
         }
@@ -724,14 +614,30 @@ impl LightingMeshRenderer {
             let mut prev_bind_groups = HashMap::new(); //store existing bind groups to reuse
             for entry in self.pipelines.values_mut() {
                 let mut entry = entry.write().unwrap();
-                entry.mesh_indices.clear();
-                entry.material_indices.clear();
-                if matches!(entry.pass_type, PipelinePassType::Shading) {
-                    for bind_group in entry.material_bind_groups.iter() {
-                        prev_bind_groups.insert(bind_group.id, bind_group.clone());
+                match &mut *entry {
+                    PipelineEntry::Shading {
+                        mesh_indices,
+                        material_indices,
+                        material_bind_groups,
+                        ..
+                    } => {
+                        mesh_indices.clear();
+                        material_indices.clear();
+                        for bind_group in material_bind_groups.iter() {
+                            prev_bind_groups.insert(bind_group.id, bind_group.clone());
+                        }
+                        material_bind_groups.clear();
                     }
+                    PipelineEntry::ZPrepass {
+                        mesh_indices,
+                        material_indices,
+                        ..
+                    } => {
+                        mesh_indices.clear();
+                        material_indices.clear();
+                    }
+                    PipelineEntry::DirectionalShadow { .. } => {}
                 }
-                entry.material_bind_groups.clear();
             }
             let mut tmp_pipelines: HashMap<Uuid, TmpPipelineEntry> = HashMap::new();
             let mut z_prepass_mesh_indices: HashSet<usize> = HashSet::new();
@@ -783,28 +689,36 @@ impl LightingMeshRenderer {
                     .get_mut(shader_id)
                     .expect("Pipeline for basic material not found");
                 let mut entry = entry.write().unwrap();
-                entry.mesh_indices = mesh_indices.clone();
-                entry.material_indices = material_indices.clone();
-                assert!(entry.mesh_indices.len() == entry.material_indices.len());
-                //create material bind groups
-                let mut passes = Vec::with_capacity(num_materials);
-                for (_, (index, pass)) in tmp_entry.material_indices_map.iter() {
-                    passes.push((index, pass));
-                }
-                passes.sort_by(|a, b| a.0.cmp(b.0));
-                for (_, pass) in passes.iter() {
-                    let id = pass.id;
-                    if let Some(bind_group_entry) = prev_bind_groups.get(&id) {
-                        entry.material_bind_groups.push(bind_group_entry.clone());
-                    } else {
-                        let bind_group_entry = Self::create_material_bind_group(
-                            device,
-                            queue,
-                            &entry.material_bind_group_layout,
-                            &self.ltc_bind_group_layout,
-                            pass,
-                        );
-                        entry.material_bind_groups.push(Arc::new(bind_group_entry));
+                if let PipelineEntry::Shading {
+                    material_bind_group_layout,
+                    material_bind_groups,
+                    mesh_indices: entry_mesh_indices,
+                    material_indices: entry_material_indices,
+                    ..
+                } = &mut *entry
+                {
+                    *entry_mesh_indices = mesh_indices.clone();
+                    *entry_material_indices = material_indices.clone();
+                    assert!(entry_mesh_indices.len() == entry_material_indices.len());
+                    let mut passes = Vec::with_capacity(num_materials);
+                    for (_, (index, pass)) in tmp_entry.material_indices_map.iter() {
+                        passes.push((index, pass));
+                    }
+                    passes.sort_by(|a, b| a.0.cmp(b.0));
+                    for (_, pass) in passes.iter() {
+                        let id = pass.id;
+                        if let Some(bind_group_entry) = prev_bind_groups.get(&id) {
+                            material_bind_groups.push(bind_group_entry.clone());
+                        } else {
+                            let bind_group_entry = Self::create_material_bind_group(
+                                device,
+                                queue,
+                                &*material_bind_group_layout,
+                                &self.ltc_bind_group_layout,
+                                pass,
+                            );
+                            material_bind_groups.push(Arc::new(bind_group_entry));
+                        }
                     }
                 }
             }
@@ -819,8 +733,15 @@ impl LightingMeshRenderer {
                     let mut entry = entry.write().unwrap();
                     let mut indices: Vec<usize> = z_prepass_mesh_indices.into_iter().collect();
                     indices.sort_unstable();
-                    entry.mesh_indices = indices;
-                    entry.material_indices.clear();
+                    if let PipelineEntry::ZPrepass {
+                        mesh_indices,
+                        material_indices,
+                        ..
+                    } = &mut *entry
+                    {
+                        *mesh_indices = indices;
+                        material_indices.clear();
+                    }
                 }
             } else {
                 self.pipelines.remove(&Z_PREPASS_PIPELINE_ID);
@@ -970,7 +891,7 @@ impl LightingMeshRenderer {
         camera: &RenderCamera,
         mesh_items: &[Arc<RenderItem>],
         light_items: &[Arc<RenderItem>],
-    ) -> Vec<Arc<PipelineEntry>> {
+    ) -> Vec<PreparedShadowPass> {
         let mut shadow_pipelines = Vec::new();
         let mut light_uniforms = LightUniforms::default();
         let mut light_textures = Vec::new();
@@ -1057,7 +978,6 @@ impl LightingMeshRenderer {
                 &self.directional_shadow_map_array.sampler,
             );
         }
-        self.directional_light_shadows = directional_light_shadows.clone();
         let mut directional_shadow_index_map = HashMap::new();
         let mut base_shadow_index = 0i32;
         for shadow in directional_light_shadows.iter() {
@@ -1329,7 +1249,170 @@ impl LightingMeshRenderer {
             0,
             bytemuck::bytes_of(&light_uniforms),
         );
-        shadow_pipelines
+        let mut shadow_passes = Vec::new();
+        if !directional_light_shadows.is_empty() {
+            shadow_passes.push(PreparedShadowPass {
+                directional_light_shadows,
+                shadow_pipelines,
+            });
+        }
+        shadow_passes
+    }
+
+    fn render_shadow_maps(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        main_camera: &RenderCamera,
+        shadow_passes: &[PreparedShadowPass],
+    ) {
+        for pass in shadow_passes {
+            self.render_directional_shadow_maps(device, queue, encoder, main_camera, pass);
+        }
+    }
+
+    fn render_directional_shadow_maps(
+        &self,
+        device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        _main_camera: &RenderCamera,
+        shadow_pass: &PreparedShadowPass,
+    ) {
+        if shadow_pass.directional_light_shadows.is_empty()
+            || shadow_pass.shadow_pipelines.is_empty()
+        {
+            return;
+        }
+
+        let local_uniform_alignment = {
+            let alignment = self.min_uniform_buffer_offset_alignment;
+            align_to(
+                std::mem::size_of::<LocalUniforms>() as wgpu::BufferAddress,
+                alignment,
+            )
+        };
+
+        let directional_light_shadows = &shadow_pass.directional_light_shadows;
+        let shadow_pipelines = &shadow_pass.shadow_pipelines;
+
+        let mut layer: u32 = 0;
+        for shadow in directional_light_shadows {
+            for cascade in shadow.cascades.iter() {
+                let shadow_camera =
+                    RenderCamera::from_matrices(cascade.light_view, cascade.light_proj);
+                let global_uniforms = GlobalUniforms {
+                    world_to_camera: shadow_camera.world_to_camera.to_cols_array_2d(),
+                    camera_to_clip: shadow_camera.camera_to_clip.to_cols_array_2d(),
+                    camera_to_world: shadow_camera.camera_to_world.to_cols_array_2d(),
+                    camera_position: [
+                        shadow_camera.position.x,
+                        shadow_camera.position.y,
+                        shadow_camera.position.z,
+                        1.0,
+                    ],
+                };
+                let shadow_global_uniform_buffer =
+                    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                        label: Some("Shadow Global Uniform Buffer"),
+                        contents: bytemuck::bytes_of(&global_uniforms),
+                        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                    });
+                let shadow_global_bind_group =
+                    device.create_bind_group(&wgpu::BindGroupDescriptor {
+                        label: Some("Shadow Global Bind Group"),
+                        layout: &self.global_bind_group_layout,
+                        entries: &[wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: shadow_global_uniform_buffer.as_entire_binding(),
+                        }],
+                    });
+
+                let shadow_texture = &cascade.texture;
+                {
+                    let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: Some("Directional Shadow Render Pass"),
+                        color_attachments: &[],
+                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                            view: &shadow_texture.view,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(1.0),
+                                store: wgpu::StoreOp::Store,
+                            }),
+                            stencil_ops: None,
+                        }),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+
+                    for pipeline_entry in shadow_pipelines {
+                        if let PipelineEntry::DirectionalShadow {
+                            pipeline,
+                            mesh_indices,
+                        } = pipeline_entry.as_ref()
+                        {
+                            render_pass.set_pipeline(pipeline);
+                            render_pass.set_bind_group(0, &shadow_global_bind_group, &[]);
+                            for item_index in mesh_indices.iter().copied() {
+                                if let RenderItem::Mesh(mesh_item) =
+                                    self.mesh_items[item_index].as_ref()
+                                {
+                                    let local_uniform_offset = item_index as wgpu::DynamicOffset
+                                        * local_uniform_alignment as wgpu::DynamicOffset;
+                                    render_pass.set_bind_group(
+                                        1,
+                                        &self.local_bind_group,
+                                        &[local_uniform_offset],
+                                    );
+                                    render_pass.set_vertex_buffer(
+                                        0,
+                                        mesh_item.mesh.vertex_buffer.slice(..),
+                                    );
+                                    render_pass.set_index_buffer(
+                                        mesh_item.mesh.index_buffer.slice(..),
+                                        wgpu::IndexFormat::Uint32,
+                                    );
+                                    render_pass
+                                        .draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &shadow_texture.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::DepthOnly,
+                    },
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &self.directional_shadow_map_array.texture,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x: 0,
+                            y: 0,
+                            z: layer as u32,
+                        },
+                        aspect: wgpu::TextureAspect::DepthOnly,
+                    },
+                    wgpu::Extent3d {
+                        width: shadow_texture
+                            .texture
+                            .width()
+                            .min(self.directional_shadow_map_array.texture.width()),
+                        height: shadow_texture
+                            .texture
+                            .height()
+                            .min(self.directional_shadow_map_array.texture.height()),
+                        depth_or_array_layers: 1,
+                    },
+                );
+                layer += 1;
+            }
+        }
     }
 
     fn build_directional_shadow_pipeline_entry(
@@ -1419,21 +1502,16 @@ impl LightingMeshRenderer {
                     label: Some("Directional Shadow Material Bind Group Layout"),
                     entries: &[],
                 });
-
-            self.directional_shadow_pipeline = Some(PipelineEntry {
-                pass_type: PipelinePassType::Shadow,
+            let _ = material_bind_group_layout;
+            self.directional_shadow_pipeline = Some(PipelineEntry::DirectionalShadow {
                 pipeline,
-                material_bind_group_layout,
-                material_bind_groups: Vec::new(),
                 mesh_indices: Vec::new(),
-                material_indices: Vec::new(),
-                sort_order: 0,
-                enable_lighting: false,
             });
         }
         let mut entry = self.directional_shadow_pipeline.clone()?;
-        entry.mesh_indices = shadow_mesh_indices.to_vec();
-        entry.material_indices.clear();
+        if let PipelineEntry::DirectionalShadow { mesh_indices, .. } = &mut entry {
+            *mesh_indices = shadow_mesh_indices.to_vec();
+        }
         Some(entry)
     }
 
@@ -1607,8 +1685,7 @@ impl LightingMeshRenderer {
         });
 
         // Create a uniform buffer for material properties
-        let entry = PipelineEntry {
-            pass_type: PipelinePassType::Shading,
+        PipelineEntry::Shading {
             pipeline,
             material_bind_group_layout,
             material_bind_groups: Vec::new(),
@@ -1616,8 +1693,7 @@ impl LightingMeshRenderer {
             material_indices: Vec::new(),
             sort_order,
             enable_lighting: has_lighting,
-        };
-        return entry;
+        }
     }
 
     fn create_z_prepass_pipeline(&self, device: &wgpu::Device) -> PipelineEntry {
@@ -1702,21 +1778,10 @@ impl LightingMeshRenderer {
             cache: None,
         });
 
-        let material_bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("Lighting Z Prepass Material Bind Group Layout"),
-                entries: &[],
-            });
-
-        PipelineEntry {
-            pass_type: PipelinePassType::ZPrepass,
+        PipelineEntry::ZPrepass {
             pipeline,
-            material_bind_group_layout,
-            material_bind_groups: Vec::new(),
             mesh_indices: Vec::new(),
             material_indices: Vec::new(),
-            sort_order: 0,
-            enable_lighting: false,
         }
     }
 }
@@ -2167,7 +2232,6 @@ impl LightingMeshRenderer {
             directional_shadow_bind_group,
             directional_shadow_info_buffer,
             directional_shadow_map_array,
-            directional_light_shadows: Vec::new(),
             directional_shadow_pipeline: None,
             mesh_items,
             textures,

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -209,7 +209,7 @@ enum PipelineEntry {
 
 struct PreparedShadowPass {
     directional_light_shadows: Vec<Arc<RenderDirectionalLightShadow>>,
-    shadow_pipelines: Vec<Arc<RwLock<PipelineEntry>>>,
+    shadow_pipeline: Arc<RwLock<PipelineEntry>>,
 }
 
 #[derive(Debug, Clone)]
@@ -872,7 +872,8 @@ impl LightingMeshRenderer {
 
     fn create_directional_shadow_info_buffer(device: &wgpu::Device) -> wgpu::Buffer {
         let directional_shadow_info_buffer_size = (MAX_DIRECTIONAL_SHADOW_NUM
-            * std::mem::size_of::<DirectionalShadowInfo>()) as wgpu::BufferAddress;
+            * std::mem::size_of::<DirectionalShadowInfo>())
+            as wgpu::BufferAddress;
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Buffer for Directional Shadow Infos"),
             size: directional_shadow_info_buffer_size,
@@ -941,8 +942,7 @@ impl LightingMeshRenderer {
         queue: &wgpu::Queue,
         directional_light_shadows: &[Arc<RenderDirectionalLightShadow>],
         shadow_mesh_indices: &[usize],
-        shadow_pipelines: &mut Vec<Arc<RwLock<PipelineEntry>>>,
-    ) {
+    ) -> Option<Arc<RwLock<PipelineEntry>>> {
         if !directional_light_shadows.is_empty() && !shadow_mesh_indices.is_empty() {
             let _ = self.build_directional_shadow_pipeline_entry(device, shadow_mesh_indices);
         }
@@ -999,11 +999,9 @@ impl LightingMeshRenderer {
                     );
                 }
             }
-
-            if !directional_light_shadows.is_empty() && !shadow_mesh_indices.is_empty() {
-                shadow_pipelines.push(pipeline_arc);
-            }
+            return Some(pipeline_arc.clone());
         }
+        return None;
     }
 
     fn prepare_lights(
@@ -1015,7 +1013,6 @@ impl LightingMeshRenderer {
         mesh_items: &[Arc<RenderItem>],
         light_items: &[Arc<RenderItem>],
     ) -> Vec<PreparedShadowPass> {
-        let mut shadow_pipelines = Vec::new();
         let mut light_uniforms = LightUniforms::default();
         let mut light_textures = Vec::new();
         let shadow_mesh_indices = mesh_items
@@ -1035,7 +1032,7 @@ impl LightingMeshRenderer {
                 })
             })
             .collect::<Vec<_>>();
-
+        let mut shadow_passes = Vec::new();
         let directional_light_shadows = create_directional_light_shadows(
             device,
             queue,
@@ -1044,12 +1041,11 @@ impl LightingMeshRenderer {
             light_items,
             render_resource_manager,
         );
-        self.update_directional_shadow_pipeline_entry(
+        let shadow_pipeline = self.update_directional_shadow_pipeline_entry(
             device,
             queue,
             &directional_light_shadows,
             &shadow_mesh_indices,
-            &mut shadow_pipelines,
         );
         let mut directional_shadow_index_map = HashMap::new();
         let mut base_shadow_index = 0i32;
@@ -1057,7 +1053,12 @@ impl LightingMeshRenderer {
             directional_shadow_index_map.insert(shadow.id, base_shadow_index);
             base_shadow_index += shadow.cascades.len() as i32;
         }
-
+        if let Some(shadow_pipeline_ref) = &shadow_pipeline {
+            shadow_passes.push(PreparedShadowPass {
+                shadow_pipeline: shadow_pipeline_ref.clone(),
+                directional_light_shadows,
+            });
+        }
         // Point lights
         {
             let mut light_buffer = Vec::new();
@@ -1322,14 +1323,8 @@ impl LightingMeshRenderer {
             0,
             bytemuck::bytes_of(&light_uniforms),
         );
-        let mut shadow_passes = Vec::new();
-        if !directional_light_shadows.is_empty() {
-            shadow_passes.push(PreparedShadowPass {
-                directional_light_shadows,
-                shadow_pipelines,
-            });
-        }
-        shadow_passes
+
+        return shadow_passes;
     }
 
     fn render_shadow_maps(
@@ -1353,9 +1348,7 @@ impl LightingMeshRenderer {
         _main_camera: &RenderCamera,
         shadow_pass: &PreparedShadowPass,
     ) {
-        if shadow_pass.directional_light_shadows.is_empty()
-            || shadow_pass.shadow_pipelines.is_empty()
-        {
+        if shadow_pass.directional_light_shadows.is_empty() {
             return;
         }
 
@@ -1368,21 +1361,7 @@ impl LightingMeshRenderer {
         };
 
         let directional_light_shadows = &shadow_pass.directional_light_shadows;
-        let shadow_pipelines = &shadow_pass.shadow_pipelines;
-        let shadow_map_array = shadow_pipelines.iter().find_map(|entry| {
-            let entry = entry.read().unwrap();
-            if let PipelineEntry::DirectionalShadow {
-                shadow_map_array, ..
-            } = &*entry
-            {
-                Some(shadow_map_array.clone())
-            } else {
-                None
-            }
-        });
-        let Some(shadow_map_array) = shadow_map_array else {
-            return;
-        };
+        let shadow_pipeline = &shadow_pass.shadow_pipeline;
 
         let mut layer: u32 = 0;
         for shadow in directional_light_shadows {
@@ -1433,8 +1412,8 @@ impl LightingMeshRenderer {
                         occlusion_query_set: None,
                     });
 
-                    for pipeline_entry in shadow_pipelines {
-                        let pipeline_entry = pipeline_entry.read().unwrap();
+                    {
+                        let pipeline_entry = shadow_pipeline.read().unwrap();
                         if let PipelineEntry::DirectionalShadow {
                             pipeline,
                             mesh_indices,
@@ -1473,35 +1452,44 @@ impl LightingMeshRenderer {
                     }
                 }
 
-                encoder.copy_texture_to_texture(
-                    wgpu::TexelCopyTextureInfo {
-                        texture: &shadow_texture.texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d::ZERO,
-                        aspect: wgpu::TextureAspect::DepthOnly,
-                    },
-                    wgpu::TexelCopyTextureInfo {
-                        texture: &shadow_map_array.texture,
-                        mip_level: 0,
-                        origin: wgpu::Origin3d {
-                            x: 0,
-                            y: 0,
-                            z: layer as u32,
-                        },
-                        aspect: wgpu::TextureAspect::DepthOnly,
-                    },
-                    wgpu::Extent3d {
-                        width: shadow_texture
-                            .texture
-                            .width()
-                            .min(shadow_map_array.texture.width()),
-                        height: shadow_texture
-                            .texture
-                            .height()
-                            .min(shadow_map_array.texture.height()),
-                        depth_or_array_layers: 1,
-                    },
-                );
+                {
+                    let pipeline_entry = shadow_pipeline.read().unwrap();
+                    if let PipelineEntry::DirectionalShadow {
+                        shadow_map_array,
+                        ..
+                    } = &*pipeline_entry
+                    {
+                        encoder.copy_texture_to_texture(
+                            wgpu::TexelCopyTextureInfo {
+                                texture: &shadow_texture.texture,
+                                mip_level: 0,
+                                origin: wgpu::Origin3d::ZERO,
+                                aspect: wgpu::TextureAspect::DepthOnly,
+                            },
+                            wgpu::TexelCopyTextureInfo {
+                                texture: &shadow_map_array.texture,
+                                mip_level: 0,
+                                origin: wgpu::Origin3d {
+                                    x: 0,
+                                    y: 0,
+                                    z: layer as u32,
+                                },
+                                aspect: wgpu::TextureAspect::DepthOnly,
+                            },
+                            wgpu::Extent3d {
+                                width: shadow_texture
+                                    .texture
+                                    .width()
+                                    .min(shadow_map_array.texture.width()),
+                                height: shadow_texture
+                                    .texture
+                                    .height()
+                                    .min(shadow_map_array.texture.height()),
+                                depth_or_array_layers: 1,
+                            },
+                        );
+                    }
+                }
                 layer += 1;
             }
         }
@@ -2165,8 +2153,7 @@ impl LightingMeshRenderer {
             mapped_at_creation: false,
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
         });
-        let directional_shadow_info_buffer =
-            Self::create_directional_shadow_info_buffer(device);
+        let directional_shadow_info_buffer = Self::create_directional_shadow_info_buffer(device);
 
         let directional_shadow_map_array =
             Self::create_directional_shadow_map_array(device, 1, 1, 1);

--- a/src/render/wgpu/lighting_renderer.rs
+++ b/src/render/wgpu/lighting_renderer.rs
@@ -144,18 +144,9 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                     renderer.prepare(
                         device,
                         queue,
+                        encoder,
                         &mut render_resource_manager,
                         &render_items,
-                        &self.render_camera,
-                    );
-                }
-                {
-                    // Render shadow pipelines before the main lighting pass.
-                    let renderer = self.mesh_renderer.read().unwrap();
-                    renderer.render_directional_shadow_maps(
-                        device,
-                        queue,
-                        encoder,
                         &self.render_camera,
                     );
                 }

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -1,4 +1,5 @@
 use super::light::DirectionalRenderLight;
+use super::light::DirectionalShadowProjection;
 use super::light::DiskRenderLight;
 use super::light::InfiniteRenderLight;
 use super::light::RectRenderLight;
@@ -126,6 +127,15 @@ fn get_directional_light_item(
         let source_angle = source_angle.max(0.2); // Prevent too small angles
         let source_angle = source_angle.to_radians();
         let cascade_count = props.find_one_int("cascadecount").unwrap_or(4).clamp(1, 4) as u32;
+        let shadow_projection = props
+            .find_one_string("shadowprojection")
+            .unwrap_or_else(|| "csm".to_string())
+            .to_lowercase();
+        let shadow_projection = if shadow_projection == "lspsm" {
+            DirectionalShadowProjection::Lspsm
+        } else {
+            DirectionalShadowProjection::Csm
+        };
         let shadow_bias = props.find_one_float("shadowbias").unwrap_or(0.001).max(0.0);
         let shadow_slope_bias = props
             .find_one_float("shadowslopebias")
@@ -149,6 +159,7 @@ fn get_directional_light_item(
             shadow_bias,
             shadow_slope_bias,
             cascade_count,
+            shadow_projection,
             ..Default::default()
         };
         let render_light = Arc::new(RenderLight::Directional(render_light));

--- a/src/render/wgpu/render_resource.rs
+++ b/src/render/wgpu/render_resource.rs
@@ -3,7 +3,6 @@ use super::lines::RenderLines;
 use super::material::RenderMaterial;
 use super::mesh::RenderMesh;
 use super::shader::RenderShader;
-use super::shadow::RenderDirectionalLightShadow;
 use super::texture::RenderTexture;
 use crate::model::scene::Component;
 
@@ -21,7 +20,6 @@ pub struct RenderResourceManager {
     pub shaders: HashMap<Uuid, Arc<RenderShader>>,
     pub materials: HashMap<Uuid, Arc<RenderMaterial>>,
     pub textures: HashMap<Uuid, Arc<RenderTexture>>,
-    pub directional_light_shadows: HashMap<Uuid, Arc<RenderDirectionalLightShadow>>,
 }
 
 impl RenderResourceManager {
@@ -33,7 +31,6 @@ impl RenderResourceManager {
             shaders: HashMap::new(),
             materials: HashMap::new(),
             textures: HashMap::new(),
-            directional_light_shadows: HashMap::new(),
         }
     }
     pub fn add_mesh(&mut self, mesh: &Arc<RenderMesh>) {
@@ -114,21 +111,6 @@ impl RenderResourceManager {
         self.textures.remove(&id);
     }
 
-    pub fn add_directional_light_shadow(&mut self, shadow: &Arc<RenderDirectionalLightShadow>) {
-        self.directional_light_shadows
-            .insert(shadow.id, shadow.clone());
-    }
-
-    pub fn get_directional_light_shadow(
-        &self,
-        id: Uuid,
-    ) -> Option<&Arc<RenderDirectionalLightShadow>> {
-        self.directional_light_shadows.get(&id)
-    }
-
-    pub fn clear_directional_light_shadows(&mut self) {
-        self.directional_light_shadows.clear();
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/render/wgpu/render_resource.rs
+++ b/src/render/wgpu/render_resource.rs
@@ -110,7 +110,6 @@ impl RenderResourceManager {
     pub fn remove_texture(&mut self, id: Uuid) {
         self.textures.remove(&id);
     }
-
 }
 
 #[derive(Debug, Clone)]

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -266,6 +266,7 @@ pub fn create_directional_light_shadows(
                 cascade_near,
                 cascade_far,
             );
+            let mut virtual_frustum_points = corners.to_vec();
             let mut world_min_c = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
             let mut world_max_c =
                 glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
@@ -278,6 +279,7 @@ pub fn create_directional_light_shadows(
                 // plane perpendicular to light_dir.
                 let extrude = scene_diagonal;
                 for p in corners {
+                    virtual_frustum_points.push(p + lspsm_depth_dir * extrude);
                     expand_bounds(
                         &mut world_min_c,
                         &mut world_max_c,
@@ -292,11 +294,11 @@ pub fn create_directional_light_shadows(
             let eye = world_center - light_dir * light_distance;
             let light_view = glam::Mat4::look_at_rh(eye, world_center, up);
 
-            let corners = get_aabb_corners(world_min_c, world_max_c);
             let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
             let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-            for corner in corners {
-                let p = light_view.transform_point3(corner);
+            // Build light-space bounds directly from the virtual frustum points.
+            for p_world in virtual_frustum_points.iter().copied() {
+                let p = light_view.transform_point3(p_world);
                 expand_bounds(&mut light_min, &mut light_max, p);
             }
 

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -296,10 +296,26 @@ pub fn create_directional_light_shadows(
 
             let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
             let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-            // Build light-space bounds directly from the virtual frustum points.
-            for p_world in virtual_frustum_points.iter().copied() {
-                let p = light_view.transform_point3(p_world);
-                expand_bounds(&mut light_min, &mut light_max, p);
+            // Build light-space bounds.
+            // CSM: receiver (virtual frustum) based fit.
+            // LSPSM: caster based fit.
+            if directional_light.shadow_projection == DirectionalShadowProjection::Lspsm {
+                for p_world in &caster_points_world {
+                    let p = light_view.transform_point3(*p_world);
+                    expand_bounds(&mut light_min, &mut light_max, p);
+                }
+                // Fallback for robustness.
+                if !light_min.is_finite() || !light_max.is_finite() {
+                    for p_world in virtual_frustum_points.iter().copied() {
+                        let p = light_view.transform_point3(p_world);
+                        expand_bounds(&mut light_min, &mut light_max, p);
+                    }
+                }
+            } else {
+                for p_world in virtual_frustum_points.iter().copied() {
+                    let p = light_view.transform_point3(p_world);
+                    expand_bounds(&mut light_min, &mut light_max, p);
+                }
             }
 
             let margin = SHADOW_BOUNDS_MARGIN;

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -230,7 +230,6 @@ pub fn create_directional_light_shadows(
     render_resource_manager: &mut RenderResourceManager,
 ) -> Vec<Arc<RenderDirectionalLightShadow>> {
     let mut shadows = Vec::new();
-    render_resource_manager.clear_directional_light_shadows();
 
     //
     let mut need_compute_shadows = false;
@@ -548,7 +547,6 @@ pub fn create_directional_light_shadows(
             shadow_slope_bias: directional_light.shadow_slope_bias,
             cascades,
         });
-        render_resource_manager.add_directional_light_shadow(&shadow);
         shadows.push(shadow);
     }
 

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -296,26 +296,11 @@ pub fn create_directional_light_shadows(
 
             let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
             let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-            // Build light-space bounds.
-            // CSM: receiver (virtual frustum) based fit.
-            // LSPSM: caster based fit.
-            if directional_light.shadow_projection == DirectionalShadowProjection::Lspsm {
-                for p_world in &caster_points_world {
-                    let p = light_view.transform_point3(*p_world);
-                    expand_bounds(&mut light_min, &mut light_max, p);
-                }
-                // Fallback for robustness.
-                if !light_min.is_finite() || !light_max.is_finite() {
-                    for p_world in virtual_frustum_points.iter().copied() {
-                        let p = light_view.transform_point3(p_world);
-                        expand_bounds(&mut light_min, &mut light_max, p);
-                    }
-                }
-            } else {
-                for p_world in virtual_frustum_points.iter().copied() {
-                    let p = light_view.transform_point3(p_world);
-                    expand_bounds(&mut light_min, &mut light_max, p);
-                }
+            // Build XY bounds from receiver footprint (virtual frustum slice).
+            // Depth (Z) is extended below with caster points.
+            for p_world in virtual_frustum_points.iter().copied() {
+                let p = light_view.transform_point3(p_world);
+                expand_bounds(&mut light_min, &mut light_max, p);
             }
 
             let margin = SHADOW_BOUNDS_MARGIN;

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -127,6 +127,100 @@ fn get_frustum_slice_corners_world(
     out
 }
 
+fn get_camera_tan_half_fov(render_camera: &RenderCamera) -> Option<(f32, f32)> {
+    let m00 = render_camera.camera_to_clip.x_axis.x;
+    let m11 = render_camera.camera_to_clip.y_axis.y;
+    if m00.abs() < 1e-8 || m11.abs() < 1e-8 {
+        return None;
+    }
+    Some((1.0 / m00.abs(), 1.0 / m11.abs()))
+}
+
+fn build_virtual_frustum_points_lspsm(
+    receiver_points: &[glam::Vec3; 8],
+    render_camera: &RenderCamera,
+    light_dir: glam::Vec3,
+    tan_half_fov_x: f32,
+) -> Option<[glam::Vec3; 8]> {
+    let camera_forward = render_camera.forward.normalize_or_zero();
+    let camera_up = render_camera.up.normalize_or_zero();
+    let mut forward = (camera_forward - light_dir * camera_forward.dot(light_dir)).normalize_or_zero();
+    if forward.length_squared() < 1e-8 {
+        forward = (camera_up - light_dir * camera_up.dot(light_dir)).normalize_or_zero();
+    }
+    if forward.length_squared() < 1e-8 {
+        return None;
+    }
+    let mut up = light_dir.cross(forward).normalize_or_zero();
+    if up.length_squared() < 1e-8 {
+        up = render_camera.right.cross(forward).normalize_or_zero();
+    }
+    if up.length_squared() < 1e-8 {
+        return None;
+    }
+    let right = forward.cross(up).normalize_or_zero();
+    if right.length_squared() < 1e-8 {
+        return None;
+    }
+
+    let mut center = glam::Vec3::ZERO;
+    for p in receiver_points {
+        center += *p;
+    }
+    center /= receiver_points.len() as f32;
+
+    let eps = 1e-3_f32;
+    let mut d_required = eps;
+    let mut min_z = f32::INFINITY;
+    let mut max_z = f32::NEG_INFINITY;
+    for p in receiver_points {
+        let rel = *p - center;
+        let x = rel.dot(right);
+        let z = rel.dot(forward);
+        min_z = min_z.min(z);
+        max_z = max_z.max(z);
+        d_required = d_required.max(x.abs() / tan_half_fov_x - z);
+        d_required = d_required.max(eps - z);
+    }
+    if !d_required.is_finite() || !min_z.is_finite() || !max_z.is_finite() {
+        return None;
+    }
+
+    let near = (min_z + d_required).max(eps);
+    let far = (max_z + d_required).max(near + eps);
+    let origin = center - forward * d_required;
+
+    // Vertical FOV is not constrained to camera FOV.
+    // Derive the minimum needed to include all receivers.
+    let mut tan_half_fov_y = 1e-3_f32;
+    for p in receiver_points {
+        let rel = *p - center;
+        let y = rel.dot(up);
+        let z = rel.dot(forward);
+        let denom = (z + d_required).max(eps);
+        tan_half_fov_y = tan_half_fov_y.max(y.abs() / denom);
+    }
+
+    let near_c = origin + forward * near;
+    let far_c = origin + forward * far;
+    let near_h = near * tan_half_fov_y;
+    let near_w = near * tan_half_fov_x;
+    let far_h = far * tan_half_fov_y;
+    let far_w = far * tan_half_fov_x;
+
+    let out = [
+        near_c - right * near_w - up * near_h,
+        near_c + right * near_w - up * near_h,
+        near_c - right * near_w + up * near_h,
+        near_c + right * near_w + up * near_h,
+        far_c - right * far_w - up * far_h,
+        far_c + right * far_w - up * far_h,
+        far_c - right * far_w + up * far_h,
+        far_c + right * far_w + up * far_h,
+    ];
+    Some(out)
+}
+
 pub fn create_directional_light_shadows(
     device: &wgpu::Device,
     _queue: &wgpu::Queue,
@@ -201,9 +295,10 @@ pub fn create_directional_light_shadows(
     let split_near = camera_near;
     let split_far = camera_far;
     let full_scene_corners = get_aabb_corners(world_min, world_max);
-    let scene_diagonal = (world_max - world_min).length().max(1.0);
     let full_frustum_corners = get_full_frustum_corners_world(render_camera);
     let camera_pos = render_camera.position;
+    let (camera_tan_half_fov_x, _camera_tan_half_fov_y) =
+        get_camera_tan_half_fov(render_camera).unwrap_or((1.0, 1.0));
 
     for item in light_items {
         let (light_item, directional_light) = match item.as_ref() {
@@ -236,7 +331,6 @@ pub fn create_directional_light_shadows(
         }
 
         let camera_up = render_camera.up.normalize_or_zero();
-        let camera_forward = render_camera.forward.normalize_or_zero();
         let up = if camera_up.length_squared() > 1e-8 && light_dir.abs().dot(camera_up) < 0.99 {
             camera_up
         } else if light_dir.abs().dot(glam::vec3(0.0, 1.0, 0.0)) < 0.99 {
@@ -244,18 +338,6 @@ pub fn create_directional_light_shadows(
         } else {
             glam::vec3(1.0, 0.0, 0.0)
         };
-        // LSPSM-only depth direction: perpendicular to light and aligned to camera depth.
-        let mut lspsm_depth_dir =
-            (camera_forward - light_dir * camera_forward.dot(light_dir)).normalize_or_zero();
-        if lspsm_depth_dir.length_squared() < 1e-8 {
-            lspsm_depth_dir = (camera_up - light_dir * camera_up.dot(light_dir)).normalize_or_zero();
-        }
-        if lspsm_depth_dir.length_squared() < 1e-8 {
-            lspsm_depth_dir = light_dir.cross(up).normalize_or_zero();
-        }
-        if lspsm_depth_dir.length_squared() < 1e-8 {
-            lspsm_depth_dir = -light_dir;
-        }
         let mut cascades = Vec::with_capacity(cascade_count);
         let mut cascade_near = split_near;
         for (cascade_index, cascade_far) in cascade_splits.iter().copied().enumerate() {
@@ -266,26 +348,25 @@ pub fn create_directional_light_shadows(
                 cascade_near,
                 cascade_far,
             );
-            let mut virtual_frustum_points = corners.to_vec();
+            let virtual_points = if directional_light.shadow_projection
+                == DirectionalShadowProjection::Lspsm
+            {
+                build_virtual_frustum_points_lspsm(
+                    &corners,
+                    render_camera,
+                    light_dir,
+                    camera_tan_half_fov_x,
+                )
+                .unwrap_or(corners)
+            } else {
+                corners
+            };
+            let virtual_frustum_points = virtual_points.to_vec();
             let mut world_min_c = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
             let mut world_max_c =
                 glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-            for p in corners {
+            for p in virtual_points {
                 expand_bounds(&mut world_min_c, &mut world_max_c, p);
-            }
-            if directional_light.shadow_projection == DirectionalShadowProjection::Lspsm {
-                // For LSPSM mode, extend frustum along a direction orthogonal to light_dir.
-                // The direction is chosen from camera-depth axis projected onto the
-                // plane perpendicular to light_dir.
-                let extrude = scene_diagonal;
-                for p in corners {
-                    virtual_frustum_points.push(p + lspsm_depth_dir * extrude);
-                    expand_bounds(
-                        &mut world_min_c,
-                        &mut world_max_c,
-                        p + lspsm_depth_dir * extrude,
-                    );
-                }
             }
             let world_center = 0.5 * (world_min_c + world_max_c);
             let world_extent = world_max_c - world_min_c;

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -156,6 +156,7 @@ pub fn create_directional_light_shadows(
 
     let mut world_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
     let mut world_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    let mut caster_points_world = Vec::new();
     let mut has_mesh = false;
 
     for item in mesh_items {
@@ -175,6 +176,7 @@ pub fn create_directional_light_shadows(
             for corner in corners {
                 let world = mesh_item.matrix.transform_point3(corner);
                 expand_bounds(&mut world_min, &mut world_max, world);
+                caster_points_world.push(world);
             }
         }
     }
@@ -194,6 +196,9 @@ pub fn create_directional_light_shadows(
         let _ = world_center;
         (near, far)
     };
+    // Keep split range aligned with camera projection for stable cascade coverage.
+    let split_near = camera_near;
+    let split_far = camera_far;
     let full_scene_corners = get_aabb_corners(world_min, world_max);
     let full_frustum_corners = get_full_frustum_corners_world(render_camera);
     let camera_pos = render_camera.position;
@@ -213,7 +218,7 @@ pub fn create_directional_light_shadows(
             .cascade_count
             .clamp(1, DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT as u32)
             as usize;
-        let cascade_splits = build_cascade_splits(camera_near, camera_far, cascade_count);
+        let cascade_splits = build_cascade_splits(split_near, split_far, cascade_count);
 
         let mut light_dir = glam::vec3(
             directional_light.direction[0],
@@ -237,7 +242,7 @@ pub fn create_directional_light_shadows(
             glam::vec3(1.0, 0.0, 0.0)
         };
         let mut cascades = Vec::with_capacity(cascade_count);
-        let mut cascade_near = camera_near;
+        let mut cascade_near = split_near;
         for (cascade_index, cascade_far) in cascade_splits.iter().copied().enumerate() {
             let corners = get_frustum_slice_corners_world(
                 &full_frustum_corners,
@@ -266,18 +271,40 @@ pub fn create_directional_light_shadows(
                 let p = light_view.transform_point3(corner);
                 expand_bounds(&mut light_min, &mut light_max, p);
             }
-            // Extend depth range by full-scene casters so grazing-angle shadows don't vanish.
-            for corner in full_scene_corners {
-                let p = light_view.transform_point3(corner);
-                light_min.z = light_min.z.min(p.z);
-                light_max.z = light_max.z.max(p.z);
-            }
 
             let margin = SHADOW_BOUNDS_MARGIN;
             let span = light_max - light_min;
             let mx = span.x.abs().max(1e-3) * margin;
             let my = span.y.abs().max(1e-3) * margin;
             let mz = span.z.abs().max(1e-3) * margin;
+
+            // Extend depth only with casters that overlap this cascade footprint in light space.
+            // This uses both camera slice (receiver bounds XY) and light-space caster positions.
+            let caster_x_min = light_min.x - mx;
+            let caster_x_max = light_max.x + mx;
+            let caster_y_min = light_min.y - my;
+            let caster_y_max = light_max.y + my;
+            let mut has_overlap_caster = false;
+            for p_world in &caster_points_world {
+                let p = light_view.transform_point3(*p_world);
+                if p.x >= caster_x_min
+                    && p.x <= caster_x_max
+                    && p.y >= caster_y_min
+                    && p.y <= caster_y_max
+                {
+                    light_min.z = light_min.z.min(p.z);
+                    light_max.z = light_max.z.max(p.z);
+                    has_overlap_caster = true;
+                }
+            }
+            // Fallback to full-scene casters when no overlap is found to avoid missing shadows.
+            if !has_overlap_caster {
+                for corner in full_scene_corners {
+                    let p = light_view.transform_point3(corner);
+                    light_min.z = light_min.z.min(p.z);
+                    light_max.z = light_max.z.max(p.z);
+                }
+            }
 
             // Snap projection center to shadow texel grid to reduce shimmering and
             // improve effective resolution usage per cascade.

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -144,7 +144,8 @@ fn build_virtual_frustum_points_lspsm(
 ) -> Option<[glam::Vec3; 8]> {
     let camera_forward = render_camera.forward.normalize_or_zero();
     let camera_up = render_camera.up.normalize_or_zero();
-    let mut forward = (camera_forward - light_dir * camera_forward.dot(light_dir)).normalize_or_zero();
+    let mut forward =
+        (camera_forward - light_dir * camera_forward.dot(light_dir)).normalize_or_zero();
     if forward.length_squared() < 1e-8 {
         forward = (camera_up - light_dir * camera_up.dot(light_dir)).normalize_or_zero();
     }
@@ -347,19 +348,18 @@ pub fn create_directional_light_shadows(
                 cascade_near,
                 cascade_far,
             );
-            let virtual_points = if directional_light.shadow_projection
-                == DirectionalShadowProjection::Lspsm
-            {
-                build_virtual_frustum_points_lspsm(
-                    &corners,
-                    render_camera,
-                    light_dir,
-                    camera_tan_half_fov_x,
-                )
-                .unwrap_or(corners)
-            } else {
-                corners
-            };
+            let virtual_points =
+                if directional_light.shadow_projection == DirectionalShadowProjection::Lspsm {
+                    build_virtual_frustum_points_lspsm(
+                        &corners,
+                        render_camera,
+                        light_dir,
+                        camera_tan_half_fov_x,
+                    )
+                    .unwrap_or(corners)
+                } else {
+                    corners
+                };
             let virtual_frustum_points = virtual_points.to_vec();
             let mut world_min_c = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
             let mut world_max_c =

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -1,4 +1,5 @@
 use super::camera::RenderCamera;
+use super::light::DirectionalShadowProjection;
 use super::light::RenderLight;
 use super::render_item::RenderItem;
 use super::render_resource::RenderResourceManager;
@@ -200,6 +201,7 @@ pub fn create_directional_light_shadows(
     let split_near = camera_near;
     let split_far = camera_far;
     let full_scene_corners = get_aabb_corners(world_min, world_max);
+    let scene_diagonal = (world_max - world_min).length().max(1.0);
     let full_frustum_corners = get_full_frustum_corners_world(render_camera);
     let camera_pos = render_camera.position;
 
@@ -234,6 +236,7 @@ pub fn create_directional_light_shadows(
         }
 
         let camera_up = render_camera.up.normalize_or_zero();
+        let camera_forward = render_camera.forward.normalize_or_zero();
         let up = if camera_up.length_squared() > 1e-8 && light_dir.abs().dot(camera_up) < 0.99 {
             camera_up
         } else if light_dir.abs().dot(glam::vec3(0.0, 1.0, 0.0)) < 0.99 {
@@ -241,6 +244,18 @@ pub fn create_directional_light_shadows(
         } else {
             glam::vec3(1.0, 0.0, 0.0)
         };
+        // LSPSM-only depth direction: perpendicular to light and aligned to camera depth.
+        let mut lspsm_depth_dir =
+            (camera_forward - light_dir * camera_forward.dot(light_dir)).normalize_or_zero();
+        if lspsm_depth_dir.length_squared() < 1e-8 {
+            lspsm_depth_dir = (camera_up - light_dir * camera_up.dot(light_dir)).normalize_or_zero();
+        }
+        if lspsm_depth_dir.length_squared() < 1e-8 {
+            lspsm_depth_dir = light_dir.cross(up).normalize_or_zero();
+        }
+        if lspsm_depth_dir.length_squared() < 1e-8 {
+            lspsm_depth_dir = -light_dir;
+        }
         let mut cascades = Vec::with_capacity(cascade_count);
         let mut cascade_near = split_near;
         for (cascade_index, cascade_far) in cascade_splits.iter().copied().enumerate() {
@@ -256,6 +271,19 @@ pub fn create_directional_light_shadows(
                 glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
             for p in corners {
                 expand_bounds(&mut world_min_c, &mut world_max_c, p);
+            }
+            if directional_light.shadow_projection == DirectionalShadowProjection::Lspsm {
+                // For LSPSM mode, extend frustum along a direction orthogonal to light_dir.
+                // The direction is chosen from camera-depth axis projected onto the
+                // plane perpendicular to light_dir.
+                let extrude = scene_diagonal;
+                for p in corners {
+                    expand_bounds(
+                        &mut world_min_c,
+                        &mut world_max_c,
+                        p + lspsm_depth_dir * extrude,
+                    );
+                }
             }
             let world_center = 0.5 * (world_min_c + world_max_c);
             let world_extent = world_max_c - world_min_c;


### PR DESCRIPTION
This pull request introduces support for configurable shadow projection modes for directional lights, allowing users to choose between CSM (Cascaded Shadow Maps) and LSPSM (Light Space Perspective Shadow Mapping). It also refactors the shadow rendering code to improve accuracy and flexibility, particularly in how shadow map bounds are computed and how casters are handled. The most important changes are grouped below.

### Shadow Projection Mode Support

* Added a new `DirectionalShadowProjection` enum and a corresponding `shadow_projection` field to `DirectionalRenderLight`, enabling selection between "csm" and "lspsm" shadow projection modes for directional lights. [[1]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR5-R11) [[2]](diffhunk://#diff-494858f17e17564cdd214611dd78bcc6cbc9e344aad495ab9d4f2290f3ea0b9cR23) [[3]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cR130-R138) [[4]](diffhunk://#diff-65f7a00bb8585665752352973613dd97025d1f57e423ef26023e31e00f32774cR162)
* Updated the light properties and inspector UI to expose the `shadowprojection` parameter and allow users to select the projection mode via a combo box. [[1]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5L5-R5) [[2]](diffhunk://#diff-3602dd6e23e623a7058e81a1173d40a9fd3909957804dc411f4ea8a98ad405e5R31) [[3]](diffhunk://#diff-00c1b037d49463e3a016c67336397991f9ad58b530ae71b36a9effd18908775cR328-R344)

### Shadow Bounds and Caster Handling

* Refactored the shadow bounds computation to use virtual frustum points for LSPSM, and improved cascade split alignment and caster overlap detection for more accurate and stable shadow rendering. [[1]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4R130-R224) [[2]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L138) [[3]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4R254) [[4]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4R274) [[5]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4R294-R301) [[6]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L216-R318) [[7]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L240-R342) [[8]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4R351-R367) [[9]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L262-R419)

### Resource Management Cleanup

* Removed the management of directional light shadow resources from `RenderResourceManager`, simplifying resource handling and removing unused methods and fields. [[1]](diffhunk://#diff-a356f2c54abf1d4631b432c9f173bb1cf235c88695a367211f048f7dd63a50dcL6) [[2]](diffhunk://#diff-a356f2c54abf1d4631b432c9f173bb1cf235c88695a367211f048f7dd63a50dcL24) [[3]](diffhunk://#diff-a356f2c54abf1d4631b432c9f173bb1cf235c88695a367211f048f7dd63a50dcL36) [[4]](diffhunk://#diff-a356f2c54abf1d4631b432c9f173bb1cf235c88695a367211f048f7dd63a50dcL116-L131) [[5]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L412)

### Renderer Pipeline Adjustment

* Modified the renderer pipeline to remove the explicit shadow map rendering step before the main lighting pass, streamlining rendering logic.