### PR TITLE
WIP: rewrite directional shadow path

### DIFF
--- a/docs/shadow_redesign.md
+++ b/docs/shadow_redesign.md
@@ -1,0 +1,210 @@
+# Shadow Redesign Notes
+
+This document summarizes the current directional-shadow implementation and proposes a simpler replacement. The intent is to support deleting the current CSM path if needed and rebuilding from a cleaner base.
+
+## Current Findings
+
+The current implementation is centered in [`src/render/wgpu/shadow.rs`](/Users/toru/src/others/pbrt-ui/src/render/wgpu/shadow.rs) and uses per-light split-space CSM.
+
+What is already working:
+
+- CPU and GPU cascade selection use the same split basis data:
+  - `split_origin`
+  - `split_forward`
+  - `split_end`
+- Shadow rendering and sampling are wired through:
+  - [`src/render/wgpu/directional_shadow_map_renderer.rs`](/Users/toru/src/others/pbrt-ui/src/render/wgpu/directional_shadow_map_renderer.rs)
+  - [`assets/shaders/include/lighting_shadow_functions.wgsl`](/Users/toru/src/others/pbrt-ui/assets/shaders/include/lighting_shadow_functions.wgsl)
+
+The main design problems are:
+
+1. `shadow.rs` mixes too many responsibilities.
+   - scene analysis
+   - cascade split selection
+   - frustum slicing
+   - light-space fitting
+   - shadow texture allocation
+
+2. Receiver and caster selection are too approximate.
+   - `build_shadow_scene_context()` uses mesh AABB corners only.
+   - casters are not sliced per cascade; Z fitting is global and overlap-tested heuristically.
+
+3. The split-space algorithm is more complex than the current renderer needs.
+   - it adds instability/debug cost before the basic shadow pipeline is validated
+   - LSPSM is still `todo!()`, so the abstraction is wider than the implementation
+
+4. The current code is hard to inspect.
+   - debug information is spread across CPU logs and shader debug modes
+   - there is no explicit “shadow build result” structure for inspection
+
+## Recommendation
+
+Do not keep the current CSM design as the baseline. Replace it with a staged design:
+
+1. First rebuild a stable single-cascade directional shadow.
+2. After that works visually, add simple camera-depth CSM.
+3. Only reintroduce split-space or other advanced partitioning if a real artifact remains.
+
+This lowers risk and makes debugging much easier.
+
+## Proposed Architecture
+
+Split the shadow system into these layers:
+
+### 1. Shadow Scene Extraction
+
+Input:
+
+- `RenderCamera`
+- shadow-casting directional lights
+- shadow-casting mesh items
+
+Output:
+
+- `ShadowSceneSnapshot`
+
+Suggested contents:
+
+- `camera_frustum_corners_world`
+- `receiver_bounds_world`
+- `caster_bounds_world`
+- `mesh_instances`
+
+This layer should not decide cascades or build matrices.
+
+### 2. Shadow Partitioning
+
+Input:
+
+- `ShadowSceneSnapshot`
+- light parameters
+
+Output:
+
+- `Vec<ShadowSlice>`
+
+Start with the simplest version:
+
+- one slice for the full visible camera range
+
+Then add basic CSM:
+
+- partition by camera depth only
+- use standard practical split scheme
+- do not use per-light split-space in the first rewrite
+
+Each `ShadowSlice` should contain:
+
+- `view_near`
+- `view_far`
+- `receiver_frustum_corners_world`
+
+### 3. Shadow Projection Fitting
+
+Input:
+
+- `ShadowSlice`
+- light direction
+- caster bounds
+
+Output:
+
+- `ShadowCascade`
+
+Responsibilities:
+
+- build `light_view`
+- fit orthographic projection from receiver footprint
+- expand Z from relevant casters
+- snap XY to texel grid
+
+This should be a pure geometry step and should not allocate textures.
+
+### 4. Shadow Resource Preparation
+
+Input:
+
+- `Vec<ShadowCascade>`
+
+Output:
+
+- GPU textures
+- info buffer
+- runtime shadow map handles
+
+This layer should own:
+
+- shadow-map array allocation
+- cascade-to-layer mapping
+- buffer upload
+
+## Suggested Data Model
+
+Prefer explicit intermediate structs instead of passing raw vectors around:
+
+```rust
+struct ShadowSceneSnapshot {
+    camera_frustum_corners_world: [glam::Vec3; 8],
+    receiver_points_world: Vec<glam::Vec3>,
+    caster_points_world: Vec<glam::Vec3>,
+}
+
+struct ShadowSlice {
+    near: f32,
+    far: f32,
+    frustum_corners_world: [glam::Vec3; 8],
+}
+
+struct FittedShadowCascade {
+    light_view: glam::Mat4,
+    light_proj: glam::Mat4,
+    light_view_proj: glam::Mat4,
+    split_near: f32,
+    split_far: f32,
+}
+```
+
+If split-space CSM is reintroduced later, add a separate type for it instead of overloading the basic slice model.
+
+## Recommended Rewrite Order
+
+1. Delete `DirectionalShadowProjection::Lspsm`.
+2. Replace current CSM build path with a single-cascade orthographic directional shadow.
+3. Validate:
+   - light direction
+   - projection fitting
+   - bias behavior
+   - shadow acne / peter-panning
+4. Reintroduce cascades with camera-depth partitioning only.
+5. Add better debug views:
+   - selected cascade index
+   - projected UV/depth
+   - cascade bounds overlay
+
+## What To Keep
+
+These parts are still useful and can stay with small adjustments:
+
+- directional shadow map renderer
+- shader-side shadow sampling path
+- texel snapping idea in orthographic fitting
+- directional shadow info buffer layout
+
+## What To Remove
+
+These can be deleted in the rewrite if they get in the way:
+
+- split-space-specific basis logic in `shadow.rs`
+- `DirectionalShadowProjection::Lspsm`
+- current mixed “scene extraction + fitting + allocation” flow
+- any debug path that depends on the old split-space model
+
+## Bottom Line
+
+The current implementation is not fundamentally broken because of one bug; it is difficult because the initial CSM design is too ambitious for the current state of the renderer.
+
+The safest path is:
+
+- rebuild directional shadowing as one clear orthographic cascade
+- add plain CSM second
+- only add split-space logic after the simpler design proves insufficient

--- a/src/panel/views/render/render_panel.rs
+++ b/src/panel/views/render/render_panel.rs
@@ -5,6 +5,7 @@ use super::render_state::RenderState;
 use super::render_view::RenderView;
 use super::scene_view::SceneView;
 use crate::render::render_mode::RenderMode;
+use crate::render::wgpu::shadow_debug_renderer::DirectionalShadowDebugMode;
 //
 use crate::controller::AppController;
 use crate::model::config::AppConfig;
@@ -22,6 +23,7 @@ pub struct RenderPanel {
     render_view: RenderView,
     scene_view: SceneView,
     render_mode: RenderMode,
+    shadow_debug_mode: DirectionalShadowDebugMode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,6 +63,7 @@ impl RenderPanel {
             render_view,
             scene_view,
             render_mode: RenderMode::Wire,
+            shadow_debug_mode: DirectionalShadowDebugMode::Off,
         }
     }
 
@@ -111,6 +114,21 @@ impl RenderPanel {
                             *mode,
                             egui::RichText::new(*label).family(egui::FontFamily::Monospace),
                         );
