### PR TITLE
Cache world transforms on scene nodes

### DIFF
--- a/src/model/scene/components/computed_transform.rs
+++ b/src/model/scene/components/computed_transform.rs
@@ -1,0 +1,46 @@
+use super::component::Component;
+use crate::model::base::Matrix4x4;
+
+#[derive(Debug, Clone)]
+pub struct ComputedTransformComponent {
+    local_matrix: Matrix4x4,
+    parent_world_matrix: Matrix4x4,
+    world_matrix: Matrix4x4,
+}
+
+impl Default for ComputedTransformComponent {
+    fn default() -> Self {
+        Self {
+            local_matrix: Matrix4x4::identity(),
+            parent_world_matrix: Matrix4x4::identity(),
+            world_matrix: Matrix4x4::identity(),
+        }
+    }
+}
+
+impl ComputedTransformComponent {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn matches(&self, local_matrix: &Matrix4x4, parent_world_matrix: &Matrix4x4) -> bool {
+        self.local_matrix == *local_matrix && self.parent_world_matrix == *parent_world_matrix
+    }
+
+    pub fn world_matrix(&self) -> Matrix4x4 {
+        self.world_matrix
+    }
+
+    pub fn update(
+        &mut self,
+        local_matrix: Matrix4x4,
+        parent_world_matrix: Matrix4x4,
+        world_matrix: Matrix4x4,
+    ) {
+        self.local_matrix = local_matrix;
+        self.parent_world_matrix = parent_world_matrix;
+        self.world_matrix = world_matrix;
+    }
+}
+
+impl Component for ComputedTransformComponent {}

