### PR TITLE
use shared directional shadow texture handles

### DIFF
--- a/src/render/wgpu/directional_shadow_map_renderer.rs
+++ b/src/render/wgpu/directional_shadow_map_renderer.rs
@@ -55,9 +55,9 @@ pub struct DirectionalShadowMapRenderer {
     local_bind_group_layout: wgpu::BindGroupLayout,
     local_bind_group: wgpu::BindGroup,
     local_uniform_buffer: wgpu::Buffer,
-    directional_shadow_pipeline: Option<wgpu::RenderPipeline>,
+    directional_shadow_pipeline: wgpu::RenderPipeline,
     directional_shadow_info_buffer: wgpu::Buffer,
-    shadow_map_array: RenderTexture,
+    shadow_map_array: Arc<RenderTexture>,
 }
 
 fn create_local_uniform_buffer(device: &wgpu::Device, num_items: usize) -> wgpu::Buffer {
@@ -133,7 +133,12 @@ impl DirectionalShadowMapRenderer {
             usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE,
         });
 
-        let shadow_map_array = Self::create_directional_shadow_map_array(device, 1, 1, 1);
+        let shadow_map_array = Arc::new(Self::create_directional_shadow_map_array(device, 1, 1, 1));
+        let directional_shadow_pipeline = Self::create_directional_shadow_pipeline(
+            device,
+            &global_bind_group_layout,
+            &local_bind_group_layout,
+        );
 
         Self {
             min_uniform_buffer_offset_alignment,
@@ -141,7 +146,7 @@ impl DirectionalShadowMapRenderer {
             local_bind_group_layout,
             local_bind_group,
             local_uniform_buffer,
-            directional_shadow_pipeline: None,
+            directional_shadow_pipeline,
             directional_shadow_info_buffer,
             shadow_map_array,
         }
@@ -295,12 +300,11 @@ impl DirectionalShadowMapRenderer {
         mesh_items: &[Arc<RenderItem>],
         directional_light_shadows: &[Arc<RenderDirectionalLightShadow>],
         shadow_mesh_indices: &[usize],
-    ) -> Option<(wgpu::Buffer, RenderTexture)> {
+    ) -> Option<(wgpu::Buffer, Arc<RenderTexture>)> {
         if directional_light_shadows.is_empty() || shadow_mesh_indices.is_empty() {
             return None;
         }
 
-        self.ensure_directional_shadow_pipeline(device);
         self.update_shadow_info_and_array(device, queue, directional_light_shadows);
         self.render_directional_shadow_maps(
             device,
@@ -316,10 +320,11 @@ impl DirectionalShadowMapRenderer {
         ))
     }
 
-    fn ensure_directional_shadow_pipeline(&mut self, device: &wgpu::Device) {
-        if self.directional_shadow_pipeline.is_some() {
-            return;
-        }
+    fn create_directional_shadow_pipeline(
+        device: &wgpu::Device,
+        global_bind_group_layout: &wgpu::BindGroupLayout,
+        local_bind_group_layout: &wgpu::BindGroupLayout,
+    ) -> wgpu::RenderPipeline {
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("DirectionalShadowMapRenderer Directional Shadow Pipeline Shader"),
             source: wgpu::ShaderSource::Wgsl(
@@ -354,13 +359,10 @@ impl DirectionalShadowMapRenderer {
         }];
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("DirectionalShadowMapRenderer Directional Shadow Pipeline Layout"),
-            bind_group_layouts: &[
-                &self.global_bind_group_layout,
-                &self.local_bind_group_layout,
-            ],
+            bind_group_layouts: &[global_bind_group_layout, local_bind_group_layout],
             push_constant_ranges: &[],
         });
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("DirectionalShadowMapRenderer Directional Shadow Pipeline"),
             layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
@@ -381,8 +383,7 @@ impl DirectionalShadowMapRenderer {
             multisample: wgpu::MultisampleState::default(),
             multiview: None,
             cache: None,
-        });
-        self.directional_shadow_pipeline = Some(pipeline);
+        })
     }
 
     fn update_shadow_info_and_array(
@@ -429,8 +430,12 @@ impl DirectionalShadowMapRenderer {
             || current_size.width != width
             || current_size.height != height
         {
-            self.shadow_map_array =
-                Self::create_directional_shadow_map_array(device, layer_count, width, height);
+            self.shadow_map_array = Arc::new(Self::create_directional_shadow_map_array(
+                device,
+                layer_count,
+                width,
+                height,
+            ));
         }
     }
 
@@ -442,9 +447,7 @@ impl DirectionalShadowMapRenderer {
         directional_light_shadows: &[Arc<RenderDirectionalLightShadow>],
         shadow_mesh_indices: &[usize],
     ) {
-        let Some(pipeline) = self.directional_shadow_pipeline.as_ref() else {
-            return;
-        };
+        let pipeline = &self.directional_shadow_pipeline;
         let local_uniform_alignment = {
             let alignment = self.min_uniform_buffer_offset_alignment;
             align_to(

--- a/src/render/wgpu/lighting_mesh_renderer.rs
+++ b/src/render/wgpu/lighting_mesh_renderer.rs
@@ -287,7 +287,9 @@ impl LightingMeshRenderer {
             self.set_directional_shadow_resources(
                 device,
                 &directional_shadow_maps.directional_shadow_info_buffer,
-                &directional_shadow_maps.directional_shadow_map_texture,
+                directional_shadow_maps
+                    .directional_shadow_map_texture
+                    .as_ref(),
             );
         }
         let (mesh_items, light_items) = Self::split_items(render_items);

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -29,7 +29,7 @@ pub struct ShadowMaps {
 pub struct DirectionalShadowMaps {
     pub directional_shadow_index_map: HashMap<Uuid, i32>,
     pub directional_shadow_info_buffer: wgpu::Buffer,
-    pub directional_shadow_map_texture: RenderTexture,
+    pub directional_shadow_map_texture: Arc<RenderTexture>,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This pull request refactors the handling of the directional shadow pipeline and shadow map textures in the rendering codebase. The main improvements include removing lazy initialization for the pipeline, switching to shared ownership (`Arc`) for shadow map textures, and updating method signatures and usage to reflect these changes. These updates simplify resource management and improve consistency.

### Directional Shadow Pipeline Refactor

* The `directional_shadow_pipeline` field in `DirectionalShadowMapRenderer` is now a direct `wgpu::RenderPipeline` instead of an `Option`, and is created eagerly during initialization rather than lazily. The helper method for lazy initialization (`ensure_directional_shadow_pipeline`) has been replaced with a creation method. [[1]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L58-R60) [[2]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L136-R149) [[3]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L319-R327) [[4]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L445-R450)
* Pipeline creation now uses passed-in bind group layouts rather than accessing struct fields directly, improving modularity. [[1]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L357-R365) [[2]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L384-R386)

### Shared Ownership of Shadow Map Textures

* The `shadow_map_array` field in `DirectionalShadowMapRenderer` and `directional_shadow_map_texture` in `DirectionalShadowMaps` are now wrapped in `Arc`, enabling shared ownership and safer resource management across threads. [[1]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L58-R60) [[2]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L136-R149) [[3]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L432-R438) [[4]](diffhunk://#diff-70944a82b90be6d7da81820f7a8f7efeae4e9b21fe5dde79974b422bab269eb4L32-R32)

### Method Signature and Usage Updates

* All methods and usages that previously expected `RenderTexture` now accept `Arc<RenderTexture>`, including return values and function parameters. [[1]](diffhunk://#diff-47354c78fb01e64fc64466a3e7c0802559f11002fcd7a544ae7512464cdba091L298-L303) [[2]](diffhunk://#diff-a220ac35be76568fe0353e0f14d344c3bf6a2f9253142756efc932b82e5c4716L290-R292)

These changes collectively improve resource management, simplify initialization logic, and enhance code safety and clarity.