+                    }
+                    if self.render_mode == RenderMode::Lighting {
+                        ui.separator();
+                        egui::ComboBox::from_label("Shadow")
+                            .selected_text(format!("{:?}", self.shadow_debug_mode))
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::Off, "Off");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::ShadowFactor, "Shadow Factor");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::ShadowDepth, "Shadow Depth");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::ProjectedUvz, "Projected UVZ");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::CascadeColor, "Cascade Color");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::SplitDepth, "Split Depth");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::SplitPick, "Split Pick");
+                                ui.selectable_value(&mut self.shadow_debug_mode, DirectionalShadowDebugMode::LightViewDepth, "Light View Depth");
+                            });
                     }
                     ui.separator();
                 })
@@ -223,12 +241,12 @@ impl RenderPanel {
                 match state {
                     RenderState::Ready => {
                         let node = self.app_controller.read().unwrap().get_root_node();
-                        self.scene_view.show(ui, &node, self.render_mode, true);
+                        self.scene_view.show(ui, &node, self.render_mode, self.shadow_debug_mode, true);
                     }
                     RenderState::Saving | RenderState::Rendering => {
                         if history.get_image_data().is_none() {
                             let node = self.app_controller.read().unwrap().get_root_node();
-                            self.scene_view.show(ui, &node, self.render_mode, false);
+                            self.scene_view.show(ui, &node, self.render_mode, self.shadow_debug_mode, false);
                         } else {
                             self.render_view.show(ui, history);
                         }

--- a/src/panel/views/render/scene_view.rs
+++ b/src/panel/views/render/scene_view.rs
@@ -12,6 +12,7 @@ use crate::render::RenderMode;
 use crate::render::SolidRenderer;
 use crate::render::WireRenderer;
 use crate::render::wgpu::camera::RenderCamera;
+use crate::render::wgpu::shadow_debug_renderer::DirectionalShadowDebugMode;
 
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -50,6 +51,7 @@ impl SceneView {
         ui: &mut egui::Ui,
         node: &Arc<RwLock<Node>>,
         render_mode: RenderMode,
+        debug_shadow_mode: DirectionalShadowDebugMode,
         is_playing: bool,
     ) {
         let available_rect = ui.available_rect_before_wrap();
@@ -158,7 +160,7 @@ impl SceneView {
             }
             RenderMode::Lighting => {
                 if let Some(renderer) = &mut self.shaded {
-                    renderer.render(ui, rect, node, &render_camera);
+                    renderer.render(ui, rect, node, &render_camera, debug_shadow_mode);
                 }
             }
             _ => {

--- a/src/render/wgpu/light.rs
+++ b/src/render/wgpu/light.rs
@@ -2,13 +2,6 @@ use super::texture::RenderTexture;
 use std::sync::Arc;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum DirectionalShadowProjection {
-    #[default]
-    Csm,
-    Lspsm,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct DirectionalRenderLight {
     pub id: Uuid,
@@ -19,8 +12,7 @@ pub struct DirectionalRenderLight {
     pub cast_shadow: bool,      // Whether the light casts shadow
     pub shadow_bias: f32,       // Shadow depth bias
     pub shadow_slope_bias: f32, // Shadow slope-scale bias
-    pub cascade_count: u32,     // Number of CSM cascades (1..4)
-    pub shadow_projection: DirectionalShadowProjection,
+    pub cascade_count: u32,     // Reserved for future cascades. Current rewrite uses 1.
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/render/wgpu/lighting_renderer.rs
+++ b/src/render/wgpu/lighting_renderer.rs
@@ -5,6 +5,9 @@ use super::lines_renderer::LinesRenderer;
 use super::render_item::get_render_items;
 use super::render_resource::RenderResourceComponent;
 use super::render_resource::RenderResourceManager;
+use super::shadow_debug_renderer::DirectionalShadowDebugMode;
+use super::shadow_debug_renderer::ShadowDebugRenderer;
+use super::shadow_map_view_renderer::ShadowMapViewRenderer;
 use super::shadow_map_renderer::ShadowMapRenderer;
 use crate::model::scene::Node;
 use crate::render::render_mode::RenderMode;
@@ -30,6 +33,8 @@ pub struct LightingRenderer {
     // surface textures
     shadow_map_renderer: Arc<RwLock<ShadowMapRenderer>>,
     mesh_renderer: Arc<RwLock<LightingMeshRenderer>>,
+    debug_renderer: Arc<RwLock<ShadowDebugRenderer>>,
+    shadow_map_view_renderer: Arc<RwLock<ShadowMapViewRenderer>>,
     lines_renderer: Arc<RwLock<LinesRenderer>>,
     copy_texture_renderer: Arc<RwLock<LinearToSrgbRenderer>>,
     frame_buffers: Arc<RwLock<FrameBufferMap>>,
@@ -40,11 +45,14 @@ struct PerFrameCallback {
     rect: [f32; 4],
     shadow_map_renderer: Arc<RwLock<ShadowMapRenderer>>,
     mesh_renderer: Arc<RwLock<LightingMeshRenderer>>,
+    debug_renderer: Arc<RwLock<ShadowDebugRenderer>>,
+    shadow_map_view_renderer: Arc<RwLock<ShadowMapViewRenderer>>,
     lines_renderer: Arc<RwLock<LinesRenderer>>,
     copy_texture_renderer: Arc<RwLock<LinearToSrgbRenderer>>,
     frame_buffers: Arc<RwLock<FrameBufferMap>>,
     node: Arc<RwLock<Node>>,
     render_camera: RenderCamera,
+    debug_shadow_mode: DirectionalShadowDebugMode,
 }
 
 unsafe impl Send for PerFrameCallback {}
@@ -159,6 +167,27 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                         &self.render_camera,
                         &shadow_maps,
                     );
+                    let mut debug_renderer = self.debug_renderer.write().unwrap();
+                    debug_renderer.prepare(
+                        device,
+                        queue,
+                        &render_items,
+                        &self.render_camera,
+                        &shadow_maps,
+                        self.debug_shadow_mode,
+                    );
+                    if self.debug_shadow_mode == DirectionalShadowDebugMode::LightViewDepth
+                        && let Some(maps) = shadow_maps.directional_shadow_maps.as_ref()
+                    {
+                        let mut shadow_map_view_renderer =
+                            self.shadow_map_view_renderer.write().unwrap();
+                        shadow_map_view_renderer.prepare(
+                            device,
+                            queue,
+                            &maps.directional_shadow_map_texture,
+                            0,
+                        );
+                    }
                 }
                 {
                     let mut renderer = self.lines_renderer.write().unwrap();
@@ -203,8 +232,16 @@ impl egui_wgpu::CallbackTrait for PerFrameCallback {
                 });
 
                 {
-                    let renderer = self.mesh_renderer.read().unwrap();
-                    renderer.paint(&mut rpass);
+                    if self.debug_shadow_mode == DirectionalShadowDebugMode::Off {
+                        let renderer = self.mesh_renderer.read().unwrap();
+                        renderer.paint(&mut rpass);
+                    } else if self.debug_shadow_mode == DirectionalShadowDebugMode::LightViewDepth {
+                        let renderer = self.shadow_map_view_renderer.read().unwrap();
+                        renderer.paint(&mut rpass);
+                    } else {
+                        let renderer = self.debug_renderer.read().unwrap();
+                        renderer.paint(&mut rpass);
+                    }
                 }
                 if false {
                     let renderer = self.lines_renderer.read().unwrap();
@@ -235,6 +272,9 @@ impl LightingRenderer {
         let queue = &render_state.queue;
         let shadow_map_renderer = ShadowMapRenderer::new(device);
         let mesh_renderer = LightingMeshRenderer::new(device, queue, INTERNAL_TEXTURE_FORMAT);
+        let debug_renderer = ShadowDebugRenderer::new(device, INTERNAL_TEXTURE_FORMAT);
+        let shadow_map_view_renderer =
+            ShadowMapViewRenderer::new(device, INTERNAL_TEXTURE_FORMAT);
         let lines_renderer = LinesRenderer::new(device, queue, INTERNAL_TEXTURE_FORMAT);
         let copy_texture_renderer =
             LinearToSrgbRenderer::new(device, queue, render_state.target_format);
@@ -242,6 +282,8 @@ impl LightingRenderer {
         return Some(LightingRenderer {
             shadow_map_renderer: Arc::new(RwLock::new(shadow_map_renderer)),
             mesh_renderer: Arc::new(RwLock::new(mesh_renderer)),
+            debug_renderer: Arc::new(RwLock::new(debug_renderer)),
+            shadow_map_view_renderer: Arc::new(RwLock::new(shadow_map_view_renderer)),
             lines_renderer: Arc::new(RwLock::new(lines_renderer)),
             copy_texture_renderer: Arc::new(RwLock::new(copy_texture_renderer)),
             frame_buffers: Arc::new(RwLock::new(HashMap::new())),
@@ -254,6 +296,7 @@ impl LightingRenderer {
         rect: egui::Rect,
         node: &Arc<RwLock<Node>>,
         render_camera: &RenderCamera,
+        debug_shadow_mode: DirectionalShadowDebugMode,
     ) {
         ui.painter().add(egui_wgpu::Callback::new_paint_callback(
             rect,
@@ -261,11 +304,14 @@ impl LightingRenderer {
                 rect: [rect.min.x, rect.min.y, rect.max.x, rect.max.y],
                 shadow_map_renderer: self.shadow_map_renderer.clone(),
                 mesh_renderer: self.mesh_renderer.clone(),
+                debug_renderer: self.debug_renderer.clone(),
+                shadow_map_view_renderer: self.shadow_map_view_renderer.clone(),
                 lines_renderer: self.lines_renderer.clone(),
                 copy_texture_renderer: self.copy_texture_renderer.clone(),
                 frame_buffers: self.frame_buffers.clone(),
                 node: node.clone(),
                 render_camera: render_camera.clone(),
+                debug_shadow_mode,
             },
         ));
     }

--- a/src/render/wgpu/mod.rs
+++ b/src/render/wgpu/mod.rs
@@ -21,6 +21,8 @@ pub mod render_resource;
 pub mod render_texture_cache;
 pub mod shader;
 pub mod shadow;
+pub mod shadow_debug_renderer;
+pub mod shadow_map_view_renderer;
 pub mod shadow_map_renderer;
 pub mod solid_mesh_renderer;
 pub mod solid_renderer;

--- a/src/render/wgpu/render_light_item.rs
+++ b/src/render/wgpu/render_light_item.rs
@@ -1,5 +1,4 @@
 use super::light::DirectionalRenderLight;
-use super::light::DirectionalShadowProjection;
 use super::light::DiskRenderLight;
 use super::light::InfiniteRenderLight;
 use super::light::RectRenderLight;
@@ -108,8 +107,6 @@ struct DirectionalLightData {
     cast_shadow: bool,
     shadow_bias: f32,
     shadow_slope_bias: f32,
-    cascade_count: u32,
-    shadow_projection: DirectionalShadowProjection,
 }
 
 struct PointLightData {
@@ -163,11 +160,6 @@ fn read_directional_light_data(
     let l = get_color(props, "L", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
     let scale = get_color(props, "scale", resource_manager).unwrap_or([1.0, 1.0, 1.0, 1.0]);
     let source_angle = props.find_one_float("sourceangle").unwrap_or(0.5357).max(0.2);
-    let shadow_projection = props
-        .find_one_string("shadowprojection")
-        .unwrap_or_else(|| "csm".to_string())
-        .to_lowercase();
-
     Some(DirectionalLightData {
         id: light.get_id(),
         edition: light.get_edition(),
@@ -183,12 +175,6 @@ fn read_directional_light_data(
             .find_one_float("shadowslopebias")
             .unwrap_or(0.01)
             .max(0.0),
-        cascade_count: props.find_one_int("cascadecount").unwrap_or(4).clamp(1, 4) as u32,
-        shadow_projection: if shadow_projection == "lspsm" {
-            DirectionalShadowProjection::Lspsm
-        } else {
-            DirectionalShadowProjection::Csm
-        },
     })
 }
 
@@ -325,8 +311,7 @@ fn get_directional_light_item(
         cast_shadow: data.cast_shadow,
         shadow_bias: data.shadow_bias,
         shadow_slope_bias: data.shadow_slope_bias,
-        cascade_count: data.cascade_count,
-        shadow_projection: data.shadow_projection,
+        cascade_count: 1,
         ..Default::default()
     }));
     set_cached_render_light(node, render_light.clone());

--- a/src/render/wgpu/shaders/shadow_debug.wgsl
+++ b/src/render/wgpu/shaders/shadow_debug.wgsl
@@ -1,0 +1,148 @@
+struct GlobalUniforms {
+    world_to_camera: mat4x4<f32>,
+    camera_to_clip: mat4x4<f32>,
+    camera_to_world: mat4x4<f32>,
+    camera_position: vec4<f32>,
+}
+
+struct LocalUniforms {
+    local_to_world: mat4x4<f32>,
+    world_to_local: mat4x4<f32>,
+}
+
+struct DebugUniforms {
+    light_direction: vec4<f32>,
+    shadow_index: i32,
+    cascade_count: u32,
+    debug_mode: u32,
+    _pad0: u32,
+}
+
+struct DirectionalShadowInfo {
+    light_view_proj: mat4x4<f32>,
+    split_origin: vec4<f32>,
+    split_forward: vec4<f32>,
+    split_end: f32,
+    bias: f32,
+    slope_bias: f32,
+    map_layer: i32,
+}
+
+@group(0) @binding(0)
+var<uniform> global_uniforms: GlobalUniforms;
+@group(1) @binding(0)
+var<uniform> local_uniforms: LocalUniforms;
+@group(2) @binding(0)
+var<uniform> debug_uniforms: DebugUniforms;
+@group(3) @binding(0)
+var<storage, read> directional_shadow_infos: array<DirectionalShadowInfo>;
+@group(3) @binding(1)
+var directional_shadow_maps: texture_depth_2d_array;
+@group(3) @binding(2)
+var directional_shadow_sampler: sampler_comparison;
+
+struct VertexOut {
+    @location(0) w_position: vec3<f32>,
+    @location(1) w_normal: vec3<f32>,
+    @builtin(position) position: vec4<f32>,
+}
+
+@vertex
+fn vs_main(
+    @location(0) position: vec3<f32>,
+    @location(1) _uvw: vec3<f32>,
+    @location(2) normal: vec3<f32>,
+    @location(3) _tangent: vec3<f32>,
+) -> VertexOut {
+    var out: VertexOut;
+    let world = local_uniforms.local_to_world * vec4<f32>(position, 1.0);
+    out.position =
+        global_uniforms.camera_to_clip * global_uniforms.world_to_camera * world;
+    out.w_position = world.xyz;
+    out.w_normal = normalize((transpose(local_uniforms.world_to_local) * vec4<f32>(normal, 0.0)).xyz);
+    return out;
+}
+
+fn get_shadow_index(split_depth: f32) -> i32 {
+    if debug_uniforms.shadow_index < 0 || debug_uniforms.cascade_count == 0u {
+        return -1;
+    }
+    return debug_uniforms.shadow_index;
+}
+
+fn project_shadow(world_position: vec3<f32>) -> vec4<f32> {
+    let shadow = directional_shadow_infos[u32(debug_uniforms.shadow_index)];
+    let clip = shadow.light_view_proj * vec4<f32>(world_position, 1.0);
+    if clip.w <= 0.0 {
+        return vec4<f32>(0.0, 0.0, 0.0, -1.0);
+    }
+    let ndc = clip.xyz / clip.w;
+    if ndc.x < -1.0 || ndc.x > 1.0 || ndc.y < -1.0 || ndc.y > 1.0 || ndc.z < 0.0 || ndc.z > 1.0 {
+        return vec4<f32>(0.0, 0.0, 0.0, -1.0);
+    }
+    return vec4<f32>(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5, ndc.z, f32(shadow.map_layer));
+}
+
+fn sample_shadow_factor(world_position: vec3<f32>, normal: vec3<f32>, light_direction: vec3<f32>) -> f32 {
+    let projected = project_shadow(world_position);
+    if projected.w < 0.0 {
+        return 1.0;
+    }
+    let shadow = directional_shadow_infos[u32(debug_uniforms.shadow_index)];
+    let l = normalize(-light_direction);
+    let ndotl = max(dot(normalize(normal), l), 0.0);
+    let compare = projected.z - (max(shadow.bias, 0.0) + max(shadow.slope_bias, 0.0) * (1.0 - ndotl));
+    return textureSampleCompare(
+        directional_shadow_maps,
+        directional_shadow_sampler,
+        projected.xy,
+        shadow.map_layer,
+        compare,
+    );
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    if debug_uniforms.shadow_index < 0 {
+        return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    let shadow = directional_shadow_infos[u32(debug_uniforms.shadow_index)];
+    let light_direction = normalize(debug_uniforms.light_direction.xyz);
+    let split_depth = dot(in.w_position - shadow.split_origin.xyz, shadow.split_forward.xyz);
+    let projected = project_shadow(in.w_position);
+    var shadow_depth = 1.0;
+    if (projected.w >= 0.0) {
+        let dims = textureDimensions(directional_shadow_maps);
+        let x = clamp(i32(projected.x * f32(max(i32(dims.x), 1))), 0, max(i32(dims.x), 1) - 1);
+        let y = clamp(i32(projected.y * f32(max(i32(dims.y), 1))), 0, max(i32(dims.y), 1) - 1);
+        shadow_depth = textureLoad(directional_shadow_maps, vec2<i32>(x, y), shadow.map_layer, 0);
+    }
+    let shadow_factor = sample_shadow_factor(in.w_position, in.w_normal, light_direction);
+    switch debug_uniforms.debug_mode {
+        case 1u: {
+            return vec4<f32>(vec3<f32>(shadow_factor), 1.0);
+        }
+        case 2u: {
+            return vec4<f32>(vec3<f32>(shadow_depth), 1.0);
+        }
+        case 3u: {
+            if projected.w < 0.0 {
+                return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+            }
+            return vec4<f32>(projected.xyz, 1.0);
+        }
+        case 4u: {
+            return vec4<f32>(1.0, 0.2, 0.2, 1.0);
+        }
+        case 5u: {
+            let t = clamp(log2(max(split_depth, 1e-4) + 1.0) / log2(max(shadow.split_end, 1e-4) + 1.0), 0.0, 1.0);
+            return vec4<f32>(t, 1.0 - abs(t * 2.0 - 1.0), 1.0 - t, 1.0);
+        }
+        case 6u: {
+            return vec4<f32>(0.2, 1.0, 1.0, 1.0);
+        }
+        default: {
+            return vec4<f32>(vec3<f32>(shadow_factor), 1.0);
+        }
+    }
+}

--- a/src/render/wgpu/shaders/shadow_map_view.wgsl
+++ b/src/render/wgpu/shaders/shadow_map_view.wgsl
@@ -1,0 +1,44 @@
+struct ViewUniforms {
+    layer: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+@group(0) @binding(0)
+var shadow_map: texture_depth_2d_array;
+
+@group(0) @binding(1)
+var<uniform> view_uniforms: ViewUniforms;
+
+struct VertexOut {
+    @location(0) uv: vec2<f32>,
+    @builtin(position) position: vec4<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOut {
+    var pos = array<vec2<f32>, 6>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 1.0, -1.0),
+        vec2<f32>( 1.0,  1.0),
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 1.0,  1.0),
+        vec2<f32>(-1.0,  1.0),
+    );
+    var out: VertexOut;
+    let p = pos[vertex_index];
+    out.position = vec4<f32>(p, 0.0, 1.0);
+    out.uv = p * vec2<f32>(0.5, -0.5) + vec2<f32>(0.5, 0.5);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOut) -> @location(0) vec4<f32> {
+    let dims = textureDimensions(shadow_map);
+    let x = clamp(i32(in.uv.x * f32(max(i32(dims.x), 1))), 0, max(i32(dims.x), 1) - 1);
+    let y = clamp(i32(in.uv.y * f32(max(i32(dims.y), 1))), 0, max(i32(dims.y), 1) - 1);
+    let d = textureLoad(shadow_map, vec2<i32>(x, y), i32(view_uniforms.layer), 0);
+    let vis = pow(clamp(1.0 - d, 0.0, 1.0), 0.2);
+    return vec4<f32>(vec3<f32>(vis), 1.0);
+}

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -1,13 +1,14 @@
 use super::camera::RenderCamera;
 use super::light::DirectionalRenderLight;
-use super::light::DirectionalShadowProjection;
 use super::light::RenderLight;
 use super::material::RenderCategory;
 use super::render_item::RenderItem;
 use super::render_resource::RenderResourceManager;
 use super::texture::RenderTexture;
 use std::collections::HashMap;
+use std::fs;
 use std::sync::Arc;
+use std::sync::{Mutex, OnceLock};
 
 use eframe::wgpu;
 use uuid::Uuid;
@@ -18,12 +19,22 @@ pub const DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT: usize = 4;
 const SHADOW_XY_EPSILON: f32 = 1e-3;
 const SHADOW_CASTER_Z_EPSILON: f32 = 1e-3;
 const SPLIT_DEPTH_EPSILON: f32 = 1e-4;
-const CSM_MIN_SPLIT_SPAN: f32 = 50.0;
-// Blend factor between uniform and logarithmic CSM split distributions.
-// split = lerp(uniform_split, log_split, CASCADE_SPLIT_LAMBDA)
-// 0.0 -> fully uniform, 1.0 -> fully logarithmic.
-// Higher values allocate more resolution to near-camera cascades.
-const CASCADE_SPLIT_LAMBDA: f32 = 0.9;
+
+static LAST_SHADOW_DEBUG_INFO: OnceLock<Mutex<String>> = OnceLock::new();
+
+fn set_last_shadow_debug_info(text: String) {
+    let slot = LAST_SHADOW_DEBUG_INFO.get_or_init(|| Mutex::new(String::new()));
+    let file_text = text.clone();
+    if let Ok(mut guard) = slot.lock() {
+        *guard = text;
+    }
+    let _ = fs::write("/tmp/pbrt_shadow_debug.txt", file_text);
+}
+
+pub fn get_last_shadow_debug_info() -> String {
+    let slot = LAST_SHADOW_DEBUG_INFO.get_or_init(|| Mutex::new(String::new()));
+    slot.lock().map(|s| s.clone()).unwrap_or_default()
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ShadowMaps {
@@ -77,17 +88,6 @@ fn get_aabb_corners(min: glam::Vec3, max: glam::Vec3) -> [glam::Vec3; 8] {
 fn expand_bounds(min: &mut glam::Vec3, max: &mut glam::Vec3, p: glam::Vec3) {
     *min = min.min(p);
     *max = max.max(p);
-}
-
-fn build_cascade_splits(near: f32, far: f32, cascade_count: usize) -> Vec<f32> {
-    let mut splits = vec![far; cascade_count];
-    for i in 1..=cascade_count {
-        let t = i as f32 / cascade_count as f32;
-        let log = near * (far / near).powf(t);
-        let uni = near + (far - near) * t;
-        splits[i - 1] = uni * (1.0 - CASCADE_SPLIT_LAMBDA) + log * CASCADE_SPLIT_LAMBDA;
-    }
-    splits
 }
 
 fn get_full_frustum_corners_world(render_camera: &RenderCamera) -> [glam::Vec3; 8] {
@@ -202,28 +202,56 @@ fn build_light_matrices_from_virtual_points_orthographic(
     light_dir: glam::Vec3,
     up: glam::Vec3,
 ) -> (glam::Mat4, glam::Mat4, glam::Mat4) {
-    let mut world_min_c = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
-    let mut world_max_c = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-    for p in virtual_frustum_points.iter().copied() {
-        expand_bounds(&mut world_min_c, &mut world_max_c, p);
-    }
-    let world_center = 0.5 * (world_min_c + world_max_c);
-    let world_extent = world_max_c - world_min_c;
-    let world_radius = world_extent.length() * 0.5;
-    let light_distance = world_radius.max(1.0) * 2.0;
-    let eye = world_center - light_dir * light_distance;
-    let light_view = glam::Mat4::look_at_rh(eye, world_center, up);
+    let forward = light_dir.normalize_or_zero();
+    let right = up.cross(forward).normalize_or_zero();
+    let up = forward.cross(right).normalize_or_zero();
 
-    let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, 0.0);
-    let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, 0.0);
-    // Build XY bounds from receiver footprint (virtual frustum slice).
-    // Z is derived from caster points only.
+    let mut receiver_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut receiver_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    for p in virtual_frustum_points.iter().copied() {
+        let lp = glam::vec3(p.dot(right), p.dot(up), p.dot(-forward));
+        expand_bounds(&mut receiver_min, &mut receiver_max, lp);
+    }
+
+    let mut caster_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut caster_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    for p in caster_points_world.iter().copied() {
+        let lp = glam::vec3(p.dot(right), p.dot(up), p.dot(-forward));
+        expand_bounds(&mut caster_min, &mut caster_max, lp);
+    }
+
+    let light_space_center = glam::vec3(
+        0.5 * (receiver_min.x + receiver_max.x),
+        0.5 * (receiver_min.y + receiver_max.y),
+        0.5 * (caster_min.z + caster_max.z),
+    );
+    let origin =
+        right * light_space_center.x + up * light_space_center.y - forward * light_space_center.z;
+
+    let light_view = glam::Mat4::from_cols_array(&[
+        right.x,
+        up.x,
+        -forward.x,
+        0.0,
+        right.y,
+        up.y,
+        -forward.y,
+        0.0,
+        right.z,
+        up.z,
+        -forward.z,
+        0.0,
+        -origin.dot(right),
+        -origin.dot(up),
+        origin.dot(forward),
+        1.0,
+    ]);
+
+    let mut light_min = glam::vec3(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut light_max = glam::vec3(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
     for p_world in virtual_frustum_points.iter().copied() {
         let p = light_view.transform_point3(p_world);
-        light_min.x = light_min.x.min(p.x);
-        light_min.y = light_min.y.min(p.y);
-        light_max.x = light_max.x.max(p.x);
-        light_max.y = light_max.y.max(p.y);
+        expand_bounds(&mut light_min, &mut light_max, p);
     }
 
     let margin = SHADOW_BOUNDS_MARGIN;
@@ -308,6 +336,30 @@ fn build_light_matrices_from_virtual_points_orthographic(
         near,
         far
     );
+    let debug_text = format!(
+        "origin=({:.2},{:.2},{:.2})\nlight_dir=({:.2},{:.2},{:.2})\nxy=[{:.2},{:.2}]x[{:.2},{:.2}] size=({:.2},{:.2})\ncenter_xy=({:.2},{:.2})\ncaster_z=[{:.4},{:.4}] mz={:.4}\nnear/far=[{:.4},{:.4}] overlap={}",
+        origin.x,
+        origin.y,
+        origin.z,
+        light_dir.x,
+        light_dir.y,
+        light_dir.z,
+        light_min.x,
+        light_max.x,
+        light_min.y,
+        light_max.y,
+        width,
+        height,
+        center_x,
+        center_y,
+        caster_z_min,
+        caster_z_max,
+        mz,
+        near,
+        far,
+        has_overlap_caster
+    );
+    set_last_shadow_debug_info(debug_text);
     let light_proj = glam::Mat4::orthographic_rh(left, right, bottom, top, near, far);
     let light_view_proj = light_proj * light_view;
     (light_view, light_proj, light_view_proj)
@@ -315,7 +367,6 @@ fn build_light_matrices_from_virtual_points_orthographic(
 
 struct ShadowSceneContext {
     full_frustum_corners: [glam::Vec3; 8],
-    receiver_points_world: Vec<glam::Vec3>,
     caster_points_world: Vec<glam::Vec3>,
 }
 
@@ -324,7 +375,6 @@ fn build_shadow_scene_context(
     mesh_items: &[Arc<RenderItem>],
 ) -> Option<ShadowSceneContext> {
     let mut caster_points_world = Vec::new();
-    let mut receiver_points_world = Vec::new();
     let mut has_mesh = false;
 
     for item in mesh_items {
@@ -344,7 +394,6 @@ fn build_shadow_scene_context(
             for corner in corners {
                 let world = mesh_item.matrix.transform_point3(corner);
                 caster_points_world.push(world);
-                receiver_points_world.push(world);
             }
         }
     }
@@ -356,7 +405,6 @@ fn build_shadow_scene_context(
 
     Some(ShadowSceneContext {
         full_frustum_corners,
-        receiver_points_world,
         caster_points_world,
     })
 }
@@ -369,43 +417,20 @@ fn create_directional_light_shadow(
     directional_light: &DirectionalRenderLight,
     ctx: &ShadowSceneContext,
 ) -> Option<Arc<RenderDirectionalLightShadow>> {
-    match directional_light.shadow_projection {
-        DirectionalShadowProjection::Lspsm => create_directional_light_shadow_lspsm(
-            device,
-            render_camera,
-            render_resource_manager,
-            light_matrix,
-            directional_light,
-            ctx,
-        ),
-        DirectionalShadowProjection::Csm => create_directional_light_shadow_csm(
-            device,
-            render_camera,
-            render_resource_manager,
-            light_matrix,
-            directional_light,
-            ctx,
-        ),
-    }
-}
+    assert!(
+        directional_light.cast_shadow,
+        "create_directional_light_shadow called for non-shadow-casting light"
+    );
 
-fn build_directional_light_basis(
-    render_camera: &RenderCamera,
-    light_matrix: glam::Mat4,
-    directional_light: &DirectionalRenderLight,
-) -> Option<(glam::Vec3, glam::Vec3)> {
     let mut light_dir = glam::vec3(
         directional_light.direction[0],
         directional_light.direction[1],
         directional_light.direction[2],
     );
-    light_dir = light_matrix
-        .transform_vector3(light_dir)
-        .normalize_or_zero();
+    light_dir = light_matrix.transform_vector3(light_dir).normalize_or_zero();
     if light_dir.length_squared() < 1e-8 {
         return None;
     }
-
     let camera_up = render_camera.up.normalize_or_zero();
     let up = if camera_up.length_squared() > 1e-8 && light_dir.abs().dot(camera_up) < 0.99 {
         camera_up
@@ -414,7 +439,55 @@ fn build_directional_light_basis(
     } else {
         glam::vec3(1.0, 0.0, 0.0)
     };
-    Some((light_dir, up))
+    let split_basis = build_split_basis(render_camera, light_dir)?;
+    let virtual_frustum_points = ctx.full_frustum_corners.to_vec();
+    let (light_view, light_proj, light_view_proj) =
+        build_light_matrices_from_virtual_points_orthographic(
+            &virtual_frustum_points,
+            &ctx.caster_points_world,
+            light_dir,
+            up,
+        );
+
+    let mut split_end = f32::NEG_INFINITY;
+    for corner in ctx.full_frustum_corners {
+        let split_depth = split_basis.project_depth(corner);
+        if split_depth.is_finite() && split_depth > SPLIT_DEPTH_EPSILON {
+            split_end = split_end.max(split_depth);
+        }
+    }
+    if !split_end.is_finite() {
+        return None;
+    }
+
+    let render_texture =
+        get_directional_shadow_texture(device, render_resource_manager, directional_light, 0);
+    let mut debug_text = get_last_shadow_debug_info();
+    if !debug_text.is_empty() {
+        debug_text.push('\n');
+    }
+    debug_text.push_str(&format!(
+        "split_end={:.4} bias={:.5} slope_bias={:.5}",
+        split_end, directional_light.shadow_bias, directional_light.shadow_slope_bias
+    ));
+    set_last_shadow_debug_info(debug_text);
+    let cascades = vec![RenderDirectionalLightShadowCascade {
+        light_view,
+        light_proj,
+        light_view_proj,
+        split_origin: split_basis.origin,
+        split_forward: split_basis.z,
+        split_end,
+        texture: render_texture,
+    }];
+
+    Some(Arc::new(RenderDirectionalLightShadow {
+        id: directional_light.id,
+        edition: directional_light.edition.clone(),
+        shadow_bias: directional_light.shadow_bias,
+        shadow_slope_bias: directional_light.shadow_slope_bias,
+        cascades,
+    }))
 }
 
 fn get_directional_shadow_texture(
@@ -475,139 +548,6 @@ fn get_directional_shadow_texture(
     });
     render_resource_manager.add_texture(&tex);
     tex
-}
-
-fn create_directional_light_shadow_csm(
-    device: &wgpu::Device,
-    render_camera: &RenderCamera,
-    render_resource_manager: &mut RenderResourceManager,
-    light_matrix: glam::Mat4,
-    directional_light: &DirectionalRenderLight,
-    ctx: &ShadowSceneContext,
-) -> Option<Arc<RenderDirectionalLightShadow>> {
-    assert!(
-        directional_light.cast_shadow,
-        "create_directional_light_shadow_csm called for non-shadow-casting light"
-    );
-
-    let cascade_count = directional_light
-        .cascade_count
-        .clamp(1, DIRECTIONAL_SHADOW_CASCADE_MAX_COUNT as u32) as usize;
-    let (light_dir, up) =
-        build_directional_light_basis(render_camera, light_matrix, directional_light)?;
-    let split_basis = build_split_basis(render_camera, light_dir)?;
-
-    let mut split_min = f32::INFINITY;
-    let mut split_max = f32::NEG_INFINITY;
-    for world in &ctx.receiver_points_world {
-        let split_depth = split_basis.project_depth(*world);
-        if split_depth.is_finite() && split_depth > SPLIT_DEPTH_EPSILON {
-            split_min = split_min.min(split_depth);
-            split_max = split_max.max(split_depth);
-        }
-    }
-    if !split_min.is_finite() || !split_max.is_finite() || split_max <= split_min {
-        for corner in ctx.full_frustum_corners {
-            let split_depth = split_basis.project_depth(corner);
-            if split_depth.is_finite() && split_depth > SPLIT_DEPTH_EPSILON {
-                split_min = split_min.min(split_depth);
-                split_max = split_max.max(split_depth);
-            }
-        }
-    }
-    if !split_min.is_finite() || !split_max.is_finite() || split_max <= split_min {
-        return None;
-    }
-    split_min = split_min.max(SPLIT_DEPTH_EPSILON);
-    split_max = split_max.max(split_min + CSM_MIN_SPLIT_SPAN);
-    log::info!(
-        "CSM light={} cascades={} split_range=[{:.4}, {:.4}]",
-        directional_light.id,
-        cascade_count,
-        split_min,
-        split_max,
-    );
-    let split_splits = build_cascade_splits(split_min, split_max, cascade_count);
-    assert_eq!(
-        split_splits.len(),
-        cascade_count,
-        "Unexpected split count: expected={}, actual={}",
-        cascade_count,
-        split_splits.len()
-    );
-    let mut cascades = Vec::with_capacity(cascade_count);
-    let mut cascade_near = split_min;
-    for (cascade_index, cascade_far) in split_splits.iter().copied().enumerate() {
-        assert!(
-            cascade_far > cascade_near,
-            "Invalid cascade interval: index={}, near={}, far={}",
-            cascade_index,
-            cascade_near,
-            cascade_far
-        );
-        log::info!(
-            "CSM light={} cascade={} near={:.4} far={:.4} split_end={:.4}",
-            directional_light.id,
-            cascade_index,
-            cascade_near,
-            cascade_far,
-            split_splits[cascade_index]
-        );
-        let virtual_points = get_frustum_slice_corners_from_split(
-            render_camera,
-            &ctx.full_frustum_corners,
-            &split_basis,
-            cascade_near,
-            cascade_far,
-        )?;
-        for p in virtual_points.iter() {
-            assert!(p.is_finite(), "Non-finite frustum slice point: {:?}", p);
-        }
-        let virtual_frustum_points = virtual_points.to_vec();
-        let (light_view, light_proj, light_view_proj) =
-            build_light_matrices_from_virtual_points_orthographic(
-                &virtual_frustum_points,
-                &ctx.caster_points_world,
-                light_dir,
-                up,
-            );
-        let render_texture = get_directional_shadow_texture(
-            device,
-            render_resource_manager,
-            directional_light,
-            cascade_index,
-        );
-
-        cascades.push(RenderDirectionalLightShadowCascade {
-            light_view,
-            light_proj,
-            light_view_proj,
-            split_origin: split_basis.origin,
-            split_forward: split_basis.z,
-            split_end: split_splits[cascade_index],
-            texture: render_texture,
-        });
-        cascade_near = cascade_far;
-    }
-
-    Some(Arc::new(RenderDirectionalLightShadow {
-        id: directional_light.id,
-        edition: directional_light.edition.clone(),
-        shadow_bias: directional_light.shadow_bias,
-        shadow_slope_bias: directional_light.shadow_slope_bias,
-        cascades,
-    }))
-}
-
-fn create_directional_light_shadow_lspsm(
-    _device: &wgpu::Device,
-    _render_camera: &RenderCamera,
-    _render_resource_manager: &mut RenderResourceManager,
-    _light_matrix: glam::Mat4,
-    _directional_light: &DirectionalRenderLight,
-    _ctx: &ShadowSceneContext,
-) -> Option<Arc<RenderDirectionalLightShadow>> {
-    todo!("create_directional_light_shadow_lspsm");
 }
 
 pub fn create_directional_light_shadows(

--- a/src/render/wgpu/shadow.rs
+++ b/src/render/wgpu/shadow.rs
@@ -367,6 +367,7 @@ fn build_light_matrices_from_virtual_points_orthographic(
 
 struct ShadowSceneContext {
     full_frustum_corners: [glam::Vec3; 8],
+    receiver_points_world: Vec<glam::Vec3>,
     caster_points_world: Vec<glam::Vec3>,
 }
 
@@ -375,6 +376,7 @@ fn build_shadow_scene_context(
     mesh_items: &[Arc<RenderItem>],
 ) -> Option<ShadowSceneContext> {
     let mut caster_points_world = Vec::new();
+    let mut receiver_points_world = Vec::new();
     let mut has_mesh = false;
 
     for item in mesh_items {
@@ -394,6 +396,7 @@ fn build_shadow_scene_context(
             for corner in corners {
                 let world = mesh_item.matrix.transform_point3(corner);
                 caster_points_world.push(world);
+                receiver_points_world.push(world);
             }
         }
     }
@@ -405,6 +408,7 @@ fn build_shadow_scene_context(
 
     Some(ShadowSceneContext {
         full_frustum_corners,
+        receiver_points_world,
         caster_points_world,
     })
 }
@@ -440,7 +444,11 @@ fn create_directional_light_shadow(
         glam::vec3(1.0, 0.0, 0.0)
     };
     let split_basis = build_split_basis(render_camera, light_dir)?;
-    let virtual_frustum_points = ctx.full_frustum_corners.to_vec();
+    let virtual_frustum_points = if ctx.receiver_points_world.is_empty() {
+        ctx.full_frustum_corners.to_vec()
+    } else {
+        ctx.receiver_points_world.clone()
+    };
     let (light_view, light_proj, light_view_proj) =
         build_light_matrices_from_virtual_points_orthographic(
             &virtual_frustum_points,

--- a/src/render/wgpu/shadow_debug_renderer.rs
+++ b/src/render/wgpu/shadow_debug_renderer.rs
@@ -1,0 +1,462 @@
+use super::camera::RenderCamera;
+use super::mesh::RenderVertex;
+use super::render_item::RenderItem;
+use super::shadow::ShadowMaps;
+use crate::render::wgpu::light::RenderLight;
+use bytemuck::{Pod, Zeroable};
+use eframe::wgpu;
+use eframe::wgpu::util::DeviceExt;
+use std::mem::size_of;
+use std::sync::Arc;
+use wgpu::util::align_to;
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectionalShadowDebugMode {
+    Off = 0,
+    ShadowFactor = 1,
+    ShadowDepth = 2,
+    ProjectedUvz = 3,
+    CascadeColor = 4,
+    SplitDepth = 5,
+    SplitPick = 6,
+    LightViewDepth = 7,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
+struct GlobalUniforms {
+    world_to_camera: [[f32; 4]; 4],
+    camera_to_clip: [[f32; 4]; 4],
+    camera_to_world: [[f32; 4]; 4],
+    camera_position: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
+struct LocalUniforms {
+    local_to_world: [[f32; 4]; 4],
+    world_to_local: [[f32; 4]; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
+struct DebugUniforms {
+    light_direction: [f32; 4],
+    shadow_index: i32,
+    cascade_count: u32,
+    debug_mode: u32,
+    _pad0: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShadowDebugRenderer {
+    pipeline: wgpu::RenderPipeline,
+    mesh_items: Vec<Arc<RenderItem>>,
+    global_bind_group: wgpu::BindGroup,
+    global_uniform_buffer: wgpu::Buffer,
+    local_bind_group_layout: wgpu::BindGroupLayout,
+    local_bind_group: wgpu::BindGroup,
+    local_uniform_buffer: wgpu::Buffer,
+    local_uniform_alignment: wgpu::BufferAddress,
+    debug_bind_group: wgpu::BindGroup,
+    debug_uniform_buffer: wgpu::Buffer,
+    shadow_bind_group_layout: wgpu::BindGroupLayout,
+    shadow_bind_group: wgpu::BindGroup,
+}
+
+fn create_local_uniform_buffer(device: &wgpu::Device, num_items: usize) -> wgpu::Buffer {
+    let alignment = device.limits().min_uniform_buffer_offset_alignment as wgpu::BufferAddress;
+    let uniform_size = size_of::<LocalUniforms>() as wgpu::BufferAddress;
+    let required_size = align_to(uniform_size, alignment) * num_items.max(1) as wgpu::BufferAddress;
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("ShadowDebug Local Uniform Buffer"),
+        size: required_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+        mapped_at_creation: false,
+    })
+}
+
+impl ShadowDebugRenderer {
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Shadow Debug Shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("shaders/shadow_debug.wgsl").into(),
+            ),
+        });
+
+        let global_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("ShadowDebug Global Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(size_of::<GlobalUniforms>() as _),
+                    },
+                    count: None,
+                }],
+            });
+        let global_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ShadowDebug Global Uniform Buffer"),
+            size: size_of::<GlobalUniforms>() as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+            mapped_at_creation: false,
+        });
+        let global_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ShadowDebug Global Bind Group"),
+            layout: &global_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: global_uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        let local_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("ShadowDebug Local Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: wgpu::BufferSize::new(size_of::<LocalUniforms>() as _),
+                    },
+                    count: None,
+                }],
+            });
+        let local_uniform_buffer = create_local_uniform_buffer(device, 1);
+        let local_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ShadowDebug Local Bind Group"),
+            layout: &local_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &local_uniform_buffer,
+                    offset: 0,
+                    size: wgpu::BufferSize::new(size_of::<LocalUniforms>() as _),
+                }),
+            }],
+        });
+
+        let debug_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("ShadowDebug Params Bind Group Layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(size_of::<DebugUniforms>() as _),
+                    },
+                    count: None,
+                }],
+            });
+        let debug_uniform_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("ShadowDebug Params Uniform Buffer"),
+            size: size_of::<DebugUniforms>() as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+            mapped_at_creation: false,
+        });
+        let debug_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ShadowDebug Params Bind Group"),
+            layout: &debug_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: debug_uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        let shadow_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("ShadowDebug Shadow Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Depth,
+                            view_dimension: wgpu::TextureViewDimension::D2Array,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Comparison),
+                        count: None,
+                    },
+                ],
+            });
+        let dummy_info = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("ShadowDebug Dummy Shadow Info"),
+            contents: &[0u8; 96],
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+        let dummy_tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("ShadowDebug Dummy Shadow Map"),
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Depth32Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let dummy_view = dummy_tex.create_view(&wgpu::TextureViewDescriptor {
+            dimension: Some(wgpu::TextureViewDimension::D2Array),
+            ..Default::default()
+        });
+        let dummy_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            compare: Some(wgpu::CompareFunction::LessEqual),
+            ..Default::default()
+        });
+        let shadow_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("ShadowDebug Shadow Bind Group"),
+            layout: &shadow_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: dummy_info.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&dummy_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&dummy_sampler),
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("ShadowDebug Pipeline Layout"),
+            bind_group_layouts: &[
+                &global_bind_group_layout,
+                &local_bind_group_layout,
+                &debug_bind_group_layout,
+                &shadow_bind_group_layout,
+            ],
+            push_constant_ranges: &[],
+        });
+        let vertex_buffer_layout = [wgpu::VertexBufferLayout {
+            array_stride: size_of::<RenderVertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: 0,
+                    shader_location: 0,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: 12,
+                    shader_location: 1,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: 24,
+                    shader_location: 2,
+                },
+                wgpu::VertexAttribute {
+                    format: wgpu::VertexFormat::Float32x3,
+                    offset: 36,
+                    shader_location: 3,
+                },
+            ],
+        }];
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Shadow Debug Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &vertex_buffer_layout,
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil: Default::default(),
+                bias: Default::default(),
+            }),
+            multisample: Default::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            mesh_items: Vec::new(),
+            global_bind_group,
+            global_uniform_buffer,
+            local_bind_group_layout,
+            local_bind_group,
+            local_uniform_buffer,
+            local_uniform_alignment: align_to(
+                size_of::<LocalUniforms>() as u64,
+                device.limits().min_uniform_buffer_offset_alignment as u64,
+            ),
+            debug_bind_group,
+            debug_uniform_buffer,
+            shadow_bind_group_layout,
+            shadow_bind_group,
+        }
+    }
+
+    pub fn prepare(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        render_items: &[Arc<RenderItem>],
+        camera: &RenderCamera,
+        shadow_maps: &ShadowMaps,
+        debug_mode: DirectionalShadowDebugMode,
+    ) {
+        self.mesh_items = render_items
+            .iter()
+            .filter(|item| matches!(item.as_ref(), RenderItem::Mesh(_)))
+            .cloned()
+            .collect();
+        if self.mesh_items.is_empty() {
+            return;
+        }
+        if self.local_uniform_buffer.size()
+            < self.local_uniform_alignment * self.mesh_items.len().max(1) as u64
+        {
+            self.local_uniform_buffer = create_local_uniform_buffer(device, self.mesh_items.len());
+            self.local_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("ShadowDebug Local Bind Group"),
+                layout: &self.local_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &self.local_uniform_buffer,
+                        offset: 0,
+                        size: wgpu::BufferSize::new(size_of::<LocalUniforms>() as _),
+                    }),
+                }],
+            });
+        }
+        for (i, item) in self.mesh_items.iter().enumerate() {
+            let mat = item.get_matrix();
+            let inv = mat.inverse();
+            let uniform = LocalUniforms {
+                local_to_world: mat.to_cols_array_2d(),
+                world_to_local: inv.to_cols_array_2d(),
+            };
+            queue.write_buffer(
+                &self.local_uniform_buffer,
+                self.local_uniform_alignment * i as u64,
+                bytemuck::bytes_of(&uniform),
+            );
+        }
+        let global = GlobalUniforms {
+            world_to_camera: camera.world_to_camera.to_cols_array_2d(),
+            camera_to_clip: camera.camera_to_clip.to_cols_array_2d(),
+            camera_to_world: camera.camera_to_world.to_cols_array_2d(),
+            camera_position: [camera.position.x, camera.position.y, camera.position.z, 1.0],
+        };
+        queue.write_buffer(&self.global_uniform_buffer, 0, bytemuck::bytes_of(&global));
+
+        let mut light_direction = [0.0, -1.0, 0.0, 0.0];
+        let mut shadow_index = -1;
+        if let Some(maps) = shadow_maps.directional_shadow_maps.as_ref() {
+            for item in render_items {
+                if let RenderItem::Light(light_item) = item.as_ref()
+                    && let RenderLight::Directional(light) = light_item.light.as_ref()
+                    && let Some(base_index) = maps.directional_shadow_index_map.get(&light.id)
+                {
+                    light_direction = [light.direction[0], light.direction[1], light.direction[2], 0.0];
+                    shadow_index = *base_index;
+                    break;
+                }
+            }
+            let uniform = DebugUniforms {
+                light_direction,
+                shadow_index,
+                cascade_count: 1,
+                debug_mode: debug_mode as u32,
+                _pad0: 0,
+            };
+            queue.write_buffer(&self.debug_uniform_buffer, 0, bytemuck::bytes_of(&uniform));
+            self.shadow_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("ShadowDebug Shadow Bind Group"),
+                layout: &self.shadow_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: maps.directional_shadow_info_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(
+                            &maps.directional_shadow_map_texture.view,
+                        ),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Sampler(
+                            &maps.directional_shadow_map_texture.sampler,
+                        ),
+                    },
+                ],
+            });
+        }
+    }
+
+    pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
+        if self.mesh_items.is_empty() {
+            return;
+        }
+        render_pass.set_pipeline(&self.pipeline);
+        render_pass.set_bind_group(0, &self.global_bind_group, &[]);
+        render_pass.set_bind_group(2, &self.debug_bind_group, &[]);
+        render_pass.set_bind_group(3, &self.shadow_bind_group, &[]);
+        for (i, item) in self.mesh_items.iter().enumerate() {
+            if let RenderItem::Mesh(mesh_item) = item.as_ref() {
+                let offset = (self.local_uniform_alignment * i as u64) as u32;
+                render_pass.set_bind_group(1, &self.local_bind_group, &[offset]);
+                render_pass.set_vertex_buffer(0, mesh_item.mesh.vertex_buffer.slice(..));
+                render_pass.set_index_buffer(
+                    mesh_item.mesh.index_buffer.slice(..),
+                    wgpu::IndexFormat::Uint32,
+                );
+                render_pass.draw_indexed(0..mesh_item.mesh.index_count, 0, 0..1);
+            }
+        }
+    }
+}