--- a/src/model/scene/components/computed_transform.rs
+++ b/src/model/scene/components/computed_transform.rs
@@ -3,16 +3,18 @@ use crate::model::base::Matrix4x4;
 
 #[derive(Debug, Clone)]
 pub struct ComputedTransformComponent {
-    local_matrix: Matrix4x4,
-    parent_world_matrix: Matrix4x4,
+    local_edition: String,
+    parent_world_edition: String,
+    world_edition: String,
     world_matrix: Matrix4x4,
 }
 
 impl Default for ComputedTransformComponent {
     fn default() -> Self {
         Self {
-            local_matrix: Matrix4x4::identity(),
-            parent_world_matrix: Matrix4x4::identity(),
+            local_edition: String::new(),
+            parent_world_edition: String::new(),
+            world_edition: String::new(),
             world_matrix: Matrix4x4::identity(),
         }
     }
@@ -23,22 +25,29 @@ impl ComputedTransformComponent {
         Self::default()
     }
 
-    pub fn matches(&self, local_matrix: &Matrix4x4, parent_world_matrix: &Matrix4x4) -> bool {
-        self.local_matrix == *local_matrix && self.parent_world_matrix == *parent_world_matrix
+    pub fn matches(&self, local_edition: &str, parent_world_edition: &str) -> bool {
+        self.local_edition == local_edition
+            && self.parent_world_edition == parent_world_edition
     }
 
     pub fn world_matrix(&self) -> Matrix4x4 {
         self.world_matrix
     }
 
+    pub fn world_edition(&self) -> String {
+        self.world_edition.clone()
+    }
+
     pub fn update(
         &mut self,
-        local_matrix: Matrix4x4,
-        parent_world_matrix: Matrix4x4,
+        local_edition: String,
+        parent_world_edition: String,
+        world_edition: String,
         world_matrix: Matrix4x4,
     ) {
-        self.local_matrix = local_matrix;
-        self.parent_world_matrix = parent_world_matrix;
+        self.local_edition = local_edition;
+        self.parent_world_edition = parent_world_edition;
+        self.world_edition = world_edition;
         self.world_matrix = world_matrix;
     }
 }

--- a/src/model/scene/components/mod.rs
+++ b/src/model/scene/components/mod.rs
@@ -1,6 +1,7 @@
 mod accelerator;
 mod animation;
 mod camera;
+mod computed_transform;
 mod component;
 mod coordinate_system;
 mod film;
@@ -18,6 +19,7 @@ mod transform;
 pub use accelerator::AcceleratorComponent;
 pub use animation::AnimationComponent;
 pub use camera::CameraComponent;
+pub use computed_transform::ComputedTransformComponent;
 pub use component::Component;
 pub use coordinate_system::CoordinateSystemComponent;
 pub use film::FilmComponent;

--- a/src/model/scene/components/transform.rs
+++ b/src/model/scene/components/transform.rs
@@ -1,5 +1,6 @@
 use super::component::Component;
 use crate::model::base::*;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct TransformComponent {
@@ -9,6 +10,10 @@ pub struct TransformComponent {
 impl Default for TransformComponent {
     fn default() -> Self {
         let mut props = PropertyMap::new();
+        props.insert(
+            "string edition",
+            Property::from(Uuid::new_v4().to_string()),
+        );
         props.insert("float position", Property::Floats(vec![0.0, 0.0, 0.0]));
         props.insert("float rotation", Property::Floats(vec![0.0, 0.0, 0.0]));
         props.insert("float scale", Property::Floats(vec![1.0, 1.0, 1.0]));
@@ -43,6 +48,7 @@ impl TransformComponent {
             "float scale",
             Property::Floats(vec![scale.x, scale.y, scale.z]),
         );
+        self.bump_edition();
     }
 
     pub fn get_local_trs(&self) -> (Vector3, Quaternion, Vector3) {
@@ -67,6 +73,19 @@ impl TransformComponent {
         let r = rotation.to_matrix();
         let s = Matrix4x4::scale(scale.x, scale.y, scale.z);
         return t * r * s;
+    }
+
+    pub fn get_edition(&self) -> String {
+        self.props
+            .find_one_string("string edition")
+            .unwrap_or_default()
+    }
+
+    fn bump_edition(&mut self) {
+        self.props.insert(
+            "string edition",
+            Property::from(Uuid::new_v4().to_string()),
+        );
     }
 
     pub fn is_identity(&self) -> bool {

--- a/src/render/scene_item.rs
+++ b/src/render/scene_item.rs
@@ -1,5 +1,6 @@
 use crate::model::base::Matrix4x4;
 use crate::model::scene::CameraComponent;
+use crate::model::scene::ComputedTransformComponent;
 use crate::model::scene::Component;
 use crate::model::scene::LightComponent;
 use crate::model::scene::MaterialComponent;
@@ -46,6 +47,30 @@ fn get_local_matrix(node: &Arc<RwLock<Node>>) -> Matrix4x4 {
     return t.get_local_matrix();
 }
 
+fn get_world_matrix(node: &Arc<RwLock<Node>>, parent_matrix: &Matrix4x4) -> Matrix4x4 {
+    let local_matrix = get_local_matrix(node);
+
+    {
+        let node_ref = node.read().unwrap();
+        if let Some(component) = node_ref.get_component::<ComputedTransformComponent>()
+            && component.matches(&local_matrix, parent_matrix)
+        {
+            return component.world_matrix();
+        }
+    }
+
+    let world_matrix = *parent_matrix * local_matrix;
+    let mut node_ref = node.write().unwrap();
+    if let Some(component) = node_ref.get_component_mut::<ComputedTransformComponent>() {
+        component.update(local_matrix, *parent_matrix, world_matrix);
+    } else {
+        let mut component = ComputedTransformComponent::new();
+        component.update(local_matrix, *parent_matrix, world_matrix);
+        node_ref.add_component(component);
+    }
+    world_matrix
+}
+
 /*
 fn get_material(node: &Arc<RwLock<Node>>) -> Arc<RwLock<Material>> {
     let node = node.read().unwrap();
@@ -59,8 +84,7 @@ fn get_scene_item(parent_matrix: &Matrix4x4, node: &Arc<RwLock<Node>>, items: &m
         return;
     }
 
-    let local_matrix = get_local_matrix(node);
-    let world_matrix = *parent_matrix * local_matrix;
+    let world_matrix = get_world_matrix(node, parent_matrix);
 
     if has_component::<ShapeComponent>(node) && has_component::<MaterialComponent>(node) {
         let item = SceneItem::new(node.clone(), SceneItemType::Mesh, world_matrix);

--- a/src/render/scene_item.rs
+++ b/src/render/scene_item.rs
@@ -11,6 +11,7 @@ use crate::model::scene::TransformComponent;
 
 use std::sync::Arc;
 use std::sync::RwLock;
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SceneItemType {
@@ -47,28 +48,50 @@ fn get_local_matrix(node: &Arc<RwLock<Node>>) -> Matrix4x4 {
     return t.get_local_matrix();
 }
 
-fn get_world_matrix(node: &Arc<RwLock<Node>>, parent_matrix: &Matrix4x4) -> Matrix4x4 {
+fn get_local_edition(node: &Arc<RwLock<Node>>) -> String {
+    let node = node.read().unwrap();
+    let t = node.get_component::<TransformComponent>().unwrap();
+    t.get_edition()
+}
+
+fn get_world_matrix(
+    node: &Arc<RwLock<Node>>,
+    parent_matrix: &Matrix4x4,
+    parent_world_edition: &str,
+) -> (Matrix4x4, String) {
     let local_matrix = get_local_matrix(node);
+    let local_edition = get_local_edition(node);
 
     {
         let node_ref = node.read().unwrap();
         if let Some(component) = node_ref.get_component::<ComputedTransformComponent>()
-            && component.matches(&local_matrix, parent_matrix)
+            && component.matches(&local_edition, parent_world_edition)
         {
-            return component.world_matrix();
+            return (component.world_matrix(), component.world_edition());
         }
     }
 
     let world_matrix = *parent_matrix * local_matrix;
+    let world_edition = Uuid::new_v4().to_string();
     let mut node_ref = node.write().unwrap();
     if let Some(component) = node_ref.get_component_mut::<ComputedTransformComponent>() {
-        component.update(local_matrix, *parent_matrix, world_matrix);
+        component.update(
+            local_edition,
+            parent_world_edition.to_string(),
+            world_edition.clone(),
+            world_matrix,
+        );
     } else {
         let mut component = ComputedTransformComponent::new();
-        component.update(local_matrix, *parent_matrix, world_matrix);
+        component.update(
+            local_edition,
+            parent_world_edition.to_string(),
+            world_edition.clone(),
+            world_matrix,
+        );
         node_ref.add_component(component);
     }
-    world_matrix
+    (world_matrix, world_edition)
 }
 
 /*
@@ -79,12 +102,17 @@ fn get_material(node: &Arc<RwLock<Node>>) -> Arc<RwLock<Material>> {
 }
 */
 
-fn get_scene_item(parent_matrix: &Matrix4x4, node: &Arc<RwLock<Node>>, items: &mut Vec<SceneItem>) {
+fn get_scene_item(
+    parent_matrix: &Matrix4x4,
+    parent_world_edition: &str,
+    node: &Arc<RwLock<Node>>,
+    items: &mut Vec<SceneItem>,
+) {
     if !node.read().unwrap().is_enabled() {
         return;
     }
 
-    let world_matrix = get_world_matrix(node, parent_matrix);
+    let (world_matrix, world_edition) = get_world_matrix(node, parent_matrix, parent_world_edition);
 
     if has_component::<ShapeComponent>(node) && has_component::<MaterialComponent>(node) {
         let item = SceneItem::new(node.clone(), SceneItemType::Mesh, world_matrix);
@@ -108,13 +136,13 @@ fn get_scene_item(parent_matrix: &Matrix4x4, node: &Arc<RwLock<Node>>, items: &m
 
     let node = node.read().unwrap();
     for child in &node.children {
-        get_scene_item(&world_matrix, child, items);
+        get_scene_item(&world_matrix, &world_edition, child, items);
     }
 }
 
 pub fn get_scene_items(node: &Arc<RwLock<Node>>) -> Vec<SceneItem> {
     let mut items = Vec::new();
     let parent_matrix = Matrix4x4::identity();
-    get_scene_item(&parent_matrix, node, &mut items);
+    get_scene_item(&parent_matrix, "", node, &mut items);
     return items;
 }


### PR DESCRIPTION
## Summary
- add ComputedTransformComponent to cache world transforms on scene nodes
- reuse cached world matrices when local and parent transform inputs are unchanged
- move scene-item world-matrix evaluation behind the cached transform helper

## Testing
- cargo build --release