### PR TITLE
refine directional shadow map renderer flow

### DIFF
--- a/src/render/wgpu/directional_shadow_map_renderer.rs
+++ b/src/render/wgpu/directional_shadow_map_renderer.rs
@@ -1,4 +1,5 @@
 use super::camera::RenderCamera;
+use super::light::RenderLight;
 use super::mesh::RenderVertex;
 use super::render_item::RenderItem;
 use super::render_resource::RenderResourceManager;
@@ -156,6 +157,10 @@ impl DirectionalShadowMapRenderer {
         camera: &RenderCamera,
     ) -> Option<DirectionalShadowMaps> {
         let (mesh_items, light_items) = Self::split_items(render_items);
+        if light_items.is_empty() {
+            // No directional lights, no need to prepare shadow maps
+            return None;
+        }
         self.prepare_locals(device, queue, &mesh_items);
 
         let shadow_mesh_indices = mesh_items
@@ -204,12 +209,12 @@ impl DirectionalShadowMapRenderer {
                 &directional_light_shadows,
                 &shadow_mesh_indices,
             )?;
-
-        return Some(DirectionalShadowMaps {
+        let directional_shadow_maps = DirectionalShadowMaps {
             directional_shadow_index_map,
             directional_shadow_info_buffer,
             directional_shadow_map_texture,
-        });
+        };
+        return Some(directional_shadow_maps);
     }
 
     fn split_items(
@@ -220,7 +225,14 @@ impl DirectionalShadowMapRenderer {
         for item in render_items {
             match item.as_ref() {
                 RenderItem::Mesh(_) => mesh_items.push(item.clone()),
-                RenderItem::Light(_) => light_items.push(item.clone()),
+                RenderItem::Light(light_item) => {
+                    if let RenderLight::Directional(directional_light) = light_item.light.as_ref() {
+                        if directional_light.cast_shadow {
+                            // Only consider directional lights that cast shadows
+                            light_items.push(item.clone());
+                        }
+                    }
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
This pull request improves how directional shadow maps are prepared by ensuring only relevant lights are considered, and by adding early exit logic when no directional lights are present. The changes focus on optimizing the shadow map rendering process and ensuring correctness in the selection of lights.

Improvements to shadow map preparation:

* Added an early return in `DirectionalShadowMapRenderer::prepare` to avoid unnecessary processing when there are no directional lights in the scene.
* Updated the splitting of render items to only include directional lights that have `cast_shadow` enabled, ensuring that only lights capable of casting shadows are considered for shadow map rendering.

Code clarity and correctness:

* Refactored the construction and return of the `DirectionalShadowMaps` object for improved readability and maintainability.
* Added import for `RenderLight` to support the new logic in filtering lights.