--- a/src/render/wgpu/shadow_map_view_renderer.rs
+++ b/src/render/wgpu/shadow_map_view_renderer.rs
@@ -1,0 +1,140 @@
+use super::texture::RenderTexture;
+use bytemuck::{Pod, Zeroable};
+use eframe::wgpu;
+use eframe::wgpu::util::DeviceExt;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+struct ViewUniforms {
+    layer: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShadowMapViewRenderer {
+    pipeline: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    uniform_buffer: wgpu::Buffer,
+    bind_group: Option<wgpu::BindGroup>,
+}
+
+impl ShadowMapViewRenderer {
+    pub fn new(device: &wgpu::Device, target_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Shadow Map View Shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("shaders/shadow_map_view.wgsl").into(),
+            ),
+        });
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Shadow Map View Bind Group Layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Depth,
+                        view_dimension: wgpu::TextureViewDimension::D2Array,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<ViewUniforms>() as _),
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Shadow Map View Uniform Buffer"),
+            contents: bytemuck::bytes_of(&ViewUniforms {
+                layer: 0,
+                _pad0: 0,
+                _pad1: 0,
+                _pad2: 0,
+            }),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Shadow Map View Pipeline Layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Shadow Map View Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(target_format.into())],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil: Default::default(),
+                bias: Default::default(),
+            }),
+            multisample: Default::default(),
+            multiview: None,
+            cache: None,
+        });
+        Self {
+            pipeline,
+            bind_group_layout,
+            uniform_buffer,
+            bind_group: None,
+        }
+    }
+
+    pub fn prepare(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, texture: &RenderTexture, layer: u32) {
+        queue.write_buffer(
+            &self.uniform_buffer,
+            0,
+            bytemuck::bytes_of(&ViewUniforms {
+                layer,
+                _pad0: 0,
+                _pad1: 0,
+                _pad2: 0,
+            }),
+        );
+        self.bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Shadow Map View Bind Group"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&texture.view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: self.uniform_buffer.as_entire_binding(),
+                },
+            ],
+        }));
+    }
+
+    pub fn paint(&self, render_pass: &mut wgpu::RenderPass) {
+        if let Some(bind_group) = self.bind_group.as_ref() {
+            render_pass.set_pipeline(&self.pipeline);
+            render_pass.set_bind_group(0, bind_group, &[]);
+            render_pass.draw(0..6, 0..1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- simplify directional shadows toward a single-cascade path
- add independent shadow debug renderers, including light-view depth
- improve shadow fitting and debug instrumentation while investigating projection issues

## Status
- work in progress
- directional shadow fitting is improved, but shadow quality tuning is still ongoing
- debug views are available for further inspection

## Verification
- cargo build --release
